### PR TITLE
Don't set the global loglevel when CLI scripts are called in-code

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -21,7 +21,7 @@ from skimage.measure import label
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -515,7 +515,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_mask = arguments.m
     fname_sc = arguments.s

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -17,7 +17,7 @@ from skimage.feature import greycomatrix, greycoprops
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like, concat_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -17,7 +17,7 @@ from skimage.feature import greycomatrix, greycoprops
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like, concat_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -311,7 +311,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # create param object
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -23,7 +23,7 @@ from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import cubic_to_point
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, get_interpolation, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, copy
 
 from spinalcordtoolbox.scripts import sct_image
@@ -341,7 +341,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     fname_dest = arguments.d

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -27,7 +27,7 @@ import psutil
 import requirements
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser
-from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, set_loglevel
 
 
 class bcolors:
@@ -201,7 +201,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = complete_test = arguments.complete
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     print("SCT info:")
     print("- version: {}".format(__version__))

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -15,7 +15,7 @@ import sys
 import os
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 
 # DEFAULT PARAMETERS
@@ -135,7 +135,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Initialization
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like, change_orientation
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname
 from spinalcordtoolbox.math import binarize
 
@@ -501,7 +501,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param = Param()
     if param.debug:

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -13,7 +13,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 
 # PARSER
@@ -77,7 +77,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Get parser info
     di = arguments.di

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -14,7 +14,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_loglevel
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.qmri.mt import compute_mtr
 
@@ -74,7 +74,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_mtr = arguments.o
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -20,7 +20,7 @@ import sys
 import os
 import json
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.qmri.mt import compute_mtsat
 from spinalcordtoolbox.image import Image, splitext
 
@@ -164,7 +164,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     printv('Load data...', verbose)
     nii_mt = Image(arguments.mt)

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -19,7 +19,7 @@ import os
 import numpy as np
 
 from spinalcordtoolbox.image import Image, empty_like, add_suffix
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, parse_num_list, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, parse_num_list, init_sct, printv, set_loglevel
 
 
 # PARAMETERS
@@ -104,7 +104,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Default params
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -20,7 +20,7 @@ import argparse
 
 from spinalcordtoolbox.image import Image, check_dim, generate_output_file
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, SmartFormatter
-from spinalcordtoolbox.utils.sys import init_sct, printv, run_proc, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, run_proc, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, check_file_exist
 
 
@@ -39,7 +39,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
     param = Param()
 
     # Initialization

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -15,7 +15,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 import spinalcordtoolbox.image as image
 
 
@@ -74,7 +74,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Building the command, do sanity checks
     fname_in = arguments.i

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -15,7 +15,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
 import spinalcordtoolbox.image as image
 
 

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -24,7 +24,7 @@ from scipy import ndimage
 
 from spinalcordtoolbox.image import Image, empty_like
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, extract_fname, rmtree, copy
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
@@ -131,7 +131,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param = Param()
     param.fname_data = os.path.abspath(arguments.i)

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -24,7 +24,7 @@ from scipy import ndimage
 
 from spinalcordtoolbox.image import Image, empty_like
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, extract_fname, rmtree, copy
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -13,7 +13,7 @@ import os
 
 from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 
 
 def get_parser():
