### PR TITLE
Add test for `sct_dmri_display_bvecs`, then add `-v` argument to make the test pass

### DIFF
--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -39,6 +39,15 @@ def get_parser():
         action="help",
         help="Show this help message and exit."
     )
+    optional.add_argument(
+        '-v',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
+    )
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -134,7 +134,7 @@ def main(argv=None):
     # Save image
     printv("Saving figure: bvecs.png\n")
     plt.savefig('bvecs.png')
-    plt.show()
+    # plt.show()
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -134,7 +134,7 @@ def main(argv=None):
     # Save image
     printv("Saving figure: bvecs.png\n")
     plt.savefig('bvecs.png')
-    # plt.show()
+    plt.show()
 
 
 if __name__ == "__main__":

--- a/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
+++ b/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
@@ -1,0 +1,13 @@
+import os
+import logging
+
+from spinalcordtoolbox.scripts import sct_dmri_display_bvecs
+
+logger = logging.getLogger(__name__)
+
+
+def test_sct_dmri_display_bvecs_png_exists():
+    """Run the CLI script."""
+    sct_dmri_display_bvecs.main(argv=['-bvec', 'sct_testing_data/dmri/bvecs.txt'])
+    assert os.path.exists('bvecs.png')
+    os.unlink('bvecs.png')

--- a/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
+++ b/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
@@ -1,11 +1,16 @@
 import os
+import sys
 import logging
+
+import pytest
 
 from spinalcordtoolbox.scripts import sct_dmri_display_bvecs
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Script uses pyplot.show, causing macOS 10.15 CI runners to hang.")
+# FIXME: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3388
 def test_sct_dmri_display_bvecs_png_exists():
     """Run the CLI script."""
     sct_dmri_display_bvecs.main(argv=['-bvec', 'sct_testing_data/dmri/bvecs.txt'])


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [X] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

#3091 added loglevel setting steps to all SCT scripts. However, `sct_dmri_display_bvecs` never had a verbose argument.

This was never caught because there is no test for `sct_dmri_display_bvecs`. So, this adds an (admittedly very basic) test for the script. (A more thorough test would require some refactoring of `sct_dmri_display_bvecs`.)

This test fails on master, but passes on this branch after `-v` is added.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3386.