### PR TITLE
Make it possible to loop across "ses-" entity

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -177,11 +177,17 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     script_base = re.sub('\\.sh$', '', os.path.basename(script))
     script_full = os.path.abspath(os.path.expanduser(script))
 
-    subject = os.path.basename(subj_dir)
-    log_file = os.path.join(path_log, '{}_{}.log'.format(script_base, subject))
-    err_file = os.path.join(path_log, 'err.{}_{}.log'.format(script_base, subject))
+    subject, session = subj_dir.split(os.path.sep)
+    # If there is no session, 'session' will be empty
+    if session:
+        subject_session = subject + '_' + session
+    else:
+        subject_session = subject
+    # subject = os.path.basename(subj_dir)
+    log_file = os.path.join(path_log, '{}_{}.log'.format(script_base, subject_session))
+    err_file = os.path.join(path_log, 'err.{}_{}.log'.format(script_base, subject_session))
 
-    print('Started at {}: {}. See log file {}'.format(time.strftime('%Hh%Mm%Ss'), subject, log_file), flush=True)
+    print('Started at {}: {}. See log file {}'.format(time.strftime('%Hh%Mm%Ss'), subject_session, log_file), flush=True)
 
     # A full copy of the environment is needed otherwise sct programs won't necessarily be found
     envir = os.environ.copy()

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -381,7 +381,18 @@ def main(argv=None):
     print("git origin: {}\n".format(__get_git_origin(path_to_git_folder=path_data)))
 
     # Find subjects and process inclusion/exclusions
-    subject_dirs = [f for f in os.listdir(path_data) if f.startswith(arguments.subject_prefix)]
+    subject_dirs = []
+    subject_flat_dirs = [f for f in os.listdir(path_data) if f.startswith(arguments.subject_prefix)]
+    for isub in subject_flat_dirs:
+        session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
+        if not session_dirs:
+            # There is no session folder, so we consider only sub- directory: sub-XX
+            subject_dirs.append(isub)
+        else:
+            # There is a session folder, so we concatenate: sub-XX/ses-YY
+            session_dirs.sort()
+            for isess in session_dirs:
+                subject_dirs.append(os.path.join(isub, isess))
 
     # Handle inclusion lists
     assert not ((arguments.include is not None) and (arguments.include_list is not None)),\

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -177,13 +177,13 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     script_base = re.sub('\\.sh$', '', os.path.basename(script))
     script_full = os.path.abspath(os.path.expanduser(script))
 
-    subject, session = subj_dir.split(os.path.sep)
-    # If there is no session, 'session' will be empty
-    if session:
+    if os.path.sep in subj_dir:
+        subject, session = subj_dir.split(os.path.sep)
         subject_session = subject + '_' + session
     else:
+        subject = subj_dir
         subject_session = subject
-    # subject = os.path.basename(subj_dir)
+
     log_file = os.path.join(path_log, '{}_{}.log'.format(script_base, subject_session))
     err_file = os.path.join(path_log, 'err.{}_{}.log'.format(script_base, subject_session))
 
@@ -390,15 +390,17 @@ def main(argv=None):
     subject_dirs = []
     subject_flat_dirs = [f for f in os.listdir(path_data) if f.startswith(arguments.subject_prefix)]
     for isub in subject_flat_dirs:
-        session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
-        if not session_dirs:
-            # There is no session folder, so we consider only sub- directory: sub-XX
-            subject_dirs.append(isub)
-        else:
-            # There is a session folder, so we concatenate: sub-XX/ses-YY
-            session_dirs.sort()
-            for isess in session_dirs:
-                subject_dirs.append(os.path.join(isub, isess))
+        # Only consider folders
+        if os.path.isdir(os.path.join(path_data, isub)):
+            session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
+            if not session_dirs:
+                # There is no session folder, so we consider only sub- directory: sub-XX
+                subject_dirs.append(isub)
+            else:
+                # There is a session folder, so we concatenate: sub-XX/ses-YY
+                session_dirs.sort()
+                for isess in session_dirs:
+                    subject_dirs.append(os.path.join(isub, isess))
 
     # Handle inclusion lists
     assert not ((arguments.include is not None) and (arguments.include_list is not None)),\

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -404,7 +404,7 @@ def main(argv=None):
     if arguments.exclude_list is not None:
         subject_dirs = [f for f in subject_dirs if f not in arguments.exclude_list]
 
-    # Determine the number of jobs we can run simulataneously
+    # Determine the number of jobs we can run simultaneously
     if arguments.jobs < 1:
         jobs = multiprocessing.cpu_count() + arguments.jobs
     else:

--- a/unit_testing/test_sct_run_batch.py
+++ b/unit_testing/test_sct_run_batch.py
@@ -84,6 +84,28 @@ def test_non_executable_task():
                             '-continue-on-error', 0])
 
 