@@ -142,7 +142,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialize ImageCropper
     cropper = ImageCropper(Image(arguments.i))

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -24,7 +24,7 @@ import spinalcordtoolbox.deepseg as deepseg
 import spinalcordtoolbox.deepseg.models
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     if (arguments.list_tasks is False
             and arguments.install_task is None

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -11,7 +11,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.image import add_suffix
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -94,7 +94,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     if arguments.o is not None:

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -111,7 +111,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_image = arguments.i
     contrast_type = arguments.c

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -15,7 +15,7 @@ import os
 import sys
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import Image, check_dim
 from spinalcordtoolbox.deepseg_sc.core import deep_segmentation_spinalcord
@@ -132,7 +132,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_image = os.path.abspath(arguments.i)
     contrast_type = arguments.c

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -7,7 +7,7 @@ from time import time
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel
 
 
 # DEFAULT PARAMETERS
@@ -92,7 +92,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     parameter = arguments.p
     remove_temp_files = arguments.r

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -261,7 +261,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Set param arguments ad inputted by user
     fname_in = arguments.i

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -14,7 +14,7 @@ import sys
 import os
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.math import binarize
@@ -105,7 +105,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_input1 = arguments.i
     fname_input2 = arguments.d

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -17,14 +17,14 @@ import sys
 import os
 import math
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 
 def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     GYRO = float(42.576 * 10 ** 6)  # gyromagnetic ratio (in Hz.T^-1)
     gradamp = []

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 
 def get_parser():
@@ -88,7 +88,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialization
     file_mask = ''

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -14,7 +14,7 @@ import sys
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 from spinalcordtoolbox.image import Image, concat_data
 
 
@@ -106,7 +106,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # check number of input args
     if not len(arguments.i) == len(arguments.order):

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
 
 def get_parser():
@@ -58,7 +58,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_bval_list = arguments.i
     # Build fname_out

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -13,7 +13,7 @@
 import sys
 import os
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
 
 def get_parser():
@@ -60,7 +60,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_bvecs_list = arguments.i
     # Build fname_out

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -16,7 +16,7 @@ import sys
 import matplotlib.pyplot as plt
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 bzero = 0.0001  # b-zero threshold
 
@@ -72,7 +72,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_bvecs = arguments.bvec
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -30,7 +30,7 @@ import sys
 import os
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils.sys import init_sct, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, display_viewer_syntax
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -177,7 +177,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialization
     param = ParamMoco(is_diffusion=True, group_size=3, metric='MI', smooth='1')
@@ -209,7 +209,7 @@ def main(argv=None):
     # run moco
     fname_output_image = moco_wrapper(param)
 
-    set_global_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
+    set_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
 
     # QC report
     if path_qc is not None:

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file, convert
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 
 from spinalcordtoolbox.scripts.sct_image import split_data, concat_data
@@ -113,7 +113,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialize parameters
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file, convert
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 
 from spinalcordtoolbox.scripts.sct_image import split_data, concat_data

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -25,7 +25,7 @@
 import os
 import sys
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_loglevel
 
 
 def get_parser():
@@ -72,7 +72,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_in = arguments.bvec
     fname_out = arguments.o

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -15,7 +15,7 @@ import sys
 
 from spinalcordtoolbox.download import install_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 
 # Dictionary containing list of URLs for data names.
@@ -149,7 +149,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     data_name = arguments.d
     if arguments.o is not None:

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -27,7 +27,7 @@ from spinalcordtoolbox.metadata import read_label_file
 from spinalcordtoolbox.aggregate_slicewise import check_labels, extract_metric, save_as_csv, Metric, LabelStruc
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, parse_num_list, display_open
-from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import check_file_exist, extract_fname, get_absolute_path
 
 
@@ -272,7 +272,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param_default = Param()
 

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -16,7 +16,7 @@ import os
 import logging
 
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.flattening import flatten_sagittal
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_anat = arguments.i
     fname_centerline = arguments.s

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -18,7 +18,7 @@ import os
 import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 
 
 class Param:
@@ -105,7 +105,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param = Param()
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -15,7 +15,7 @@ import sys
 import os
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils.sys import init_sct, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax, list_type
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -154,7 +154,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialization
     param = ParamMoco(group_size=1, metric='MeanSquares', smooth='0')
@@ -185,7 +185,7 @@ def main(argv=None):
     # run moco
     fname_output_image = moco_wrapper(param)
 
-    set_global_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
+    set_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
 
     # QC report
     if path_qc is not None:

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -9,7 +9,7 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -120,7 +120,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Input filename
     fname_input_data = arguments.i

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -22,7 +22,7 @@ from spinalcordtoolbox.scripts import sct_apply_transfo, sct_resample
 from spinalcordtoolbox.image import (Image, concat_data, add_suffix, change_orientation, split_img_data, pad_image,
                                      create_formatted_header_string, HEADER_FORMATS)
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, rmtree
 
 
@@ -194,7 +194,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initializations
     output_type = None

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -22,7 +22,7 @@ from spinalcordtoolbox.scripts import sct_apply_transfo, sct_resample
 from spinalcordtoolbox.image import (Image, concat_data, add_suffix, change_orientation, split_img_data, pad_image,
                                      create_formatted_header_string, HEADER_FORMATS)
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, rmtree
 
 

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -27,7 +27,7 @@ from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils import (SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, printv,
-                                     parse_num_list, set_global_loglevel)
+                                     parse_num_list, set_loglevel)
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 
@@ -245,7 +245,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     output_fname = arguments.o

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -23,7 +23,7 @@ from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_signature, cache_valid, cache_save, \
     copy, extract_fname, rmtree
 from spinalcordtoolbox.math import threshold, laplacian
