### PR TITLE
Add check of FSLeyes version into sct_check_dependencies.py

### DIFF
--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -350,25 +350,28 @@ def main(argv=None):
     # Check version of FSLeyes
     print_line('Check FSLeyes version')
     cmd = 'fsleyes --version'
-    try:
-        status, output = run_proc(cmd, verbose=0, raise_exception=True)
+    status, output = run_proc(cmd, verbose=0, raise_exception=False)
+    # Exit code 0 - command has run successfully
+    if status == 0:
         # Fetch only version number (full output of 'fsleyes --version' is 'fsleyes/FSLeyes version 0.34.2')
         fsleyes_version = output.split()[2]
         print_ok(more=(" (%s)" % fsleyes_version))
-    # FSLeyes is not installed
-    except RuntimeError:
-        print("Not installed. While FSLeyes is not a requirement of SCT, we recommend to install it to easily "
-              "visualize processing outputs and/or to use SCT within FSLeyes. More info at: "
-              "https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html")
-    # Potentially sct_plugin.py related problem - see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3426
-    except AttributeError as err:
-        print('AttributeError exception occurred. This exception might be related to sct_plugin.py script. More info '
-              'at: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3426')
-        print(err)
-    # Other exceptions
-    except Exception as err:
-        print('Following exception occurred when trying to get FSLeyes version:')
-        print(err)
+    # Exit code 126 - Command invoked cannot execute (permission problem or command is not an executable)
+    elif status == 126:
+        print('Command not executable. Please check permissions of fsleyes command.')
+    # Exit code 127 - Command not found (possible problem with $PATH)
+    elif status == 127:
+        print('Command not found. If you installed FSLeyes as part of FSL package, please check that FSL is included '
+              'in $PATH variable. If you installed FSLeyes using conda environment, make sure that the environment is '
+              'activated. If you do not have FSLeyes installed, consider its installation to easily visualize '
+              'processing outputs and/or to use SCT within FSLeyes. More info at: '
+              'https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html')
+    # All other exit codes
+    else:
+        print(f'Exit code {status} occurred. Please report this issue on SCT GitHub: '
+              f'https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues')
+        if complete_test:
+            print(output)
 
     print('')
     sys.exit(e + install_software)

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -347,6 +347,21 @@ def main(argv=None):
             print_fail()
             print(err)
 
+    # Check version of FSLeyes
+    print_line('Check FSLeyes version')
+    cmd = 'fsleyes --version'
+    status, output = run_proc(cmd, verbose=0, raise_exception=False)
+    # Fetch only version number (full output of 'fsleyes --version' is 'fsleyes/FSLeyes version 0.34.2')
+    fsleyes_version = output.split()[2]
+    if status == 0:
+        print_ok(more=(" (%s)" % fsleyes_version))
+    else:
+        print_fail(f" ({output})")
+        e = 1
+    if complete_test:
+        print('>> ' + cmd)
+        print((status, output), '\n')
+
     print('')
     sys.exit(e + install_software)
 

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -356,9 +356,9 @@ def main(argv=None):
     if status == 0:
         print_ok(more=(" (%s)" % fsleyes_version))
     else:
-        print(f" Not installed. While FSLeyes is not a requirement of SCT, we recommend to install it to easily "
-              f"visualize processing outputs and/or to use SCT within FSLeyes. More info at: "
-              f"https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html")
+        print("Not installed. While FSLeyes is not a requirement of SCT, we recommend to install it to easily "
+              "visualize processing outputs and/or to use SCT within FSLeyes. More info at: "
+              "https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html")
     if complete_test:
         print('>> ' + cmd)
         print((status, output), '\n')

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -350,18 +350,25 @@ def main(argv=None):
     # Check version of FSLeyes
     print_line('Check FSLeyes version')
     cmd = 'fsleyes --version'
-    status, output = run_proc(cmd, verbose=0, raise_exception=False)
-    # Fetch only version number (full output of 'fsleyes --version' is 'fsleyes/FSLeyes version 0.34.2')
-    fsleyes_version = output.split()[2]
-    if status == 0:
+    try:
+        status, output = run_proc(cmd, verbose=0, raise_exception=True)
+        # Fetch only version number (full output of 'fsleyes --version' is 'fsleyes/FSLeyes version 0.34.2')
+        fsleyes_version = output.split()[2]
         print_ok(more=(" (%s)" % fsleyes_version))
-    else:
+    # FSLeyes is not installed
+    except RuntimeError:
         print("Not installed. While FSLeyes is not a requirement of SCT, we recommend to install it to easily "
               "visualize processing outputs and/or to use SCT within FSLeyes. More info at: "
               "https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html")
