### PR TITLE
Don't crash on non-ImportError exceptions when checking dependencies

### DIFF
--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -23,6 +23,7 @@ import platform
 import importlib
 import warnings
 import psutil
+import traceback
 
 import requirements
 
@@ -278,9 +279,10 @@ def main(argv=None):
             else:
                 print_ok()
 
-        except ImportError as err:
+        except Exception as err:
             print_fail()
-            print(err)
+            print(f"An error occured while importing module {dep_pkg} -> {err}")
+            print(f"Full traceback: {traceback.format_exc()}")
             install_software = 1
 
     print_line('Check if spinalcordtoolbox is installed')
@@ -289,6 +291,7 @@ def main(argv=None):
         print_ok()
     except ImportError:
         print_fail()
+        print("Unable to import spinalcordtoolbox module!?")
         install_software = 1
 
     # Check ANTs integrity

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -290,8 +290,7 @@ def main(argv=None):
         importlib.import_module('spinalcordtoolbox')
         print_ok()
     except ImportError:
-        print_fail()
-        print("Unable to import spinalcordtoolbox module!?")
+        print_fail("Unable to import spinalcordtoolbox module.")
         install_software = 1
 
     # Check ANTs integrity


### PR DESCRIPTION


<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
When checking dependencies don't crash if non-`ImportError` exceptions occur, instead log and carry on.

## Linked issues
Closes #3411 
