### PR TITLE
Stop trying to detect headless systems using `DISPLAY`, and no longer set `MPLBACKEND`

### DIFF
--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           PIP_PROGRESS_BAR=off ./install_sct -y
           cat ~/.bashrc | grep "export SCT_DIR" | cut -d " " -f 2 >> $GITHUB_ENV
-          cat ~/.bashrc | grep "export MPLBACKEND" | cut -d " " -f 2 >> $GITHUB_ENV
           cat ~/.bashrc | grep "export PATH" | grep -o "/.*" | cut -d ':' -f 1 >> $GITHUB_PATH
 
       - name: Run batch_processing.sh

--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 def pytest_sessionstart():
-    """ Download sct_testing_data prior to test collection. """
+    """Perform actions that must be done prior to test collection."""
+    # Use a non-interactive backend so that no GUI plots will interrupt the test suite.
+    # (NB: We do this here to ensure it is set before `matplotlib` is first imported.)
+    os.environ["MPLBACKEND"] = 'Agg'
+
+    # Download sct_testing_data prior to test collection
     logger.info("Downloading sct test data")
     downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
 

--- a/conftest.py
+++ b/conftest.py
@@ -29,7 +29,8 @@ def pytest_sessionstart():
     """Perform actions that must be done prior to test collection."""
     # Use a non-interactive backend so that no GUI plots will interrupt the test suite.
     # (NB: We do this here to ensure it is set before `matplotlib` is first imported.)
-    os.environ["MPLBACKEND"] = 'Agg'
+    if 'MPLBACKEND' not in os.environ:
+        os.environ["MPLBACKEND"] = 'Agg'
 
     # Download sct_testing_data prior to test collection
     logger.info("Downloading sct test data")

--- a/install_sct
+++ b/install_sct
@@ -265,10 +265,8 @@ function edit_shellrc() {
     # Switch between shell
     if [[ "$THE_RC" == "bash" ]]; then
       echo "export SCT_DIR=$SCT_DIR"
-      echo "export MPLBACKEND=Agg"
     elif [[ "$THE_RC" == "csh" ]]; then
       echo "setenv SCT_DIR $SCT_DIR"
-      echo "setenv MPLBACKEND Agg"
     fi
     # add line
     echo ""
@@ -542,11 +540,6 @@ else
   die "This variable is not recognized: THE_RC=$THE_RC"
 fi
 
-# Update MPLBACKEND on headless system. See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2137
-if [[ -z "${MLBACKEND:-}" ]]; then
-  export MPLBACKEND=Agg
-fi
-
 # Copy files to destination directory
 if [[ "$SCT_DIR" != "$SCT_SOURCE" ]]; then
   print info "Copying source files from $SCT_SOURCE to $SCT_DIR"
@@ -701,7 +694,13 @@ conda deactivate >/dev/null 2>&1
 if [[ -e "$RC_FILE_PATH" ]]; then
     if grep "sct_env" "$RC_FILE_PATH"; then
       print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
-      sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
+      sed_i '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
+    fi
+    if grep "^export MPLBACKEND=Agg" "$RC_FILE_PATH"; then
+      print info "Commenting out 'export MPLBACKEND=Agg' from previous SCT installation"
+      sed_i 's/^export MPLBACKEND=Agg/# The line below has been commented out by a more recent installation of SCT,\
+# because export MPLBACKEND=Agg is no longer needed as of SCT v5.4.0\
+# export MPLBACKEND=Agg/' "$RC_FILE_PATH"
     fi
 fi
 

--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -207,8 +207,6 @@ def get_centerline(im_seg, param=ParamCenterline(), verbose=1):
     # Display fig of fitted curves
     if verbose == 2:
         from datetime import datetime
-        import matplotlib
-        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
         plt.figure(figsize=(16, 10))
         plt.subplot(3, 1, 1)

--- a/spinalcordtoolbox/centerline/nurbs.py
+++ b/spinalcordtoolbox/centerline/nurbs.py
@@ -1082,8 +1082,6 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
         if not twodim:
             PC_z = [p[2] for p in PC]
 
-        import matplotlib
-        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
         if not twodim:
             plt.figure(1)

--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -17,10 +17,6 @@ def main():
     env = dict()
     env.update(os.environ)
 
-    if "DISPLAY" not in os.environ:
-        # No DISPLAY, set suitable default matplotlib backend as pyplot is used
-        env["MPLBACKEND"] = "Agg"
-
     if "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS" not in os.environ:
         env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(multiprocessing.cpu_count())
 

--- a/spinalcordtoolbox/registration/landmarks.py
+++ b/spinalcordtoolbox/registration/landmarks.py
@@ -257,10 +257,6 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
     logger.info(f"Translation:\n {translation_array}")
 
     if verbose == 2:
-
-        import matplotlib
-        # use Agg to prevent display
-        matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         from mpl_toolkits.mplot3d import Axes3D
 

--- a/spinalcordtoolbox/registration/register.py
+++ b/spinalcordtoolbox/registration/register.py
@@ -464,8 +464,6 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
     # TODO: no need to split the src or dest if it is the template (we know its centerline and orientation already)
 
     if verbose == 2:
-        import matplotlib
-        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
 
     # Get image dimensions and retrieve nz
@@ -721,8 +719,6 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
 
     # for display stuff
     if verbose == 2:
-        import matplotlib
-        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
 
     # Get image dimensions and retrieve nz

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -45,8 +45,6 @@ class ErnstAngle:
 
     # draw the graph
     def draw(self, tr_min, tr_max):
-        import matplotlib
-        matplotlib.use('TkAgg')
         import matplotlib.pyplot as plt
         from numpy import arange
         step = (tr_max - tr_min) / 50

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -483,7 +483,6 @@ def compute_similarity(img1: Image, img2: Image, fname_out: str, metric: str, me
     res, data1_1d, data2_1d = sct_math.compute_similarity(img1.data, img2.data, metric=metric)
 
     if verbose > 1:
-        matplotlib.use('Agg')
         plt.plot(data1_1d, 'b')
         plt.plot(data2_1d, 'r')
         plt.title('Similarity: ' + metric_full + ' = ' + str(res))

--- a/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
+++ b/unit_testing/cli/test_cli_sct_dmri_display_bvecs.py
@@ -9,8 +9,6 @@ from spinalcordtoolbox.scripts import sct_dmri_display_bvecs
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Script uses pyplot.show, causing macOS 10.15 CI runners to hang.")
-# FIXME: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3388
 def test_sct_dmri_display_bvecs_png_exists():
     """Run the CLI script."""
     sct_dmri_display_bvecs.main(argv=['-bvec', 'sct_testing_data/dmri/bvecs.txt'])


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

### Context

Historically, to avoid crashes on headless systems (#1784), we've set `MPLBACKEND` to a non-GUI backend in the user's RC file. We've also tried to detect headless systems using `DISPLAY`, then if we are headless, set `MPLBACKEND` in the CLI launcher. 

However, #1784 appears to have been fixed upstream (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3401#issuecomment-861614835), so in theory, these heavy-handed `MPLBACKEND` workarounds are no longer needed.

### PR Changes

* Avoid setting `MPLBACKEND` at all within SCT, and let matplotlib choose an appropriate backend itself (Fixes #3392)
* Set `MPLBACKEND=Agg` for the test suite only, since showing interactive plots would interrupt the tests (Fixes #3388)

Additionally, since checking for headless systems using `$DISPLAY` is no longer relevant, this PR refactors the `sct_check_dependencies` GUI checks to be more useful. (Fixes #2693)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2693.
Fixes #3388.
Fixes #3392.

Supersedes #3401.