@@ -229,7 +229,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initializations
     initz = ''

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -252,7 +252,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     dim_list = ['x', 'y', 'z', 't']
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree
 from spinalcordtoolbox.math import binarize
 
@@ -185,7 +185,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # create param objects
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -28,7 +28,7 @@ from spinalcordtoolbox.process_seg import compute_shape
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, parse_num_list, display_open
-from spinalcordtoolbox.utils.sys import init_sct, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 from spinalcordtoolbox.utils.fs import get_absolute_path
 
 
@@ -269,7 +269,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Initialization
     slices = ''

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -23,7 +23,7 @@ from scipy import ndimage as ndi
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like, convert
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, mv, copy
 from spinalcordtoolbox.centerline import optic
 from spinalcordtoolbox.reports.qc import generate_qc
@@ -655,7 +655,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     fname_input_data = os.path.abspath(arguments.i)
     img_input = Image(fname_input_data)

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -10,7 +10,7 @@
 
 import sys
 
-from spinalcordtoolbox.utils import init_sct, set_global_loglevel, SCTArgumentParser
+from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser
 
 
 def get_parser():
@@ -77,7 +77,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     from spinalcordtoolbox.reports.qc import generate_qc
     # Build args list (for display)

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -40,7 +40,7 @@ import numpy as np
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.registration.register import Paramreg, ParamregMultiStep
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import check_dim
 
@@ -300,7 +300,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initialize parameters
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -29,8 +29,11 @@ from spinalcordtoolbox.math import dilate, binarize
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import *
-from spinalcordtoolbox.utils import Metavar
+from spinalcordtoolbox.utils.fs import (copy, extract_fname, check_file_exist, rmtree,
+                                        cache_save, cache_signature, cache_valid)
+from spinalcordtoolbox.utils.shell import (SCTArgumentParser, ActionCreateFolder, Metavar, list_type,
+                                           printv, display_viewer_syntax)
+from spinalcordtoolbox.utils.sys import set_loglevel, init_sct
 from spinalcordtoolbox import __data_dir__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -293,7 +293,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initializations
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 import spinalcordtoolbox.resampling
 
 
@@ -113,7 +113,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param.fname_data = arguments.i
     arg = 0

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -34,7 +34,7 @@ import yaml
 import psutil
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
-from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__, set_loglevel
 from spinalcordtoolbox.utils.fs import Tee
 
 from stat import S_IEXEC
@@ -227,7 +227,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # See if there's a configuration file and import those options
     if arguments.config is not None:

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file, convert, add_suffix
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_save, cache_signature, cache_valid, copy, \
     extract_fname, rmtree
 from spinalcordtoolbox.math import smooth
@@ -122,7 +122,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # Initialization
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -19,7 +19,7 @@ from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 
 def get_parser():
@@ -197,7 +197,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     centerline_file = arguments.s

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -23,7 +23,7 @@ import signal
 import numpy as np
 from pandas import DataFrame
 
-from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__, set_global_loglevel, SCTArgumentParser
+from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__, set_loglevel, SCTArgumentParser
 from spinalcordtoolbox.scripts import sct_download_data
 
 # FIXME
@@ -213,7 +213,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.verbose
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     # initializations
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -17,7 +17,7 @@ import os
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import copy
 from spinalcordtoolbox.scripts import sct_apply_transfo
 
@@ -233,7 +233,7 @@ def main(argv=None):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_global_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose)
 
     param = Param()
 

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -17,7 +17,7 @@ import os
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import copy
 from spinalcordtoolbox.scripts import sct_apply_transfo
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -48,7 +48,7 @@ def get_caller_module():
     return mod
 
 
