### PR TITLE
Added bibliography reference for sct_denoising_onlm

### DIFF
--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -24,8 +24,11 @@ class Param:
 
 def get_parser():
     parser = SCTArgumentParser(
-        description='Utility function to denoise images. (Return the denoised image and also the difference '
-                    'between the input and the output.)'
+        description='Utility function to denoise images. Return the denoised image and also the difference '
+                    'between the input and the output. The denoising algorithm is based on the Non-local means'
+                    'methods (Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins. “Adaptive Multiresolution '
+                    'Non-Local Means Filter for 3D MR Image Denoising” IET Image Processing, Institution of '
+                    'Engineering and Technology, 2011). The implementation is based on Dipy (https://dipy.org/).'
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -5,6 +5,7 @@ from time import time
 
 import numpy as np
 import nibabel as nib
+from dipy.denoise.nlmeans import nlmeans
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel
 
@@ -123,8 +124,6 @@ def main(argv=None):
     # Process for manual detecting of background
     # mask = data[:, :, :] > noise_threshold
     # data = data[:, :, :]
-
-    from dipy.denoise.nlmeans import nlmeans
 
     if arguments.std is not None:
         sigma = std_noise

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import sys
-import os
 from time import time
 
 import numpy as np


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Currently, `sct_denoise_onlm` gives no indication about the algorithm(s) used for denoising. We should at least add the proper articles where the methods is implemented:

<details><summary>Function usage</summary>

```console
julien-macbook:~/sct_testing_data/t2s $ sct_denoising_onlm 

--
Spinal Cord Toolbox (git-jca/3413-run-batch-session-c41958db922273a66764ef88239587f91af3adad)

sct_denoising_onlm 
--

usage: sct_denoising_onlm -i <file> [-h] [-p {Rician,Gaussian}] [-d <int>] [-std <float>] [-o <str>]
                          [-r {0,1}] [-v <int>]

Utility function to denoise images. (Return the denoised image and also the difference between the input and the output.)

MANDATORY ARGUMENTS:
  -i <file>             Input NIFTI image to be denoised. Example: image_input.nii.gz

OPTIONAL ARGUMENTS:
  -h, --help            Show this help message and exit
  -p {Rician,Gaussian}  Type of assumed noise distribution. Default is: Rician. (default: Rician)
  -d <int>              Threshold value for what to be considered as noise. The standard deviation
                        of the noise is calculated for values below this limit. Not relevant if -std
                        value is precised. Default is 80. (default: 80)
  -std <float>          Standard deviation of the noise. If not specified, it is calculated using a
                        background of point of values below the threshold value (parameter d).
  -o <str>              Name of the output NIFTI image.
  -r {0,1}              Remove temporary files. Specify 0 to get access to temporary files.
                        (default: 1)
  -v <int>              Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info
                        messages, 2: Debug mode (default: 1)

```

</details>

The appropriate reference is:

> Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins. “Adaptive Multiresolution Non-Local Means Filter for 3D MR Image Denoising” IET Image Processing, Institution of Engineering and Technology, 2011

## Linked issues
Fixes #3424
