### PR TITLE
Skip redownloading `sct_testing_data/` if the directory already exists

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -25,7 +25,7 @@ from spinalcordtoolbox.scripts import sct_download_data as downloader
 logger = logging.getLogger(__name__)
 
 
-def pytest_sessionstart(session):
+def pytest_sessionstart():
     """Perform actions that must be done prior to test collection."""
     # Use a non-interactive backend so that no GUI plots will interrupt the test suite.
     # (NB: We do this here to ensure it is set before `matplotlib` is first imported.)
@@ -33,16 +33,9 @@ def pytest_sessionstart(session):
         os.environ["MPLBACKEND"] = 'Agg'
 
     # Download sct_testing_data prior to test collection
-    if not session.config.getoption('--skip-data-dl'):
+    if not os.path.exists(sct_test_path()):
         logger.info("Downloading sct test data")
         downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
-
-
-def pytest_addoption(parser):
-    """Pytest hook to add custom command line option(s)."""
-    parser.addoption(
-        "--skip-data-dl", action="store_true", help="Opt out of redownloading sct_testing_data when running tests."
-    )
 
 
 @pytest.fixture

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -25,7 +25,7 @@ from spinalcordtoolbox.scripts import sct_download_data as downloader
 logger = logging.getLogger(__name__)
 
 
-def pytest_sessionstart():
+def pytest_sessionstart(session):
     """Perform actions that must be done prior to test collection."""
     # Use a non-interactive backend so that no GUI plots will interrupt the test suite.
     # (NB: We do this here to ensure it is set before `matplotlib` is first imported.)
@@ -33,8 +33,16 @@ def pytest_sessionstart():
         os.environ["MPLBACKEND"] = 'Agg'
 
     # Download sct_testing_data prior to test collection
-    logger.info("Downloading sct test data")
-    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+    if not session.config.getoption('--skip-data-dl'):
+        logger.info("Downloading sct test data")
+        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+
+
+def pytest_addoption(parser):
+    """Pytest hook to add custom command line option(s)."""
+    parser.addoption(
+        "--skip-data-dl", action="store_true", help="Opt out of redownloading sct_testing_data when running tests."
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, in pytest, we redownload the test data on every run to ensure that we're working with a fresh copy of the test data. This is wasteful and unnecessary when debugging. 

Ideally we would skip this if the existing test data is fine, and in #2959, we outlined some rough plans to use checksums to verify the integrity of the test data. But, #2959 has stalled (likely due to the workload required for it), so in the meantime, this PR adds a simpler way to skip test data downloading.

I'll also document this on the Test data Wiki page.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A, born from Slack message.