### PR TITLE
Use binaries that are packaged by the `spinalcordtoolbox-binaries` repo

### DIFF
--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -76,13 +76,13 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://osf.io/cs6zt/?action=download",
+            "https://github.com/kousu/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F3%2Fmerge-85120650/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_osx": {
         "mirrors": [
-            "https://osf.io/874cy?action=download",
+            "https://github.com/kousu/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F3%2Fmerge-85120650/spinalcordtoolbox-binaries_osx.tar.gz",
         ],
         "default_location": __bin_dir__,
     },

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -76,19 +76,19 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220512/spinalcordtoolbox-binaries_linux.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_osx": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220512/spinalcordtoolbox-binaries_osx.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_osx.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_win": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/test-release/binaries_win.zip",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_windows.tar.gz",
         ],
         "default_location": __bin_dir__,
     },

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -76,19 +76,19 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_linux.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516-2/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_osx": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_osx.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516-2/spinalcordtoolbox-binaries_osx.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_win": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516/spinalcordtoolbox-binaries_windows.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220516-2/spinalcordtoolbox-binaries_windows.tar.gz",
         ],
         "default_location": __bin_dir__,
     },

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -76,13 +76,13 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://github.com/kousu/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F3%2Fmerge-85120650/spinalcordtoolbox-binaries_linux.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220512/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },
     "binaries_osx": {
         "mirrors": [
-            "https://github.com/kousu/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F3%2Fmerge-85120650/spinalcordtoolbox-binaries_osx.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20220512/spinalcordtoolbox-binaries_osx.tar.gz",
         ],
         "default_location": __bin_dir__,
     },


### PR DESCRIPTION
## Context

Currently, SCT depends on [8 total external C++ tools](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-How-to-compile-binaries-(ANTs,-isct)#c-binary-dependencies) that must be pre-built and packaged:

* 4/8: `ANTs` binaries we borrow from the external ANTs package.
* 2/8: `ctrDetect` binaries we borrow from an external contributor to SCT.
* 2/8: `isct_` binaries (from the `spinalcordtoolbox/dev` folder).

To make re-building the ANTs binaries easier/more reproducible, PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2821 automated the build process via the [`kousu/ANTs`](https://github.com/kousu/ANTs) repo. 

However, there was still a bit of work left to be done, as:

1. The ANTs-building workflow is stored in a personal repo, rather than a `spinalcordtoolbox`-affiliated repo.
2. Packaging and hosting the ANTs binaries (together with the `ctrDetect`/`isct_` binaries) still had to be done manually.
3. Windows is now natively supported as a platform, and this comes with its own set of ANTs binaries.

## Description

To address issues 1, 2, and 3, this PR updates `binaries_linux`, `binaries_osx`, and `binaries_windows` to use packages built online by:

* [`build_ANTs`](https://github.com/spinalcordtoolbox/build_ANTs) - [`build-ants.yml`](https://github.com/spinalcordtoolbox/build_ANTs/blob/master/.github/workflows/build-ants.yml): A workflow that builds ANTs, which then feeds into:
* [`spinalcordtoolbox-binaries`](https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries) - [`package-binaries.yml`](https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/blob/master/.github/workflows/package-binaries.yml): A workflow that packages up all 8 binaries.

Additionally, the above CI workflows include the licenses for the external binaries (ANTs + ctrDetect), which addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2665.

## Discussion

This makes Github our primary mirror (for these files), which is something we should talk about. On the plus side, it's easily integrated in an **automated** build pipeline, it's accessible in China. On the negative side, it's not-quite vendor lock-in and it breaks the symmetry in `sct_download_data`.

## Linked issues

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2665.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3788.
Supersedes #2666.
Supersedes #2667.