### PR TITLE
Display soft segmentation in qc report

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -63,9 +63,9 @@ class QcImage(object):
                      "#a22abd", "#d58240", "#ac2aff"]
     _seg_colormap = ["#4d0000", "#ff0000"]
 
-    
+
     def __init__(self, qc_report, interpolation, action_list, process, stretch_contrast=True,
-                stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
+                 stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
         """
         :param qc_report: QcReport: The QC report object
         :param interpolation: str: Type of interpolation used in matplotlib

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -61,13 +61,11 @@ class QcImage(object):
                      "#9f89b0", "#e08e08", "#3d2b54",
                      "#7d0434", "#fb1849", "#14aab4",
                      "#a22abd", "#d58240", "#ac2aff"]
-    # _seg_colormap = ["#660000", "#ff0000"]  # Dark red
-    # _seg_colormap = ["#000000", "#ff0000"]  # With Black
-    _seg_colormap = ["#4d0000", "#ff0000"]  # Darker red
+    _seg_colormap = ["#4d0000", "#ff0000"]
 
     
     def __init__(self, qc_report, interpolation, action_list, process, stretch_contrast=True,
-                 stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
+                stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
         """
         :param qc_report: QcReport: The QC report object
         :param interpolation: str: Type of interpolation used in matplotlib
@@ -136,9 +134,8 @@ class QcImage(object):
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
                   cmap=color.LinearSegmentedColormap.from_list("", self._seg_colormap),
-                  norm=color.Normalize(vmin=0, vmax=1),
+                  norm=color.Normalize(vmin=0.5, vmax=1),
                   interpolation=self.interpolation,
-                  # alpha=1,
                   aspect=float(self.aspect_mask))
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -61,8 +61,11 @@ class QcImage(object):
                      "#9f89b0", "#e08e08", "#3d2b54",
                      "#7d0434", "#fb1849", "#14aab4",
                      "#a22abd", "#d58240", "#ac2aff"]
-    # _seg_colormap = plt.cm.autumn
+    #_seg_colormap = ["#660000", "#ff0000"] # Dark red
+    #_seg_colormap = ["#000000", "#ff0000"] # With Black
+    _seg_colormap = ["#4d0000", "#ff0000"] # Darker red
 
+    
     def __init__(self, qc_report, interpolation, action_list, process, stretch_contrast=True,
                  stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
         """
@@ -130,12 +133,12 @@ class QcImage(object):
 
     def listed_seg(self, mask, ax):
         """Create figure with red segmentation. Common scenario."""
-        img = np.rint(np.ma.masked_where(mask < 1, mask))
+        img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
-                  cmap=color.ListedColormap(self._color_bin_red),
+                  cmap=color.LinearSegmentedColormap.from_list("",self._seg_colormap),
                   norm=color.Normalize(vmin=0, vmax=1),
                   interpolation=self.interpolation,
-                  alpha=1,
+                  #alpha=1,
                   aspect=float(self.aspect_mask))
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -61,9 +61,9 @@ class QcImage(object):
                      "#9f89b0", "#e08e08", "#3d2b54",
                      "#7d0434", "#fb1849", "#14aab4",
                      "#a22abd", "#d58240", "#ac2aff"]
-    #_seg_colormap = ["#660000", "#ff0000"] # Dark red
-    #_seg_colormap = ["#000000", "#ff0000"] # With Black
-    _seg_colormap = ["#4d0000", "#ff0000"] # Darker red
+    # _seg_colormap = ["#660000", "#ff0000"]  # Dark red
+    # _seg_colormap = ["#000000", "#ff0000"]  # With Black
+    _seg_colormap = ["#4d0000", "#ff0000"]  # Darker red
 
     
     def __init__(self, qc_report, interpolation, action_list, process, stretch_contrast=True,
@@ -135,10 +135,10 @@ class QcImage(object):
         """Create figure with red segmentation. Common scenario."""
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
-                  cmap=color.LinearSegmentedColormap.from_list("",self._seg_colormap),
+                  cmap=color.LinearSegmentedColormap.from_list("", self._seg_colormap),
                   norm=color.Normalize(vmin=0, vmax=1),
                   interpolation=self.interpolation,
-                  #alpha=1,
+                  # alpha=1,
                   aspect=float(self.aspect_mask))
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -352,7 +352,6 @@ class Slice(object):
             nii_r = resample_nib(nii, image_dest=nii_ref, interpolation=dict_interp[type_img])
         # If resampled image is a segmentation, binarize using threshold at 0.5
         if type_img == 'seg':
-            # img_r_data = (nii_r.get_data() > 0.5) * 1 # TODO binarize later
             img_r_data = nii_r.get_data()
             img_r_data[img_r_data < 0.5] = 0
         else:

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -352,7 +352,7 @@ class Slice(object):
             nii_r = resample_nib(nii, image_dest=nii_ref, interpolation=dict_interp[type_img])
         # If resampled image is a segmentation, binarize using threshold at 0.5
         if type_img == 'seg':
-            #img_r_data = (nii_r.get_data() > 0.1) * 1 #TODO binarize later
+            #img_r_data = (nii_r.get_data() > 0.5) * 1 # TODO binarize later
             img_r_data = nii_r.get_data()
         else:
             img_r_data = nii_r.get_data()

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -352,7 +352,8 @@ class Slice(object):
             nii_r = resample_nib(nii, image_dest=nii_ref, interpolation=dict_interp[type_img])
         # If resampled image is a segmentation, binarize using threshold at 0.5
         if type_img == 'seg':
-            img_r_data = (nii_r.get_data() > 0.5) * 1
+            #img_r_data = (nii_r.get_data() > 0.1) * 1 #TODO binarize later
+            img_r_data = nii_r.get_data()
         else:
             img_r_data = nii_r.get_data()
         # Create Image objects

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -354,6 +354,7 @@ class Slice(object):
         if type_img == 'seg':
             # img_r_data = (nii_r.get_data() > 0.5) * 1 # TODO binarize later
             img_r_data = nii_r.get_data()
+            img_r_data[img_r_data < 0.5] = 0
         else:
             img_r_data = nii_r.get_data()
         # Create Image objects

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -352,7 +352,7 @@ class Slice(object):
             nii_r = resample_nib(nii, image_dest=nii_ref, interpolation=dict_interp[type_img])
         # If resampled image is a segmentation, binarize using threshold at 0.5
         if type_img == 'seg':
-            #img_r_data = (nii_r.get_data() > 0.5) * 1 # TODO binarize later
+            # img_r_data = (nii_r.get_data() > 0.5) * 1 # TODO binarize later
             img_r_data = nii_r.get_data()
         else:
             img_r_data = nii_r.get_data()


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The purpose of this PR is to add the option to display a soft segmenation in the qc report.

What is done:

- [x] Add a colormap to look like the red colormap in FSLeyes (like the image in #3417).
- [x] Remove binarization of the segmentation.

What is left:

- [x] I wasn't sure what was the best way to differentiate softseg and binary seg --> Either add a flag/check if the segmentation is soft or not to binarize the segmentation after linear interpolation.
- [x] Choose the colormap (I commented 2 other options).

#### What it looks like with current color map:
On T1w:
![image](https://user-images.githubusercontent.com/71230552/121694780-6e578000-ca98-11eb-83eb-4ce16d367654.png)

On T2w:
![image](https://user-images.githubusercontent.com/71230552/121694851-829b7d00-ca98-11eb-8667-a2eec941e8dc.png)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #3417 