-    if complete_test:
-        print('>> ' + cmd)
-        print((status, output), '\n')
+    # Potentially sct_plugin.py related problem - see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3426
+    except AttributeError as err:
+        print('AttributeError exception occurred. This exception might be related to sct_plugin.py script. More info '
+              'at: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3426')
+        print(err)
+    # Others exceptions
+    except Exception as err:
+        print('Following exception occurred when trying to get FSLeyes version:')
+        print(err)
 
     print('')
     sys.exit(e + install_software)

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -356,7 +356,9 @@ def main(argv=None):
     if status == 0:
         print_ok(more=(" (%s)" % fsleyes_version))
     else:
-        print_fail(f" ({output})")
+        print(f" Not installed. While FSLeyes is not a requirement of SCT, we recommend to install it to easily "
+              f"visualize processing outputs and/or to use SCT within FSLeyes. More info at: "
+              f"https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html")
     if complete_test:
         print('>> ' + cmd)
         print((status, output), '\n')

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -365,7 +365,7 @@ def main(argv=None):
         print('AttributeError exception occurred. This exception might be related to sct_plugin.py script. More info '
               'at: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3426')
         print(err)
-    # Others exceptions
+    # Other exceptions
     except Exception as err:
         print('Following exception occurred when trying to get FSLeyes version:')
         print(err)

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -357,7 +357,6 @@ def main(argv=None):
         print_ok(more=(" (%s)" % fsleyes_version))
     else:
         print_fail(f" ({output})")
-        e = 1
     if complete_test:
         print('>> ' + cmd)
         print((status, output), '\n')

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 import sys
-import os
 from time import time
 
 import numpy as np
 import nibabel as nib
+from dipy.denoise.nlmeans import nlmeans
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel
 
