### PR TITLE
Fix `rescale_header is not 1` because the default value is `1.0`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -618,22 +618,20 @@ def propseg(img_input, options_dict):
                    1, 'error')
         sys.exit(1)
 
-    # build output filename
+    # rename output files
+    fname_seg_old = os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_seg"))
     fname_seg = os.path.join(folder_output, fname_out)
+    mv(fname_seg_old, fname_seg)
+    fname_centerline_old = os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_centerline"))
     fname_centerline = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_centerline")))
-    # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
-    if rescale_header != 1.0:
-        mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_seg")),
-               fname_seg)
-        mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_centerline")),
-               fname_centerline)
-        # if user was used, copy the labelled points to the output folder (they will then be scaled back)
-        if use_viewer:
-            fname_labels_viewer_new = os.path.join(folder_output, os.path.basename(add_suffix(fname_data,
-                                                                                              "_labels_viewer")))
-            copy(fname_labels_viewer, fname_labels_viewer_new)
-            # update variable (used later)
-            fname_labels_viewer = fname_labels_viewer_new
+    mv(fname_centerline_old, fname_centerline)
+
+    # if viewer was used, copy the labelled points to the output folder
+    if use_viewer:
+        fname_labels_viewer_new = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_labels_viewer")))
+        copy(fname_labels_viewer, fname_labels_viewer_new)
+        # update variable (used later)
+        fname_labels_viewer = fname_labels_viewer_new
 
     # check consistency of segmentation
     if arguments.correct_seg:

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -497,7 +497,7 @@ def propseg(img_input, options_dict):
         elif str(arguments.init_centerline) == "hough":
             use_optic = False
         else:
-            if rescale_header is not 1:
+            if rescale_header != 1.0:
                 fname_labels_viewer = func_rescale_header(str(arguments.init_centerline), rescale_header, verbose=verbose)
             else:
                 fname_labels_viewer = str(arguments.init_centerline)
@@ -507,7 +507,7 @@ def propseg(img_input, options_dict):
         if str(arguments.init_mask) == "viewer":
             use_viewer = "mask"
         else:
-            if rescale_header is not 1:
+            if rescale_header != 1.0:
                 fname_labels_viewer = func_rescale_header(str(arguments.init_mask), rescale_header)
             else:
                 fname_labels_viewer = str(arguments.init_mask)
@@ -552,7 +552,7 @@ def propseg(img_input, options_dict):
     path_tmp = tmp_create(basename="label_vertebrae")
 
     # rescale header (see issue #1406)
-    if rescale_header is not 1:
+    if rescale_header != 1.0:
         fname_data_propseg = func_rescale_header(fname_data, rescale_header)
     else:
         fname_data_propseg = fname_data
@@ -622,7 +622,7 @@ def propseg(img_input, options_dict):
     fname_seg = os.path.join(folder_output, fname_out)
     fname_centerline = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_centerline")))
     # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
-    if rescale_header is not 1:
+    if rescale_header != 1.0:
         mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_seg")),
                fname_seg)
         mv(os.path.join(folder_output, add_suffix(os.path.basename(fname_data_propseg), "_centerline")),


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

1. We've been using "`if rescale is not 1`" to check if a non-default value has been passed for `rescale`. But, the default value for `rescale` is a float (`1.0`), so the check has been silently evaluating to `True` when we expected it to evaluate to `False`. 
2. Because the check has been silently evaluating to `True` 100% of the time, some file renaming code has quietly become the default behavior of the script. If the faulty check is fixed, suddenly the files won't be renamed anymore, causing an existing test to fail.

This PR fixes both issues. (Improves the checks, makes sure files are still renamed.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

This PR is based off of the work in PR #3382.