### PR TITLE
Improve R-L placement in `sct_detect_pmj`

### DIFF
--- a/documentation/source/overview/studies.rst
+++ b/documentation/source/overview/studies.rst
@@ -97,3 +97,4 @@ The following studies (in chronological order) have used SCT:
 -  `Tinnermann et al. Observation of others’ painful heat stimulation involves responses in the spinal cord. Science Advances, 2021 <https://pubmed.ncbi.nlm.nih.gov/33789899/>`_
 -  `Zhang et al. Automatic spinal cord segmentation from axial-view MRI slices using CNN with grayscale regularized active contour propagation. Computers in Biology and Medicine, 2021 <https://pubmed.ncbi.nlm.nih.gov/33780869/>`_
 -  `Savini et al. Pilot Study on Quantitative Cervical Cord and Muscular MRI in Spinal Muscular Atrophy: Promising Biomarkers of Disease Evolution and Treatment? Front Neurol, 2021 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8039452/>`_
+-  `Vallotton et al. Tracking white and grey matter degeneration along the spinal cord axis in degenerative cervical myelopathy. J Neurotrauma. 2021 <https://pubmed.ncbi.nlm.nih.gov/34238034/>`_

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1633,3 +1633,77 @@ def apply_mask_if_soft(fname_im: str, fname_mask: str):
         im.data = np.multiply(im.data, im_mask.data, casting="unsafe")
         im.save(fname_im, mutable=True)
     return fname_im, fname_mask