+def test_no_sessions():
+    # Test that sessions ('ses') can be separated so that sct_run_batch can process each session folder separately.
+    with TemporaryDirectory() as data,\
+            TemporaryDirectory() as out,\
+            NamedTemporaryFile('w', suffix='.sh') as script:
+        # Create dummy BIDS directory with sessions
+        os.makedirs(os.path.join(data, 'sub-01', 'anat'))
+        os.makedirs(os.path.join(data, 'sub-02', 'anat'))
+        # Dummy script that displays subject
+        script_text = """
+        #!/bin/bash
+        SUBJECT=$1
+        echo $SUBJECT
+        """
+        script.write(dedent(script_text)[1:])  #indexing removes beginning newline
+        script.flush()
+
+        sct_run_batch.main(['-path-data', data, '-path-out', out, '-script', script.name])
+        file_log = glob.glob(os.path.join(out, 'log', '*sub-01.log'))[0]
+        assert 'sub-01' in open(file_log, "r").read()
+
+
 def test_separate_sessions():
     # Test that sessions ('ses') can be separated so that sct_run_batch can process each session folder separately.
     with TemporaryDirectory() as data,\

--- a/unit_testing/test_sct_run_batch.py
+++ b/unit_testing/test_sct_run_batch.py
@@ -60,6 +60,7 @@ def test_only_one_include():
                                 'arg2', '-path-data', data, '-path-out', out
                                 , '-script', out])
 
+
 def test_non_executable_task():
     data_path = sct_test_path()
     with \

--- a/unit_testing/test_sct_run_batch.py
+++ b/unit_testing/test_sct_run_batch.py
@@ -82,3 +82,26 @@ def test_non_executable_task():
                             '-script', script.name,
                             '-continue-on-error', 0])
 
+
+def test_separate_sessions():
+    # Test that sessions ('ses') can be separated so that sct_run_batch can process each session folder separately.
+    with TemporaryDirectory() as data,\
+            TemporaryDirectory() as out,\
+            NamedTemporaryFile('w', suffix='.sh') as script:
+        # Create dummy BIDS directory with sessions
+        os.makedirs(os.path.join(data, 'sub-01', 'ses-01'))
+        os.makedirs(os.path.join(data, 'sub-01', 'ses-02'))
+        os.makedirs(os.path.join(data, 'sub-01', 'ses-03'))
+        os.makedirs(os.path.join(data, 'sub-02', 'ses-01'))
+        os.makedirs(os.path.join(data, 'sub-02', 'ses-02'))
+        # Dummy script that displays subject
+        script_text = """
+        #!/bin/bash
+        SUBJECT=$1
+        echo $SUBJECT
+        """
+        script.write(dedent(script_text)[1:])  #indexing removes beginning newline
+        script.flush()
+
+        sct_run_batch.main(['-path-data', data, '-path-out', out, '-script', script.name])
+        # TODO: check first log file: it should say sub-01_ses-01

--- a/unit_testing/test_sct_run_batch.py
+++ b/unit_testing/test_sct_run_batch.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 import pytest
@@ -104,4 +105,5 @@ def test_separate_sessions():
         script.flush()
 
         sct_run_batch.main(['-path-data', data, '-path-out', out, '-script', script.name])
-        # TODO: check first log file: it should say sub-01_ses-01
+        file_log = glob.glob(os.path.join(out, 'log', '*sub-01_ses-01.log'))[0]
+        assert 'sub-01/ses-01' in open(file_log, "r").read()


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

### Context

The [BIDS](https://bids.neuroimaging.io/) way to accommodate time points is to introduce the "ses-X" sub-folder. Example:

~~~
dataset
├── dataset_description.json
├── participants.json
├── participants.tsv
├── sub-ubc01
├── sub-ubc02
├── sub-ubc03
├── sub-ubc04
├── sub-ubc05
├── sub-ubc06
│   ├── ses-01
│   └── ses-02
|       └── anat
|           ├── sub-ubc06_ses-02_T1w.json
|           ├── sub-ubc06_ses-02_T1w.nii.gz
|           ├── sub-ubc06_ses-02_T2w.json
|           ├── sub-ubc06_ses-02_T2w.nii.gz
|           ├── sub-ubc06_ses-02_acq-ax_T2w.json
|           └── sub-ubc06_ses-02_acq-ax_T2w.nii.gz
|
└── derivatives
    └── labels
        └── sub-ubc06
                ├── ses-01
                └── ses-02
                    └── anat
                        ├── sub-ubc06_ses-02_T2w_seg-manual.json
                        ├── sub-ubc06_ses-02_T2w_seg-manual.nii.gz  <------------- manually-corrected spinal cord segmentation
                        ├── sub-ubc06_ses-02_T2w_lesion-manual.json
                        └── sub-ubc06_ses-02_T2w_lesion-manual.nii.gz  <---------- manually-created lesion segmentation
~~~

Suggestion

So far, `sct_run_batch` only loops across subjects. This PR makes it possible to consider another level of depth, so that the function would loop across: {sub-01_ses-01, sub-01_ses-02, ..., sub-02_ses-01, sub-01_ses-02, ...}.

Specifications:
- To be considered, the sub-folders NEED to start with `ses-`, according to BIDS
- If `ses-` folders are present, they are passed on as `$1` in the called script. So it is the responsibility of the SHELL script to parse `sub-XX/ses-YY` into `sub-XX_ses-YY`, or into `sub-XX`, if necessary.

## Linked issues

Fixes #3413 