### PR TITLE
Check if input segmentation is binary for QC report

### DIFF
--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -340,8 +340,6 @@ class Slice(object):
         dict_interp = {'im': 'spline', 'seg': 'linear'}
         # Create nibabel object
         nii = Nifti1Image(image.data, image.hdr.get_best_affine())
-        # Check if input image is binary
-        is_binary = np.isin(nii.get_data(), [0, 1]).all()
         # If no reference image is provided, resample to specified resolution
         if image_ref is None:
             # Resample to px x p_resample x p_resample mm (orientation is SAL by convention in QC module)
@@ -355,6 +353,8 @@ class Slice(object):
         # If resampled image is a segmentation, binarize using threshold at 0.5 for binary segmentation
         # Apply threshold at 0.5 for non-binary segmentation
         if type_img == 'seg':
+            # Check if input image is binary
+            is_binary = np.isin(nii.get_data(), [0, 1]).all()
             img_r_data = nii_r.get_data()
             if is_binary:
                 img_r_data = (img_r_data > 0.5) * 1


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR addresses #3434. For generating QC report of spinal cord segmentation, when resampling a binary segmentation (with linear interpolation), it introduces non-binary values. Binarization was removed in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3418 to be able to display segmentations with a colormap. A threshold of 0.5 was applied. Most binary segmentations were displayed correctly in the QC report, but there were a few exceptions.
 
This PR includes :
* Check if input image is binary
* If the image is binary, binarize at 0.5
* Else, apply a threshold at 0.5

To test the fix, I suggest to run `sct_qc` on `/spine-generic-processed/derivatives/labels/sub-mpicbs02/anat/sub-mpicbs02_T1w_seg-manual.nii.gz` from `data.neuro.polymtl.ca:datasets/spine-generic-processed` which was problematic.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #3434 