### PR TITLE
License binaries

### DIFF
--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -76,13 +76,13 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://osf.io/cs6zt/?action=download",
+            "https://osf.io/xhr4v/?action=download",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_osx": {
         "mirrors": [
-            "https://osf.io/874cy?action=download",
+            "https://osf.io/eg2m5/?action=download",
         ],
         "default_location": __bin_dir__,
     },


### PR DESCRIPTION
To partially address #2665, I manually gathered the relevant open source licenses ([ANTS](https://github.com/ANTsX/ANTs/blob/master/COPYING.txt), [ctrDetect](http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_x86_64.tar.gz)) and included them in our binary distribution. This is awkward because it just dumps the licenses under `bin/`, which is not a good place for them, but at least they exist, and it helps me clarify what my planned automated packaging solution should look like.

```
$ tree copyright/
copyright/
├── LICENSE_ants.txt
├── LICENSE_ctrDetect.txt
└── LICENSE_opencv.txt

0 directories, 3 files
```

As in https://github.com/neuropoly/spinalcordtoolbox/pull/2642#issuecomment-616783109 and https://github.com/neuropoly/spinalcordtoolbox/pull/2666#issue-406442891, I unpacked the [previous](https://osf.io/admxy/?action=download) [versions](https://osf.io/7vx5g/?action=download), added these files, and repacked:

<details><summary>Build log</summary>

```
$ mkdir binaries_osx; tar -zxf 20200421_sct_binaries_osx.tar.gz -C binaries_osx
$ cp -r copyright/ binaries_osx/
$ tar --sort=name -czvf 20200422_sct_binaries_osx.tar.gz -C binaries_osx/ .
./
./copyright/
./copyright/LICENSE_ants.txt
./copyright/LICENSE_ctrDetect.txt
./copyright/LICENSE_opencv.txt
./isct_ComposeMultiTransform
./isct_antsApplyTransforms
./isct_antsRegistration
./isct_antsSliceRegularizedRegistration
./isct_dice_coefficient
./isct_propseg
./isct_spine_detect
./isct_train_svm
```

``` 
$ mkdir binaries_linux; tar -zxf 20200421_sct_binaries_linux.tar.gz -C binaries_linux
$ cp -r copyright/ binaries_linux/
$ tar --sort=name -czvf 20200422_sct_binaries_linux.tar.gz -C binaries_linux/ .
./
./copyright/
./copyright/LICENSE_ants.txt
./copyright/LICENSE_ctrDetect.txt
./copyright/LICENSE_opencv.txt
./isct_ComposeMultiTransform
./isct_antsApplyTransforms
./isct_antsRegistration
./isct_antsSliceRegularizedRegistration
./isct_dice_coefficient
./isct_propseg
./isct_spine_detect
./isct_train_svm
```

</details>

Outputs, which I uploaded to OSF.io:

```
$ sha256sum 20200422_sct_binaries_*
6a3e57ad424fa401d0a6ee05a9e640bef049147b8517e195f0d845f09b3b0795  20200422_sct_binaries_linux.tar.gz
f17afc136c3482542b6e5ff2f02638a40dff5c69f826f65e5f06fa89704d29c8  20200422_sct_binaries_osx.tar.gz
```

This *depends on #2666* being merged first, and as a reminder should be rebased on top of it which means manually rebuilding, reuploading new revisions to the same mirror links.

