### PR TITLE
Change `x is not 1` to `x != 1` to avoid SyntaxWarnings

### DIFF
--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -497,7 +497,7 @@ def propseg(img_input, options_dict):
         elif str(arguments.init_centerline) == "hough":
             use_optic = False
         else:
-            if rescale_header is not 1:
+            if rescale_header != 1:
                 fname_labels_viewer = func_rescale_header(str(arguments.init_centerline), rescale_header, verbose=verbose)
             else:
                 fname_labels_viewer = str(arguments.init_centerline)
@@ -507,7 +507,7 @@ def propseg(img_input, options_dict):
         if str(arguments.init_mask) == "viewer":
             use_viewer = "mask"
         else:
-            if rescale_header is not 1:
+            if rescale_header != 1:
                 fname_labels_viewer = func_rescale_header(str(arguments.init_mask), rescale_header)
             else:
                 fname_labels_viewer = str(arguments.init_mask)
@@ -552,7 +552,7 @@ def propseg(img_input, options_dict):
     path_tmp = tmp_create(basename="label_vertebrae")
 
     # rescale header (see issue #1406)
-    if rescale_header is not 1:
+    if rescale_header != 1:
         fname_data_propseg = func_rescale_header(fname_data, rescale_header)
     else:
         fname_data_propseg = fname_data
@@ -622,7 +622,7 @@ def propseg(img_input, options_dict):
     fname_seg = os.path.join(folder_output, fname_out)
     fname_centerline = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_centerline")))
     # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
-    if rescale_header is not 1:
+    if rescale_header != 1:
         mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_seg")),
                fname_seg)
         mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_centerline")),


### PR DESCRIPTION
Changed `x is not 1` to `x != 1` to avoid SyntaxWarnings.

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