+
+
+def compute_cross_corr_3d(image: Image, coord, xrange=list(range(-10, 10)), xshift=10, yshift=10, zshift=10):
+    """
+    Compute cross-correlation between image and its mirror using a sliding window in R-L direction to find the image symmetry and adjust R-L coordinate.
+    Use a sliding window of 20x20x20 mm by default.
+    :param image: image in RPI orientation
+    :param coord: 3x1 array: coordinate where to start slidding window (in RPI)
+    :param xrange:
+    :param xshift:
+    :param yshift:
+    :param zshift:
+
+    :return: R-L coordinate of the image symmetry
+    """
+    from spinalcordtoolbox.math import correlation
+
+    nx, ny, nz, _, px, py, pz, _ = image.dim
+    x, y, z = coord
+    # initializations
+    I_corr = np.zeros(len(xrange))
+    allzeros = 0
+    # current_z = 0
+    ind_I = 0
+    # Adjust parameters with physical dimensions
+    xrange = [int(item//px) for item in xrange]
+    xshift = int(xshift//px)
+    yshift = int(yshift//py)
+    zshift = int(zshift//pz)
+    for ix in xrange:
+        # if pattern extends towards left part of the image, then crop and pad with zeros
+        if x + ix + 1 + xshift > nx:
+            padding_size = x + ix + xshift + 1 - nx
+            src = image.data[x + ix - xshift: x + ix + xshift + 1 - padding_size,
+                             y - yshift:y + yshift + 1,
+                             z - zshift: z + zshift + 1]
+            src = np.pad(src, ((0, 0), (0, 0), (0, padding_size)), 'constant',
+                         constant_values=0)
+        # if pattern extends towards right part of the image, then crop and pad with zeros
+        elif x + ix - xshift < 0:
+            padding_size = abs(ix - xshift)
+            src = image.data[x + ix - xshift + padding_size: x + ix + xshift + 1,
+                             y - yshift:y + yshift + 1,
+                             z - zshift: z + zshift + 1]
+
+            src = np.pad(src, ((0, 0), (0, 0), (padding_size, 0)), 'constant',
+                         constant_values=0)
+        else:
+            src = image.data[x + ix - xshift: x + xshift + ix + 1,
+                             y - yshift:y + yshift + 1,
+                             z - zshift: z + zshift + 1]
+        target = src[::-1, :, :]  # Mirror of src (in R-L direction)
+        # convert to 1d
+        src_1d = src.ravel()
+        target_1d = target.ravel()
+        # check if src_1d contains at least one non-zero value
+        if (src_1d.size == target_1d.size) and np.any(src_1d):
+            I_corr[ind_I] = correlation(src_1d, target_1d)
+        else:
+            allzeros = 1
+        ind_I = ind_I + 1
+    if allzeros:
+        logger.warning('Data contained zero. We probably hit the edge of the image.')
+    if np.any(I_corr):
+        # if I_corr contains at least a non-zero value
+        ind_peak = [i for i in range(len(I_corr)) if I_corr[i] == max(I_corr)][0]  # index of max along x
+        logger.info('.. Peak found: x=%s (correlation = %s)', xrange[ind_peak], I_corr[ind_peak])
+        # TODO (maybe) check if correlation is high enough compared to previous R-L coord
+    else:
+        # if I_corr contains only zeros
+        logger.warning('Correlation vector only contains zeros.')
+    # Change adjust rl_coord
+    logger.info('R-L coordinate adjusted from %s to  %s)', x, x + xrange[ind_peak])
+    return x + xrange[ind_peak]

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -138,7 +138,7 @@ class DetectPMJ:
 
         self.orient2pir()  # orient data to PIR orientation
 
-        self.extract_pmjsymmetrical_sagittal_slice()  # extracts slice based on PMJ symmetry point, contains a detection, but only used to select the ROI for correlation
+        self.extract_pmj_symmetrical_sagittal_slice()  # extracts slice based on PMJ symmetry point, contains a detection, but only used to select the ROI for correlation
 
         self.detect()  # run the detection
 
@@ -236,7 +236,7 @@ class DetectPMJ:
 
         run_proc(['sct_crop_image', '-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1), '-o', self.slice2D_im])
 
-    def extract_pmjsymmetrical_sagittal_slice(self):
+    def extract_pmj_symmetrical_sagittal_slice(self):
         """Extract a slice that is symmetrical about the estimated PMJ location."""
         # Here, detection is used just as a way to determine the ROI for the sliding window approach
         self.extract_sagittal_slice()

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -264,14 +264,14 @@ class DetectPMJ:
 
     def compute_cross_corr_3d(self, xrange=list(range(-10, 10)), xshift=10, yshift=10, zshift=10):  # Range of 20 is bit extreme?
         """
-        Compute cross-correlation between image and it's mirror using a slidding window in R-L direction to find the image symmetry and adjust R-L coordinate.
-        Use a slidding window of 20x20x20 by default.
+        Compute cross-correlation between image and its mirror using a sliding window in R-L direction to find the image symmetry and adjust R-L coordinate.
+        Use a sliding window of 20x20x20 by default.
         :param xrange:
         :param xshift:
         :param yshift:
         :param zshift:
         """
-        img = Image(self.fname_im)   # img in PIR orientation
+        img = Image(self.fname_im)  # img in PIR orientation
         ny, nz, nx, *_ = img.dim
         # initializations
         I_corr = np.zeros(len(xrange))

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -292,7 +292,6 @@ class DetectPMJ:
         xshift = int(xshift//px)
         yshift = int(yshift//py)
         zshift = int(zshift//pz)
-        print(xrange, )
         for ix in xrange:
             # if pattern extends towards left part of the image, then crop and pad with zeros
             if self.rl_coord + ix + 1 + xshift > nx:

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -262,22 +262,27 @@ class DetectPMJ:
         self.curdir = os.getcwd()
         os.chdir(self.tmp_dir)  # go to tmp directory
 
-    def compute_cross_corr_3d(self, xrange=list(range(-10, 10)), xshift=10, yshift=10, zshift=10):  # Range of 20 is bit extreme?
+    def compute_cross_corr_3d(self, xrange=list(range(-10, 10)), xshift=10, yshift=10, zshift=10):
         """
         Compute cross-correlation between image and its mirror using a sliding window in R-L direction to find the image symmetry and adjust R-L coordinate.
-        Use a sliding window of 20x20x20 by default.
+        Use a sliding window of 20x20x20 mm by default.
         :param xrange:
         :param xshift:
         :param yshift:
         :param zshift:
         """
         img = Image(self.fname_im)  # img in PIR orientation
-        ny, nz, nx, *_ = img.dim
+        ny, nz, nx, _, py, pz, px, _ = img.dim
         # initializations
         I_corr = np.zeros(len(xrange))
         allzeros = 0
         # current_z = 0
         ind_I = 0
+        # Adjust parameters with physical dimensions
+        xrange = [int(item//px) for item in xrange]
+        xshift = int(xshift//px)
+        yshift = int(yshift//py)
+        zshift = int(zshift//pz)
         for ix in xrange:
             # if pattern extends towards left part of the image, then crop and pad with zeros
             if self.rl_coord + ix + 1 + xshift > nx:


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR addresses #3456. Currently, the algorithm od `sct_detect_pmj`works by getting the mid-sagittal slice (averaged across a few adjacent slices)
and running a 2D CNN to detect the PMJ. However, if the mid-sagittal slice does not correspond to the anatomical medial plane, then the detected PMJ will be "off" in the right-left direction.

This PR adds a function `compute_cross_corr_3d` after detecting the PMJ to fine tune R-L coordinate. We pass a sliding window of 20x20x20 from the PMJ coordinate in a range of -10 to 10 in R-L direction. We compute cross-correlation between the image and its mirror and find the maximum which corresponds to the symmetry point. The R-L coordinate of the PMJ is updated to be at the symmetry point.

## Example of results
This was an image where the head was tilted. 
**yellow: before fine tuning**
**blue: after fine tunning**
![image](https://user-images.githubusercontent.com/71230552/125963613-e6046171-711a-4ea4-914a-8cea46675b5d.png)
![image](https://user-images.githubusercontent.com/71230552/125963782-7d2a2518-95fb-40eb-884b-ffcdb4586a24.png)
![image](https://user-images.githubusercontent.com/71230552/125963949-d46a11b9-5d67-4c76-b8ab-1eec5de09814.png)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #3456 