### PR TITLE
Add a `-k` flag to keep existing installation files, rather than cleaning them

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -17,8 +17,9 @@ install_sct () {
   #     instead of the installed folder, where the extra detection models are.
   #     Further explanation at https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
   #     TO BE REMOVED during https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3140.
-  # NB: '-c' disables sct_check_dependencies so we can check it separately
-  ./install_sct -iyc
+  # NB: '-c' disables sct_check_dependencies so we can check it
+  # NB: '-k' keeps the folders 'data/', 'bin/', and 'python/' to speed up installation
+  ./install_sct -iyck
 }
 
 activate_venv_sct(){

--- a/install_sct
+++ b/install_sct
@@ -594,7 +594,11 @@ if [ ! -x "$SCT_DIR/$PYTHON_DIR"/bin/conda ]; then
   find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
 fi
 
-if ! ( "$SCT_DIR/$PYTHON_DIR"/bin/conda info -e | cut -f 1 -d ' ' | grep venv_sct >/dev/null ); then
+# activate miniconda
+# shellcheck disable=SC1091
+source python/etc/profile.d/conda.sh
+
+if ! ( conda info -e | cut -f 1 -d ' ' | grep venv_sct >/dev/null ); then
   # create conda environment
   print info "Creating conda environment..."
   python/bin/conda create -y -n venv_sct python=3.7
@@ -609,9 +613,6 @@ fi
 # * Fix details: https://github.com/conda/conda/issues/7173#issuecomment-980496682
 echo "include-system-site-packages = false" > "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/pyvenv.cfg"
 
-# activate miniconda
-# shellcheck disable=SC1091
-source python/etc/profile.d/conda.sh
 set +u #disable safeties, for conda is not written to their standard.
 conda activate venv_sct
 set -u # reactivate safeties

--- a/install_sct
+++ b/install_sct
@@ -13,14 +13,15 @@
 # installation is successful.
 #
 # USAGE
-#   ./install_sct [-h] [-i] [-y] [-c] [-o] [-v]
+#   ./install_sct [-h] [-i] [-y] [-c] [-k] [-v]
 #
 # OPTIONS
 #  -h   Show this help
 #  -i   Install in-place; this is the default when working from git.
 #  -y   Install without interruption with 'yes' as default answer
 #  -c   Prevent checks from being run to validate the installation
-#  -o   Overwrite existing installation files (by default, 'python/', 'bin/' and 'data/' are preserved)
+#  -o   Keep existing installation files (by default, 'python/', 'bin/' and 'data/' are overwritten)
+#       This will speed up installation but can cause bugs.
 #  -v   Full verbose
 #
 #
@@ -54,7 +55,7 @@ MACOSSUPPORTED="13"  # Minimum version of macOS 10 supported
 # CLI options
 SCT_INSTALL_TYPE=""
 NONINTERACTIVE=""
-CLEAN=""
+CLEAN="yes"
 NO_DATA_INSTALL=""
 NO_SCT_BIN_INSTALL=""
 NO_INSTALL_VALIDATION=""
@@ -347,19 +348,17 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":iycovh" opt; do
+while getopts ":iyckvh" opt; do
   case $opt in
   i)
     SCT_INSTALL_TYPE="in-place"
     ;;
   y)
-    echo " non-interactive mode"
+    print info " non-interactive mode"
     NONINTERACTIVE="yes"
     ;;
-  o)
-    echo " SCT binaries will be overwritten"
-    echo " data directory will be overwritten"
-    CLEAN="yes"
+  k)
+    CLEAN=""
     ;;
   c)
     echo " no checks will be run (installation will not be validated)"
@@ -592,6 +591,8 @@ if [ ! -x "$SCT_DIR/$PYTHON_DIR"/bin/conda ]; then
   # See: https://github.com/conda/conda/issues/9948#issuecomment-909989810
   # Syntax explanation: https://stackoverflow.com/a/6085237
   find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+else
+  print info " conda will not be reinstalled"
 fi
 
 # activate miniconda
@@ -605,6 +606,8 @@ if ! ( conda info -e | cut -f 1 -d ' ' | grep venv_sct >/dev/null ); then
 
   # Reapply the touch fix to avoid `pip` connection issues on WSL
   find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+else
+  print info " venv_sct will not be recreated"
 fi
 
 # make sure that there is no conflict with local python install by making venv_sct an isolated environment.
