### PR TITLE
Don't output `dest->src` files if registration is only performed one-way

### DIFF
--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -312,7 +312,6 @@ def main(argv=None):
     fname_dest_seg = ''
     fname_src_label = ''
     fname_dest_label = ''
-    generate_warpinv = 1
 
     start_time = time.time()
 
@@ -420,7 +419,8 @@ def main(argv=None):
         else:
             printv('WARNING: Cannot generate QC because it requires destination segmentation.', 1, 'warning')
 
-    if generate_warpinv:
+    # If dest wasn't registered (e.g. unidirectional registration due to '-initwarp'), then don't output syntax
+    if fname_dest2src:
         display_viewer_syntax([fname_src, fname_dest2src], verbose=verbose)
     display_viewer_syntax([fname_dest, fname_src2dest], verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -29,8 +29,11 @@ from spinalcordtoolbox.math import dilate, binarize
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import *
-from spinalcordtoolbox.utils import Metavar
+from spinalcordtoolbox.utils.fs import (copy, extract_fname, check_file_exist, rmtree,
+                                        cache_save, cache_signature, cache_valid)
+from spinalcordtoolbox.utils.shell import (SCTArgumentParser, ActionCreateFolder, Metavar, list_type,
+                                           printv, display_viewer_syntax)
+from spinalcordtoolbox.utils.sys import set_global_loglevel, init_sct
 from spinalcordtoolbox import __data_dir__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -1162,7 +1162,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         fname_output_warp = os.path.join(path_out, 'warp_' + file_src + '2' + file_dest + '.nii.gz')
     generate_output_file(os.path.join(path_tmp, "warp_src2dest.nii.gz"), fname_output_warp, param.verbose)
 
-    # generate dest -> sec output files
+    # generate dest -> src output files
     if generate_warpinv:
         fname_dest2src = os.path.join(path_out, file_out_inv + ext_dest)
         generate_output_file(os.path.join(path_tmp, "dest_reg.nii"), fname_dest2src, param.verbose)

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -1031,8 +1031,8 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         if fname_initwarpinv:
             warp_inverse.append(fname_initwarpinv)
         else:
-            printv('\nWARNING: No initial inverse warping field was specified, therefore the inverse warping field '
-                   'will NOT be generated.', param.verbose, 'warning')
+            printv('\nWARNING: No initial inverse warping field was specified, therefore the registration will be '
+                   'src->dest only, and the inverse warping field will NOT be generated.', param.verbose, 'warning')
             generate_warpinv = 0
     else:
         if same_space:

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -1134,13 +1134,15 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         '-w', 'warp_src2dest.nii.gz',
         '-o', 'src_reg.nii',
         '-x', interp])
-    printv('\nApply transfo dest --> source...', param.verbose)
-    sct_apply_transfo.main(argv=[
-        '-i', 'dest.nii',
-        '-d', 'src.nii',
-        '-w', 'warp_dest2src.nii.gz',
-        '-o', 'dest_reg.nii',
-        '-x', interp])
+
+    if generate_warpinv:
+        printv('\nApply transfo dest --> source...', param.verbose)
+        sct_apply_transfo.main(argv=[
+            '-i', 'dest.nii',
+            '-d', 'src.nii',
+            '-w', 'warp_dest2src.nii.gz',
+            '-o', 'dest_reg.nii',
+            '-x', interp])
 
     # come back
     os.chdir(curdir)
@@ -1149,24 +1151,23 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
     # ------------------------------------------------------------------------------------------------------------------
 
     printv('\nGenerate output files...', param.verbose)
-    # generate: src_reg
-    fname_src2dest = generate_output_file(
-        os.path.join(path_tmp, "src_reg.nii"), os.path.join(path_out, file_out + ext_out), param.verbose)
 
-    # generate: dest_reg
-    fname_dest2src = generate_output_file(
-        os.path.join(path_tmp, "dest_reg.nii"), os.path.join(path_out, file_out_inv + ext_dest), param.verbose)
-
-    # generate: forward warping field
+    # generate src -> dest output files
+    fname_src2dest = os.path.join(path_out, file_out + ext_out)
+    generate_output_file(os.path.join(path_tmp, "src_reg.nii"), fname_src2dest, param.verbose)
     if fname_output_warp == '':
         fname_output_warp = os.path.join(path_out, 'warp_' + file_src + '2' + file_dest + '.nii.gz')
     generate_output_file(os.path.join(path_tmp, "warp_src2dest.nii.gz"), fname_output_warp, param.verbose)
 
-    # generate: inverse warping field
+    # generate dest -> sec output files
     if generate_warpinv:
+        fname_dest2src = os.path.join(path_out, file_out_inv + ext_dest)
+        generate_output_file(os.path.join(path_tmp, "dest_reg.nii"), fname_dest2src, param.verbose)
         fname_output_warpinv = os.path.join(path_out, 'warp_' + file_dest + '2' + file_src + '.nii.gz')
         generate_output_file(os.path.join(path_tmp, "warp_dest2src.nii.gz"), fname_output_warpinv, param.verbose)
     else:
