### PR TITLE
Fix display of PMJ in QC report

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -223,7 +223,7 @@ class QcImage(object):
         y, x = np.where(mask == 50)
         img = np.full_like(mask, np.nan)
         ax.imshow(img, cmap='gray', alpha=0, aspect=float(self.aspect_mask))
-        ax.text(x, y, 'X', color='lime', clip_on=True)
+        ax.plot(x, y, 'x', color='lime', markersize=6)
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR fixes #3441 where PMJ is wrongly displayed in QC report.
When using `ax.text(x,y, 'X')` with PMJ coordinates, The `X` is not centered on the coordinate.

I tried using the parameters `ha='center', va='center'` (vertical and horizontal alignement), but when changing `X` for `x` or other letters, the position still varied. Using `ax.text` isn't very robust to display a label. 

I chose to use `ax.plot` to display the label as it is done for QC of `sct_label_utils`
Here is in red the label that was displayed before vs now in green:
![image](https://user-images.githubusercontent.com/71230552/124520689-2556cb00-ddbb-11eb-80fe-21a83b34e93a.png)

## Linked issues
Resolves #3441 