@@ -695,6 +698,8 @@ if [ ! -x "${SCT_DIR}/${BIN_DIR}/isct_antsSliceRegularizedRegistration" ]; then
   # this if is a bit hacky but it's the best we've got until we migrate
   # these to a better package management system (one with built in caching)
   run sct_download_data -d "binaries_${OS}" -k
+else
+  print info " SCT binaries will not be reinstalled"
 fi
 
 print info "All requirements installed!"
@@ -709,6 +714,8 @@ run mkdir -p "$SCT_DIR/$DATA_DIR"
 for data in PAM50 gm_model optic_models pmj_models deepseg_sc_models deepseg_gm_models deepseg_lesion_models c2c3_disc_models; do
   if [ ! -d "$SCT_DIR/$DATA_DIR/$data" ]; then
     run sct_download_data -d "$data"
+  else
+    print info " $DATA_DIR/$data will not be reinstalled"
   fi
 done
 
@@ -718,6 +725,8 @@ fi
 if [ ! -d "$SCT_DIR/$DATA_DIR/deepseg_models" ]; then
   print info "Installing deep learning models..."
   python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.models.install_default_models()'
+else
+  print info " deepseg models will not be reinstalled"
 fi
 
 

--- a/install_sct
+++ b/install_sct
@@ -13,15 +13,14 @@
 # installation is successful.
 #
 # USAGE
-#   ./install_sct [-h] [-i] [-y] [-d] [-b] [-v]
+#   ./install_sct [-h] [-i] [-y] [-c] [-o] [-v]
 #
 # OPTIONS
 #  -h   Show this help
 #  -i   Install in-place; this is the default when working from git.
 #  -y   Install without interruption with 'yes' as default answer
-#  -d   Prevent the (re)-installation of the data/ directory
-#  -b   Prevent the (re)-installation of the SCT binaries files
 #  -c   Prevent checks from being run to validate the installation
+#  -o   Overwrite existing installation files (by default, 'python/', 'bin/' and 'data/' are preserved)
 #  -v   Full verbose
 #
 #
@@ -55,6 +54,7 @@ MACOSSUPPORTED="13"  # Minimum version of macOS 10 supported
 # CLI options
 SCT_INSTALL_TYPE=""
 NONINTERACTIVE=""
+CLEAN=""
 NO_DATA_INSTALL=""
 NO_SCT_BIN_INSTALL=""
 NO_INSTALL_VALIDATION=""
@@ -347,7 +347,7 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":iydbcvh" opt; do
+while getopts ":iycovh" opt; do
   case $opt in
   i)
     SCT_INSTALL_TYPE="in-place"
@@ -356,13 +356,10 @@ while getopts ":iydbcvh" opt; do
     echo " non-interactive mode"
     NONINTERACTIVE="yes"
     ;;
-  d)
-    echo " data directory will not be (re)-installed"
-    NO_DATA_INSTALL="yes"
-    ;;
-  b)
-    echo " SCT binaries will not be (re)-installed "
-    NO_SCT_BIN_INSTALL="yes"
+  o)
+    echo " SCT binaries will be overwritten"
+    echo " data directory will be overwritten"
+    CLEAN="yes"
     ;;
   c)
     echo " no checks will be run (installation will not be validated)"
@@ -569,35 +566,42 @@ fi
 
 
 # Remove old python folder
-run rm -rf "$SCT_DIR/$PYTHON_DIR"
-run mkdir -p "$SCT_DIR/$PYTHON_DIR"
+if [ -n "$CLEAN" ]; then
+  run rm -rf "$SCT_DIR/$PYTHON_DIR"
+fi
 
-# Download miniconda
-print info "Downloading Miniconda..."
-case $OS in
-linux*)
-  download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  ;;
-osx)
-  download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-  ;;
-esac
+if [ ! -x "$SCT_DIR/$PYTHON_DIR"/bin/conda ]; then
+  run mkdir -p "$SCT_DIR/$PYTHON_DIR"
 
-# Run conda installer
-print info "Installing Miniconda..."
-run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
+  # Download miniconda
+  print info "Downloading Miniconda..."
+  case $OS in
+  linux*)
+    download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    ;;
+  osx)
+    download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+    ;;
+  esac
 
