### PR TITLE
Implement support for gaussian mask in slicereg

### DIFF
--- a/spinalcordtoolbox/registration/register.py
+++ b/spinalcordtoolbox/registration/register.py
@@ -132,7 +132,20 @@ def register_step_ants_slice_regularized_registration(src, dest, step, metricSiz
     list_fname = [src, dest]
     if fname_mask:
         list_fname.append(fname_mask)
-        mask_options = ['-x', fname_mask]
+        # Check if this mask is soft (i.e. non-binary, such as a Gaussian mask)
+        mask = image.Image(fname_mask)
+        if not np.array_equal(mask.data, mask.data.astype(bool)):
+            # If it is, multiply the target by the soft mask and do not pass
+            # mask options to register() (this is a workaround for ANTS
+            # not supporting non-binary masks).
+            mask_options = []
+            im = image.Image(dest)
+            im_masked = im.copy()
+            im_masked.data = im.data * mask.data
+            im_masked.save()
+        else:
+            # If not, pass it to register() like normal
+            mask_options = ['-x', fname_mask]
     else:
         mask_options = []
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ]  ~~I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution~~
- [ ] ~~I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages~~

## Description
`sct_register_multimodal` currently doesn't support Gaussian masks for `algo=slicereg`. @jcohenadad implemented a simple hack for this in the motion correction API in #2634 - this PR ports that code into `register_step_ants_slice_regularized_registration`. The fix consists of multiplying the target image with the Gaussian mask and not passing the Gaussian mask to the ANTs backend.

## Linked issues
Fixes #3075, Fixes https://github.com/ivadomed/pipeline-hemis/issues/3
