### PR TITLE
Add QC report for `sct_process_segmentation` for PMJ-based CSA

### DIFF
--- a/spinalcordtoolbox/csa_pmj.py
+++ b/spinalcordtoolbox/csa_pmj.py
@@ -80,7 +80,7 @@ def get_slices_for_pmj_distance(segmentation, pmj, distance, extent, param_cente
     mask.change_orientation(native_orientation)
 
     np.savetxt("centerline.csv", arr_ctl, delimiter=",")
-    
+
     # Get corresponding slices
     # TODO: why the "-1"?
     slices = "{}:{}".format(zmin, zmax-1)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -131,7 +131,6 @@ class QcImage(object):
 
     def listed_seg(self, mask, ax):
         """Create figure with red segmentation. Common scenario."""
-        #mask = mask/mask.max()  # TODO: move when generating smooth centerline
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
                   cmap=color.LinearSegmentedColormap.from_list("", self._seg_colormap),

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -850,6 +850,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
     # Metric outputs (only graphs)
     elif process in ['sct_process_segmentation']:
         plane = 'Sagittal'
+        dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         fname_list = [fname_in1]
         fname_list.extend(fname_seg)
         qcslice_type = qcslice.Sagittal([Image(fname) for fname in fname_list], p_resample=None)  # TODO: add multiple overlays

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -266,7 +266,7 @@ class QcImage(object):
 
     def smooth_centerline(self, mask, ax):
         """Display smoothed centerline"""
-        mask = mask/mask.max()  # TODO: move when generating smooth centerline
+        mask = mask/mask.max()
         mask[mask < 0.05] = 0  # Apply 0.5 threshold
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -851,6 +851,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
         plane = 'Sagittal'
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         fname_list = [fname_in1]
+        # fname_seg should be a list of 4 images: 3 for each of the `qcslice_operations`, plus an extra
+        # centerline image, which is needed to make `Sagittal.get_center_spit` work correctly
         fname_list.extend(fname_seg)
         qcslice_type = qcslice.Sagittal([Image(fname) for fname in fname_list], p_resample=None)  # TODO: add multiple overlays
         qcslice_operations = [QcImage.smooth_centerline, QcImage.highlight_pmj, QcImage.listed_seg]

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -854,10 +854,9 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
         # fname_seg should be a list of 4 images: 3 for each of the `qcslice_operations`, plus an extra
         # centerline image, which is needed to make `Sagittal.get_center_spit` work correctly
         fname_list.extend(fname_seg)
-        qcslice_type = qcslice.Sagittal([Image(fname) for fname in fname_list], p_resample=None)  # TODO: add multiple overlays
+        qcslice_type = qcslice.Sagittal([Image(fname) for fname in fname_list], p_resample=None)
         qcslice_operations = [QcImage.smooth_centerline, QcImage.highlight_pmj, QcImage.listed_seg]
         def qcslice_layout(x): return x.single()
-        # assert os.path.isfile(path_img)  # TODO: REMOVE
     else:
         raise ValueError("Unrecognized process: {}".format(process))
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -779,7 +779,6 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
     qcslice_operations = None
     qcslice_layout = None
 
-
     # Get QC specifics based on SCT process
     # Axial orientation, switch between two input images
     if process in ['sct_register_multimodal', 'sct_register_to_template']:

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -323,8 +323,8 @@ class QcImage(object):
         Create overlay and background images for all processes that deal with 3d volumes
         (all except sct_fmri_moco and sct_dmri_moco)
 
-        :param img: list of mosaic images after motion correction  # Doesn't seem correct?
-        :param mask: list of mosaic images before motion correction
+        :param img: The base image to display underneath the overlays (typically anatomical)
+        :param mask: A list of images to be processed and overlaid on top of `img`
         :return:
         """
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -27,6 +27,7 @@ from matplotlib.ticker import MaxNLocator
 from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, save_as_csv, func_wa, func_std, \
     func_sum, merge_dict
 from spinalcordtoolbox.process_seg import compute_shape
+from spinalcordtoolbox.scripts import sct_maths
 from spinalcordtoolbox.csa_pmj import get_slices_for_pmj_distance
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.image import add_suffix
@@ -381,7 +382,7 @@ def main(argv=None):
 
         # Generated centerline smoothed in RL direction for visualization (and QC report)
         fname_ctl_smooth = add_suffix(fname_ctl, '_smooth')
-        subprocess.run(['sct_maths', '-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth], stdout=subprocess.PIPE, check=True)
+        sct_maths.main(['-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth])
 
     for key in metrics:
         if key == 'length':

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -16,6 +16,7 @@
 
 # TODO: the import of scipy.misc imsave was moved to the specific cases (orth and ellipse) in order to avoid issue #62. This has to be cleaned in the future.
 
+import subprocess
 import sys
 import os
 import logging
@@ -378,6 +379,10 @@ def main(argv=None):
         fname_ctl = add_suffix(arguments.i, '_centerline_extrapolated')
         im_ctl.save(fname_ctl)
 
+        # Generated centerline smoothed in RL direction for visualization (and QC report)
+        fname_ctl_smooth = add_suffix(arguments.i, '_smooth')
+        subprocess.run(['sct_maths', '-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth], stdout=subprocess.PIPE, check=True)
+
     for key in metrics:
         if key == 'length':
             # For computing cord length, slice-wise length needs to be summed across slices
@@ -400,7 +405,7 @@ def main(argv=None):
         if fname_pmj is not None:
             if arguments.qc_image is not None:
                 generate_qc(fname_in1=get_absolute_path(arguments.qc_image),
-                            fname_seg=[fname_ctl, fname_pmj, fname_mask_out, fname_ctl],
+                            fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth],  # Repeat centerline to flatten image along the centerline
                             args=arguments,
                             path_qc=os.path.abspath(path_qc),
                             dataset=qc_dataset,

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -188,7 +188,7 @@ def get_parser():
         metavar=Metavar.folder,
         action=ActionCreateFolder,
         help="The path where the quality control generated content will be saved."
-             "QC report is only availbale for PMJ-based CSA."
+             " The QC report is only available for PMJ-based CSA (with flag '-pmj')."
     )
     optional.add_argument(
         '-qc-image',

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -380,7 +380,7 @@ def main(argv=None):
         im_ctl.save(fname_ctl)
 
         # Generated centerline smoothed in RL direction for visualization (and QC report)
-        fname_ctl_smooth = add_suffix(arguments.i, '_smooth')
+        fname_ctl_smooth = add_suffix(fname_ctl, '_smooth')
         subprocess.run(['sct_maths', '-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth], stdout=subprocess.PIPE, check=True)
 
     for key in metrics:

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -411,7 +411,7 @@ def main(argv=None):
                             # to be properly layered underneath the PMJ + mask. However, Sagittal.get_center_spit
                             # is called during QC, and it uses `fname_seg[-1]` to center the slices. `fname_mask_out`
                             # doesn't work for this, so we have to repeat `fname_ctl_smooth` at the end of the list.
-                            fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth], 
+                            fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth],
                             args=sys.argv[1:],
                             path_qc=os.path.abspath(path_qc),
                             dataset=qc_dataset,

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -193,7 +193,9 @@ def get_parser():
     optional.add_argument(
         '-qc-image',
         metavar=Metavar.str,
-        help='Input image to display in QC report. To be used with flag -qc '
+        help="Input image to display in QC report. Typically, it would be the "
+             "source anatomical image used to generate the spinal cord "
+             "segmentation. This flag is mandatory if using flag '-qc'."
     )
     optional.add_argument(
         '-qc-dataset',

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -406,7 +406,7 @@ def main(argv=None):
             if arguments.qc_image is not None:
                 generate_qc(fname_in1=get_absolute_path(arguments.qc_image),
                             fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth],  # Repeat centerline to flatten image along the centerline
-                            args=arguments,
+                            args=sys.argv[1:],
                             path_qc=os.path.abspath(path_qc),
                             dataset=qc_dataset,
                             subject=qc_subject,

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -407,7 +407,11 @@ def main(argv=None):
         if fname_pmj is not None:
             if arguments.qc_image is not None:
                 generate_qc(fname_in1=get_absolute_path(arguments.qc_image),
-                            fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth],  # Repeat centerline to flatten image along the centerline
+                            # NB: For this QC figure, the centerline has to be first in the list in order for the centerline
+                            # to be properly layered underneath the PMJ + mask. However, Sagittal.get_center_spit
+                            # is called during QC, and it uses `fname_seg[-1]` to center the slices. `fname_mask_out`
+                            # doesn't work for this, so we have to repeat `fname_ctl_smooth` at the end of the list.
+                            fname_seg=[fname_ctl_smooth, fname_pmj, fname_mask_out, fname_ctl_smooth], 
                             args=sys.argv[1:],
                             path_qc=os.path.abspath(path_qc),
                             dataset=qc_dataset,

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -16,7 +16,6 @@
 
 # TODO: the import of scipy.misc imsave was moved to the specific cases (orth and ellipse) in order to avoid issue #62. This has to be cleaned in the future.
 
-import subprocess
 import sys
 import os
 import logging


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR addresses #3431. It modifies the QC report for `sct_process_segmentation` to visualize the extrapolated centerline smoothed in R-L direction, the PMJ label and the coverage mask.

Currently, the QC report for `sct_process_segmentation ` was only available inside `sct_process_segmentation` and not when calling `sct_qc`. I left it that way, we could also add it. 

**I created this feature from the branch [jca/sb/3063-csa-measure-from-pmj](https://github.com/spinalcordtoolbox/spinalcordtoolbox/tree/jca/sb%2F3063-csa-measure-from-pmj), I'll merge inside the branch and not the master when it is ready.**

The overlay includes smoothed centerline, coverage mask and PMJ label (in one overlay), do we want to seprate them ?(that would require some further changes). Also, to use the QC with the[ extrapolation method of the centerline](https://github.com/spinalcordtoolbox/spinalcordtoolbox/tree/sb/3063-csa-measure-from-pmj) (what is implemented in #3429 ), there is very little chance that PMJ label is at the same R-L slice than the extrapolated centerline, it will definitely be a problem for that since the image is flatten from the centerline.

Here is what it looks like:

![image](https://user-images.githubusercontent.com/71230552/125797857-133677fc-fb75-4c90-af25-ab2460119e42.png)


To test it out, run `sct_process_segmentation` with `-i, -pmj, -distance, -qc, and -qc-image`

## Linked issues
Resolves #3431