-# Workaround for WSL "HTTP 000 Connection Failed" error
-# See: https://github.com/conda/conda/issues/9948#issuecomment-909989810
-# Syntax explanation: https://stackoverflow.com/a/6085237
-find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+  # Run conda installer
+  print info "Installing Miniconda..."
+  run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
 
-# create conda environment
-print info "Creating conda environment..."
-python/bin/conda create -y -n venv_sct python=3.7
+  # Workaround for WSL "HTTP 000 Connection Failed" error
+  # See: https://github.com/conda/conda/issues/9948#issuecomment-909989810
+  # Syntax explanation: https://stackoverflow.com/a/6085237
+  find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+fi
 
-# Reapply the touch fix to avoid `pip` connection issues on WSL
-find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+if ! ( "$SCT_DIR/$PYTHON_DIR"/bin/conda info -e | cut -f 1 -d ' ' | grep venv_sct >/dev/null ); then
+  # create conda environment
+  print info "Creating conda environment..."
+  python/bin/conda create -y -n venv_sct python=3.7
+
+  # Reapply the touch fix to avoid `pip` connection issues on WSL
+  find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
+fi
 
 # make sure that there is no conflict with local python install by making venv_sct an isolated environment.
 # For more information, see:
@@ -681,29 +685,39 @@ export PATH="$SCT_DIR/$BIN_DIR:$PATH"
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Install binaries
-if [[ -n "$NO_SCT_BIN_INSTALL" ]]; then
-  print warning "WARNING: SCT binaries will not be (re)-installed"
-else
+if [ -n "$CLEAN" ]; then
+  rm -f "${SCT_DIR}/${BIN_DIR}/isct_*"
+fi
+# use isct_antsSliceRegularizedRegistration as a proxy for "the binaries are installed"; this is hacky:
+if [ ! -x "${SCT_DIR}/${BIN_DIR}/isct_antsSliceRegularizedRegistration" ]; then
   print info "Installing binaries..."
+  # this if is a bit hacky but it's the best we've got until we migrate
+  # these to a better package management system (one with built in caching)
   run sct_download_data -d "binaries_${OS}" -k
 fi
+
 print info "All requirements installed!"
 
 # Install data
-if [[ -n "$NO_DATA_INSTALL" ]]; then
-  print warning "WARNING: data/ will not be (re)-install"
-else
-  # Download data
-  print info "Installing data..."
+if [ -n "$CLEAN" ]; then
   run rm -rf "$SCT_DIR/$DATA_DIR"
-  run mkdir -p "$SCT_DIR/$DATA_DIR"
-  for data in PAM50 gm_model optic_models pmj_models deepseg_sc_models deepseg_gm_models deepseg_lesion_models c2c3_disc_models; do
-    run sct_download_data -d "$data"
-  done
 fi
 
-# Install deep learning models
-python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.models.install_default_models()'
+print info "Installing data..."
+run mkdir -p "$SCT_DIR/$DATA_DIR"
+for data in PAM50 gm_model optic_models pmj_models deepseg_sc_models deepseg_gm_models deepseg_lesion_models c2c3_disc_models; do
+  if [ ! -d "$SCT_DIR/$DATA_DIR/$data" ]; then
+    run sct_download_data -d "$data"
+  fi
+done
+
+if [ -n "$CLEAN" ]; then
+  run rm -rf "$SCT_DIR/$DATA_DIR/deepseg_models"
+fi
+if [ ! -d "$SCT_DIR/$DATA_DIR/deepseg_models" ]; then
+  print info "Installing deep learning models..."
+  python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.models.install_default_models()'
+fi
 
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

    Add a -c (clean) flag.
    
    This replaces -b (clean binaries) and -d (clean data) with a single -b flag, and expands
    it to cover cleaning miniconda and the deepseg models.
    With this, iterating on sct is a lot easier because the installer
    doesn't take 3-10 minutes every time.
    
    It should be safe to expand this to cover miniconda (in most case):
    pip handles dependency versioning fine, and is smart enough to recognize
    what's changed if anything has changed.
    
    It is unsafe to use it with binaries/data/deepseg models because we do
    not have those versioned. But it was already unsafe to use -b and -d in
    anyway for exactly that reason; most of our users will be installing SCT to
    fresh directories ~/sct_$VERSION each time anyway, so I think the tradeoff
    is worth it.



## Linked issues

Depends on #3102 being merged first.
