### PR TITLE
Removal of scary message for user by changing certain function call parameters

### DIFF
--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -236,7 +236,7 @@ class DetectPMJ:
     def orient2pir(self):
         """Orient input data to PIR orientation."""
         if self.orientation_im != 'PIR':  # open image and re-orient it to PIR if needed
-            Image(self.fname_im, verbose=0).change_orientation("PIR").save(''.join(extract_fname(self.fname_im)[1:]))
+            Image(self.fname_im).change_orientation("PIR").save(''.join(extract_fname(self.fname_im)[1:]), verbose=0)
 
             if self.fname_seg is not None:
                 Image(self.fname_seg, verbose=0).change_orientation('PIR').save(''.join(extract_fname(self.fname_seg)[1:]))

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -236,10 +236,10 @@ class DetectPMJ:
     def orient2pir(self):
         """Orient input data to PIR orientation."""
         if self.orientation_im != 'PIR':  # open image and re-orient it to PIR if needed
-            Image(self.fname_im).change_orientation("PIR").save(''.join(extract_fname(self.fname_im)[1:]))
+            Image(self.fname_im, verbose=0).change_orientation("PIR").save(''.join(extract_fname(self.fname_im)[1:]))
 
             if self.fname_seg is not None:
-                Image(self.fname_seg).change_orientation('PIR').save(''.join(extract_fname(self.fname_seg)[1:]))
+                Image(self.fname_seg, verbose=0).change_orientation('PIR').save(''.join(extract_fname(self.fname_seg)[1:]))
 
     def ifolder2tmp(self):
         """Copy data to tmp folder."""

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -239,7 +239,7 @@ class DetectPMJ:
             Image(self.fname_im).change_orientation("PIR").save(''.join(extract_fname(self.fname_im)[1:]), verbose=0)
 
             if self.fname_seg is not None:
-                Image(self.fname_seg, verbose=0).change_orientation('PIR').save(''.join(extract_fname(self.fname_seg)[1:]))
+                Image(self.fname_seg).change_orientation('PIR').save(''.join(extract_fname(self.fname_seg)[1:]), verbose=0)
 
     def ifolder2tmp(self):
         """Copy data to tmp folder."""


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
Hi, 
I have changed the function call to save the image with passing `verbose=0` as parameters for the same. Please check if this is what it was intended to be. I did ran the `sct_detect_pmj` twice after the modification with the testing data. I have attached the console output for the second run. 

![image](https://user-images.githubusercontent.com/41565795/126057907-52640400-7ac2-4f56-ad1d-1976b378aeba.png)


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #3469 