-def set_global_loglevel(verbose):
+def set_loglevel(verbose):
     """
     Use SCT's verbosity values to set the logging level.
 
@@ -108,7 +108,7 @@ def init_sct():
         return _format
 
     # Initialize logging
-    set_global_loglevel(verbose=False)  # False => "INFO". For "DEBUG", must be called again with verbose=True.
+    set_loglevel(verbose=False)  # False => "INFO". For "DEBUG", must be called again with verbose=True.
     hdlr = logging.StreamHandler(sys.stdout)
     fmt = logging.Formatter()
     fmt.format = _format_wrap(fmt.format)

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -15,6 +15,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
+import inspect
 
 import tqdm
 
@@ -38,9 +39,22 @@ if os.getenv('SENTRY_DSN', None):
     import raven
 
 
+def get_caller_module():
+    """Return the first non-`utils.sys` module in the stack (to see where `utils.sys` is being called from)."""
+    for frame in inspect.stack():
+        mod = inspect.getmodule(frame[0])
+        if mod.__file__ != __file__:
+            break
+    return mod
+
+
 def set_global_loglevel(verbose):
     """
-    Use SCT's verbosity values to set the global logging level.
+    Use SCT's verbosity values to set the logging level.
+
+    The behavior of this function changes depending on how the caller module was invoked:
+       1. If the module was invoked via the command line, the root (global) logger will be used.
+       2. If the module was invoked via code (e.g. sct_script.main()), then only its local logger will be used.
 
     :verbosity: Verbosity value, typically from argparse (args.v). Values must adhere
     one of two schemes:
@@ -56,9 +70,22 @@ def set_global_loglevel(verbose):
         raise ValueError(f"Invalid verbosity level '{verbose}' does not map to a log level, so cannot set.")
 
     log_level = dict_log_levels[str(verbose)]
-    # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
+
+    # Set logging level for this file
     logger.setLevel(getattr(logging, log_level))
-    logging.root.setLevel(getattr(logging, log_level))
+
+    # Set logging level for the file that called this function
+    caller_module_name = get_caller_module().__name__
+    caller_logger = logging.getLogger(caller_module_name)
+    caller_logger.setLevel(getattr(logging, log_level))
+
+    # Set the logging level globally, but only when scripts are directly invoked (e.g. from the command line)
+    if caller_module_name == "__main__":
+        logging.root.setLevel(getattr(logging, log_level))
+    else:
+        # NB: Nothing will be set if we're calling a CLI script in-code, i.e. <sct_cli_script>.main(). This keeps
+        # the loglevel changes from leaking: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3341
+        pass
 
 
 # TODO: add test

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -13,13 +13,13 @@ from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, f
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 import spinalcordtoolbox.math
-from spinalcordtoolbox.utils import sct_test_path, init_sct, set_global_loglevel
+from spinalcordtoolbox.utils import sct_test_path, init_sct, set_loglevel
 
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 
 # Set logger to "DEBUG"
 init_sct()
-set_global_loglevel(verbose=2)
+set_loglevel(verbose=2)
 # Separate setting for get_centerline. Set to 2 to save images ("DEBUG"), 0 otherwise ("INFO")
 VERBOSE = 0
 

--- a/unit_testing/test_qmri.py
+++ b/unit_testing/test_qmri.py
@@ -8,12 +8,12 @@ import pytest
 
 from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import init_sct, set_global_loglevel
+from spinalcordtoolbox.utils import init_sct, set_loglevel
 
 
 # Set logger to "DEBUG"
 init_sct()
-set_global_loglevel(verbose=2)
+set_loglevel(verbose=2)
 
 
 def make_sct_image(data):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, we set the global loglevel at the start of every CLI script. We do this to avoid having to repeatedly set the loglevel for every single child module.

However, this is a problem for in-code CLI script calls like this one:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/916ab591ca2e35cab9f5f27ec2439ce8fdb0b9d2/spinalcordtoolbox/moco.py#L768-L773

Because we set the loglevel globally, the `-v 0` change leaks outside of `sct_apply_transfo`. This means that any `logger.info` messages that come afterwards won't show up.

So, this PR makes sure that the global loglevel is _only set_ when we're calling a CLI script directly from the command line. (3c21fe8)

#### Note about "55 files changed"

(Note: Most of the file changes are due to a7bf27c. The actual substantial changes are quite small.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3341.