+        # we skip generating files if there is no inverse warping field (i.e. we're doing a one-way registration)
+        fname_dest2src = None
         fname_output_warpinv = None
 
     # Delete temporary files

--- a/unit_testing/cli/test_cli_sct_register_multimodal.py
+++ b/unit_testing/cli/test_cli_sct_register_multimodal.py
@@ -1,4 +1,5 @@
 from pytest_console_scripts import script_runner
+import os
 import pytest
 import logging
 
@@ -17,7 +18,7 @@ def test_sct_register_multimodal_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_register_multimodal_mask_no_checks(tmp_path):
+def test_sct_register_multimodal_mask_files_exist(tmp_path):
     """Run the script without validating results.
 
     TODO: Write a check that verifies the registration results as part of
@@ -35,3 +36,11 @@ def test_sct_register_multimodal_mask_no_checks(tmp_path):
         '-m', fname_mask,
         '-initwarp', sct_test_path('t2', 'warp_template2anat.nii.gz')
     ])
+
+    for path in ["PAM50_t2_reg.nii.gz", "warp_PAM50_t22mt1.nii.gz"]:
+        assert os.path.isfile(path)
+        os.unlink(path)
+
+    # Because `-initwarp` was specified (but `-initwarpinv` wasn't) the dest->seg files should NOT exist
+    for path in ["mt1_reg.nii.gz", "warp_mt12PAM50_t2.nii.gz"]:
+        assert not os.path.isfile(path)

--- a/unit_testing/cli/test_cli_sct_register_multimodal.py
+++ b/unit_testing/cli/test_cli_sct_register_multimodal.py
@@ -19,10 +19,15 @@ def test_sct_register_multimodal_backwards_compat(script_runner):
 
 
 def test_sct_register_multimodal_mask_files_exist(tmp_path):
-    """Run the script without validating results.
+    """
+    Run the script without validating results.
 
-    TODO: Write a check that verifies the registration results as part of
-    https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3246."""
+    - TODO: Write a check that verifies the registration results as part of
+            https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3246.
+    - TODO: Parametrize this test to add '-initwarpinv warp_anat2template.nii.gz',
+            after the file is added to sct_testing_data:
+            https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3407#discussion_r646895013
+    """
     fname_mask = str(tmp_path/'mask_mt1.nii.gz')
     sct_create_mask.main(['-i', sct_test_path('mt', 'mt1.nii.gz'),
                           '-p', f"centerline,{sct_test_path('mt', 'mt1_seg.nii.gz')}",

--- a/unit_testing/cli/test_cli_sct_register_multimodal.py
+++ b/unit_testing/cli/test_cli_sct_register_multimodal.py
@@ -34,13 +34,13 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
         '-dseg', sct_test_path('mt', 'mt1_seg.nii.gz'),
         '-param', 'step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3',
         '-m', fname_mask,
-        '-initwarp', sct_test_path('t2', 'warp_template2anat.nii.gz')
+        '-initwarp', sct_test_path('t2', 'warp_template2anat.nii.gz'),
+        '-ofolder', str(tmp_path)
     ])
 
     for path in ["PAM50_t2_reg.nii.gz", "warp_PAM50_t22mt1.nii.gz"]:
-        assert os.path.isfile(path)
-        os.unlink(path)
+        assert os.path.isfile(tmp_path/path)
 
     # Because `-initwarp` was specified (but `-initwarpinv` wasn't) the dest->seg files should NOT exist
     for path in ["mt1_reg.nii.gz", "warp_mt12PAM50_t2.nii.gz"]:
-        assert not os.path.isfile(path)
+        assert not os.path.isfile(tmp_path/path)

--- a/unit_testing/cli/test_cli_sct_register_multimodal.py
+++ b/unit_testing/cli/test_cli_sct_register_multimodal.py
@@ -39,8 +39,8 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
     ])
 
     for path in ["PAM50_t2_reg.nii.gz", "warp_PAM50_t22mt1.nii.gz"]:
-        assert os.path.isfile(tmp_path/path)
+        assert os.path.exists(tmp_path/path)
 
     # Because `-initwarp` was specified (but `-initwarpinv` wasn't) the dest->seg files should NOT exist
     for path in ["mt1_reg.nii.gz", "warp_mt12PAM50_t2.nii.gz"]:
-        assert not os.path.isfile(tmp_path/path)
+        assert not os.path.exists(tmp_path/path)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In `sct_register_multimodal`, if `-initwarp` is passed but `-initwarpinv` isn't passed, then registration will only be performed one way (i.e. only one warping field will be generated). However, we're still outputting 2 registered image files, with one of them (`dest->src`) being completely empty. Instead of outputting an empty file, we should not output it at all.

So, this PR adds a failing test to check file existence, then includes the necessary changes to make the test pass:

* Skip applying the transform and generating the `dest->src` output files when we're performing one-way registration.
* Only display the viewer syntax if the relevant files were created

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3404.