### PR TITLE
Ensure a copy of the header is used in `zeros_like` to fix `-create-viewer` bug

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1245,7 +1245,7 @@ def zeros_like(img, dtype=None):
     intent and avoid doing a copy, which is slower than initialization with a constant.
 
     """
-    zimg = Image(np.zeros_like(img.data), hdr=img.hdr)
+    zimg = Image(np.zeros_like(img.data), hdr=img.hdr.copy())
     if dtype is not None:
         zimg.change_type(dtype)
     return zimg


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Because a copy of the header wasn't made, the exact header object would be reused. This meant that if the header in the original image was changed, then the header of the `zeros_like` image would be changed too. :facepalm: 

This caused problems with `sct_label_utils`, because reorienting the input `img` accidentally affected the header of the `out` image:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/9a4b45715240d6c08b8d71587ffbe99a41326cc6/spinalcordtoolbox/scripts/sct_label_utils.py#L366

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/9a4b45715240d6c08b8d71587ffbe99a41326cc6/spinalcordtoolbox/gui/base.py#L323

This had a cascade of effects inside the sagittal viewer (which are a bit complicated to explain, and not really necessary to understand for this PR).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3397.
Follows #3379.