@@ -24,8 +24,11 @@ class Param:
 
 def get_parser():
     parser = SCTArgumentParser(
-        description='Utility function to denoise images. (Return the denoised image and also the difference '
-                    'between the input and the output.)'
+        description='Utility function to denoise images. Return the denoised image and also the difference '
+                    'between the input and the output. The denoising algorithm is based on the Non-local means'
+                    'methods (Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins. “Adaptive Multiresolution '
+                    'Non-Local Means Filter for 3D MR Image Denoising” IET Image Processing, Institution of '
+                    'Engineering and Technology, 2011). The implementation is based on Dipy (https://dipy.org/).'
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -124,8 +127,6 @@ def main(argv=None):
     # Process for manual detecting of background
     # mask = data[:, :, :] > noise_threshold
     # data = data[:, :, :]
-
-    from dipy.denoise.nlmeans import nlmeans
 
     if arguments.std is not None:
         sigma = std_noise


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

After [recent issue](https://forum.spinalcordmri.org/t/problem-with-fsleyes/715) of one user with FSLeyes, we concluded in Slack discussion, that it would be useful if `sct_check_dependencies.py` was able to check FSLeyes version.

Thus, this PR adds check of FSLeyes version into `sct_check_dependencies.py`.

<details>
<summary> Output of sct_check_dependencies.py if FSLeyes is installed: </summary>

```console
--
Spinal Cord Toolbox (git-jv/sct_check_dependencies-check-FSLeyes-version-9c0b9bfcca2e936ebbc20a899bb8023972d83028)

sct_check_dependencies 
--

SCT info:
- version: git-jv/sct_check_dependencies-check-FSLeyes-version-9c0b9bfcca2e936ebbc20a899bb8023972d83028
- path: /usr/local/sct
OS: osx (Darwin-19.6.0-x86_64-i386-64bit)
CPU cores: Available: 4, Used by ITK functions: 4
RAM: Total: 8192MB, Used: 4913MB, Available: 2185MB
Check Python executable.............................[OK]
  Using bundled python 3.6.13 |Anaconda, Inc.| (default, Feb 23 2021, 12:58:59) 
[GCC Clang 10.0.0 ] at /usr/local/sct/python/envs/venv_sct/bin/python
Check if data are installed.........................[OK]
Check if colored is installed.......................[OK] (1.4.2)
Check if dipy is installed..........................[OK] (1.4.1)
Check if futures is installed.......................[OK]
Check if h5py is installed..........................[OK] (2.10.0)
Check if Keras (2.1.5) is installed.................[OK] (2.1.5)
Check if ivadomed is installed......................[OK] (2.7.4)
Check if matplotlib is installed....................[OK] (3.3.4)
Check if nibabel is installed.......................[OK] (3.2.1)
Check if numpy is installed.........................[OK] (1.19.5)
Check if onnxruntime (1.4.0) is installed...........[OK] (1.4.0)
Check if pandas is installed........................[OK] (1.1.5)
Check if psutil is installed........................[OK] (5.8.0)
Check if pyqt5 (5.11.3) is installed................[OK] (5.11.3)
Check if pytest is installed........................[OK] (6.2.4)
Check if pytest-cov is installed....................[OK] (2.12.0)
Check if raven is installed.........................[OK]
Check if requests is installed......................[OK] (2.25.1)
Check if requirements-parser is installed...........[OK] (0.2.0)
Check if scipy is installed.........................[OK] (1.5.4)
Check if scikit-image is installed..................[OK] (0.17.2)
Check if scikit-learn is installed..................[OK] (0.24.2)
Check if tensorflow (1.5.0) is installed............[OK] (1.5.0)
Check if torch (1.5.0) is installed.................[OK] (1.5.0)
Check if torchvision (0.6.0) is installed...........[OK] (0.6.0)
Check if xlwt is installed..........................[OK] (1.3.0)
Check if tqdm is installed..........................[OK] (4.60.0)
Check if transforms3d is installed..................[OK] (0.3.1)
Check if urllib3 is installed.......................[OK] (1.26.4)
Check if pytest_console_scripts is installed........[OK]
Check if wquantiles is installed....................[OK] (0.4)
Check if spinalcordtoolbox is installed.............[OK]
Check ANTs compatibility with OS ...................[OK]
Check PropSeg compatibility with OS ................[OK]
Check if figure can be opened with matplotlib.......[FAIL] (Using non-GUI backend 'agg')
Check if figure can be opened with PyQt.............[OK]
Check FSLeyes version...............................[OK] (0.34.2)

```
</details>

<details>
<summary> Output of sct_check_dependencies.py if FSLeyes is not installed or if is not included in $PATH : </summary>

```console
--
Spinal Cord Toolbox (git-jv/sct_check_dependencies-check-FSLeyes-version-9c0b9bfcca2e936ebbc20a899bb8023972d83028)

sct_check_dependencies 
--

SCT info:
- version: git-jv/sct_check_dependencies-check-FSLeyes-version-9c0b9bfcca2e936ebbc20a899bb8023972d83028
- path: /usr/local/sct
OS: osx (Darwin-19.6.0-x86_64-i386-64bit)
CPU cores: Available: 4, Used by ITK functions: 4
RAM: Total: 8192MB, Used: 4743MB, Available: 2012MB
Check Python executable.............................[OK]
  Using bundled python 3.6.13 |Anaconda, Inc.| (default, Feb 23 2021, 12:58:59) 
[GCC Clang 10.0.0 ] at /usr/local/sct/python/envs/venv_sct/bin/python
Check if data are installed.........................[OK]
Check if colored is installed.......................[OK] (1.4.2)
Check if dipy is installed..........................[OK] (1.4.1)
Check if futures is installed.......................[OK]
Check if h5py is installed..........................[OK] (2.10.0)
Check if Keras (2.1.5) is installed.................[OK] (2.1.5)
Check if ivadomed is installed......................[OK] (2.7.4)
Check if matplotlib is installed....................[OK] (3.3.4)
Check if nibabel is installed.......................[OK] (3.2.1)
Check if numpy is installed.........................[OK] (1.19.5)
Check if onnxruntime (1.4.0) is installed...........[OK] (1.4.0)
Check if pandas is installed........................[OK] (1.1.5)
Check if psutil is installed........................[OK] (5.8.0)
Check if pyqt5 (5.11.3) is installed................[OK] (5.11.3)
Check if pytest is installed........................[OK] (6.2.4)
Check if pytest-cov is installed....................[OK] (2.12.0)
Check if raven is installed.........................[OK]
Check if requests is installed......................[OK] (2.25.1)
Check if requirements-parser is installed...........[OK] (0.2.0)
Check if scipy is installed.........................[OK] (1.5.4)
Check if scikit-image is installed..................[OK] (0.17.2)
Check if scikit-learn is installed..................[OK] (0.24.2)
Check if tensorflow (1.5.0) is installed............[OK] (1.5.0)
Check if torch (1.5.0) is installed.................[OK] (1.5.0)
Check if torchvision (0.6.0) is installed...........[OK] (0.6.0)
Check if xlwt is installed..........................[OK] (1.3.0)
Check if tqdm is installed..........................[OK] (4.60.0)
Check if transforms3d is installed..................[OK] (0.3.1)
Check if urllib3 is installed.......................[OK] (1.26.4)
Check if pytest_console_scripts is installed........[OK]
Check if wquantiles is installed....................[OK] (0.4)
Check if spinalcordtoolbox is installed.............[OK]
Check ANTs compatibility with OS ...................[OK]
Check PropSeg compatibility with OS ................[OK]
Check if figure can be opened with matplotlib.......[FAIL] (Using non-GUI backend 'agg')
Check if figure can be opened with PyQt.............[OK]
Check FSLeyes version...............................[FAIL] (/bin/sh: fsleyes: command not found)

```
</details>
