### PR TITLE
Fix bug in Read the Docs

### DIFF
--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -289,10 +289,10 @@ code.literal {
     /* color: #6dd2d2; */
 }
 
-.sidebar-drawer {
+/* .sidebar-drawer {
     border-right: 1px solid var(--color-sidebar-background-border);
     background: #3d3d3c !important;
-}
+} */
 
 :root {
     --color-sidebar-background: #3d3d3c
@@ -305,6 +305,7 @@ code.literal {
 @media (prefers-color-scheme: light) {
     :root {
         --color-background-primary: #fcfcfc;
+        --color-sidebar-background: #3d3d3c !important;
         --color-admonition-title-background: #EAF6FF;
         --color-admonition-title: #c2e2fb;
         --color-admonition-title-background--note: #30c42626;
@@ -317,7 +318,7 @@ code.literal {
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --color-sidebar-background: #1a1c1e;
+        --color-sidebar-background: #1a1c1e !important;
         --color-admonition-title: #0054af;
         --color-admonition-title-background: #0054af5c;
     }

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -289,8 +289,13 @@ code.literal {
     /* color: #6dd2d2; */
 }
 
+.sidebar-drawer {
+    border-right: 1px solid var(--color-sidebar-background-border);
+    background: #3d3d3c !important;
+}
+
 :root {
-    --color-sidebar-background: #3d3d3c;
+    --color-sidebar-background: #3d3d3c
     --color-sidebar-item-background--hover: #5a5a58;
     --color-sidebar-link-text: #fcfcfc;
 }

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -5,6 +5,12 @@
     --admonition-title-font-size: 1rem;
 }
 
+.sidebar-scroll::-webkit-scrollbar, .toc-scroll::-webkit-scrollbar {
+    display: None;
+    width: 0rem !important;
+    height: 0rem !important;
+}
+
 
 /* body{font-family:'Roboto',sans-serif;} */
 .wy-side-nav-search>div.version{color:#000000;}
@@ -322,10 +328,4 @@ code.literal {
         --color-admonition-title: #0054af;
         --color-admonition-title-background: #0054af5c;
     }
-}
-
-.sidebar-scroll::-webkit-scrollbar, .toc-scroll::-webkit-scrollbar, article[role=main] ::-webkit-scrollbar {
-    display: None;
-    width: 0rem !important;
-    height: 0rem !important;
 }

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -12,7 +12,7 @@
 }
 
 .sidebar-scroll::-webkit-scrollbar-thumb, .toc-scroll::-webkit-scrollbar-thumb, article[role=main] ::-webkit-scrollbar-thumb {
-    background-color: var(--color-sidebar-background);
+    background-color: var(--color-sidebar-background) !important;
     border-radius: .125rem;
 }
 

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -325,6 +325,7 @@ code.literal {
 }
 
 .sidebar-scroll::-webkit-scrollbar, .toc-scroll::-webkit-scrollbar, article[role=main] ::-webkit-scrollbar {
+    display: None;
     width: 0rem !important;
     height: 0rem !important;
 }

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -11,6 +11,11 @@
     height: 0rem !important;
 }
 
+.sidebar-scroll::-webkit-scrollbar-thumb, .toc-scroll::-webkit-scrollbar-thumb, article[role=main] ::-webkit-scrollbar-thumb {
+    background-color: var(--color-sidebar-background);
+    border-radius: .125rem;
+}
+
 
 /* body{font-family:'Roboto',sans-serif;} */
 .wy-side-nav-search>div.version{color:#000000;}

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -325,6 +325,6 @@ code.literal {
 }
 
 .sidebar-scroll::-webkit-scrollbar, .toc-scroll::-webkit-scrollbar, article[role=main] ::-webkit-scrollbar {
-    width: 0rem;
-    height: 0rem;
+    width: 0rem !important;
+    height: 0rem !important;
 }

--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -323,3 +323,8 @@ code.literal {
         --color-admonition-title-background: #0054af5c;
     }
 }
+
+.sidebar-scroll::-webkit-scrollbar, .toc-scroll::-webkit-scrollbar, article[role=main] ::-webkit-scrollbar {
+    width: 0rem;
+    height: 0rem;
+}

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -115,8 +115,8 @@ html_logo = './_static/img/sct_logo_dark_grey.png'
 html_theme_options = {
     "sidebar_hide_name": True,
     "light_css_variables": {
-            "--color-background-primary": "#fcfcfc",
-            # --color-sidebar-background: #3d3d3c !important;
+            "color-background-primary": "#fcfcfc",
+            "color-sidebar-background": "#3d3d3c",
             # --color-admonition-title-background: #EAF6FF;
             # --color-admonition-title: #c2e2fb;
             # --color-admonition-title-background--note: #30c42626;

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -117,10 +117,17 @@ html_theme_options = {
     "light_css_variables": {
             "color-background-primary": "#fcfcfc",
             "color-sidebar-background": "#3d3d3c",
-            # --color-admonition-title-background: #EAF6FF;
-            # --color-admonition-title: #c2e2fb;
-            # --color-admonition-title-background--note: #30c42626;
-            # --color-admonition-title--note: #30c42659;
+            "color-admonition-title-background": "#EAF6FF",
+            "color-admonition-title": "#c2e2fb",
+            "color-admonition-title-background--note": "#30c42626",
+            "color-admonition-title--note": "#30c42659",
+            "color-sidebar-item-background--hover": "#5a5a58",
+            "color-sidebar-link-text": "#fcfcfc"
+    },
+    "dark_css_variables": {
+        "color-sidebar-background": "#1a1c1e",
+        "color-admonition-title": "#0054af",
+        "color-admonition-title-background": "#0054af5c"
     }
 }
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -115,14 +115,14 @@ html_logo = './_static/img/sct_logo_dark_grey.png'
 html_theme_options = {
     "sidebar_hide_name": True,
     "light_css_variables": {
-            "color-background-primary": "#fcfcfc",
-            "color-sidebar-background": "#3d3d3c",
-            "color-admonition-title-background": "#EAF6FF",
-            "color-admonition-title": "#c2e2fb",
-            "color-admonition-title-background--note": "#30c42626",
-            "color-admonition-title--note": "#30c42659",
-            "color-sidebar-item-background--hover": "#5a5a58",
-            "color-sidebar-link-text": "#fcfcfc"
+        "color-background-primary": "#fcfcfc",
+        "color-sidebar-background": "#3d3d3c",
+        "color-admonition-title-background": "#EAF6FF",
+        "color-admonition-title": "#c2e2fb",
+        "color-admonition-title-background--note": "#30c42626",
+        "color-admonition-title--note": "#30c42659",
+        "color-sidebar-item-background--hover": "#5a5a58",
+        "color-sidebar-link-text": "#fcfcfc"
     },
     "dark_css_variables": {
         "color-sidebar-background": "#1a1c1e",

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -115,7 +115,12 @@ html_logo = './_static/img/sct_logo_dark_grey.png'
 html_theme_options = {
     "sidebar_hide_name": True,
     "light_css_variables": {
-
+            "--color-background-primary": "#fcfcfc",
+            # --color-sidebar-background: #3d3d3c !important;
+            # --color-admonition-title-background: #EAF6FF;
+            # --color-admonition-title: #c2e2fb;
+            # --color-admonition-title-background--note: #30c42626;
+            # --color-admonition-title--note: #30c42659;
     }
 }
 

--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -3,3 +3,4 @@ recommonmark
 sphinx_rtd_theme
 sphinx-copybutton
 furo==2021.4.11b34
+sphinx==4.1.2

--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -2,5 +2,5 @@ sphinxcontrib.programoutput
 recommonmark
 sphinx_rtd_theme
 sphinx-copybutton
-furo==2021.4.11b34
+furo==2021.6.18b35
 sphinx==4.1.2

--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -2,5 +2,5 @@ sphinxcontrib.programoutput
 recommonmark
 sphinx_rtd_theme
 sphinx-copybutton
-furo==2021.4.11b34
 sphinx==4.1.2
+furo==2021.4.11b34

--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -2,5 +2,5 @@ sphinxcontrib.programoutput
 recommonmark
 sphinx_rtd_theme
 sphinx-copybutton
-sphinx==4.1.2
 furo==2021.4.11b34
+sphinx==4.1.2

--- a/documentation/source/requirements.txt
+++ b/documentation/source/requirements.txt
@@ -2,4 +2,4 @@ sphinxcontrib.programoutput
 recommonmark
 sphinx_rtd_theme
 sphinx-copybutton
-furo
+furo==2021.4.11b34

--- a/documentation/source/user_section/help.rst
+++ b/documentation/source/user_section/help.rst
@@ -7,3 +7,5 @@ Help
 If you have any SCT-related question, please post it in `the SCT forum <http://forum.spinalcordmri.org/c/sct>`_. You may search for previously asked questions there.
 
 If you think you found a previously unknown issue with the software, you can report it `on the GitHub's issue page <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/>`_, but you may also communicate on the forum.
+
+Test

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,12 @@ setup(
     include_package_data=True,
     extras_require={
         'docs': [
-            'sphinx==4.1.2',
             'sphinxcontrib-programoutput',
             'sphinx_rtd_theme',
             'sphinx-copybutton',
             'furo==2021.4.11b34',
             'recommonmark'
+            'sphinx==4.1.2'
         ],
     },
     entry_points=dict(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             'sphinxcontrib-programoutput',
             'sphinx_rtd_theme',
             'sphinx-copybutton',
-            'furo==2021.4.11b34',
+            'furo==2021.6.18b35',
             'recommonmark',
             'sphinx==4.1.2'
         ],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'sphinxcontrib-programoutput',
             'sphinx_rtd_theme',
             'sphinx-copybutton',
-            'furo',
+            'furo==2021.4.11b34',
             'recommonmark'
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     extras_require={
         'docs': [
-            'sphinx',
+            'sphinx==4.1.2',
             'sphinxcontrib-programoutput',
             'sphinx_rtd_theme',
             'sphinx-copybutton',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'sphinx_rtd_theme',
             'sphinx-copybutton',
             'furo==2021.4.11b34',
-            'recommonmark'
+            'recommonmark',
             'sphinx==4.1.2'
         ],
     },


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
The variables updated in `custom.css` were being ignored and the default Furo variables were still being used (most noticeably, causing the sidebar to be illegible). This PR used the `light_css_variables` and `dark_css_variables` parameters in `conf.py` to amend it. It looks good on the PR build, but it looked fine in PR #3355 as well and then built differently in the public page, so we may have to merge to verify that it is fixed 😅 

## Linked issues
https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3487
