### PR TITLE
Fix hover colour on sidebar of docs

### DIFF
--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -270,24 +270,6 @@ code.literal {
     background: #3d3d3c;
 }
 
-/* Sidebar */
-
-/* Blue Sidebar */
-
-/* .sidebar-tree .toctree-l1>.reference, .sidebar-tree .toctree-l1>label .icon {
-    color: #fcfcfc;
-}
-
-.sidebar-tree .caption, .sidebar-tree .caption-text {
-    color: #fcfcfc;
-}
-
-:root {
-    --color-sidebar-background: #0054af;
-    --color-sidebar-item-background--hover: #0866c7;
-    --color-sidebar-link-text: #fcfcfc;
-} */
-
 /* Dark Grey Sidebar */
 
 .sidebar-tree .toctree-l1>.reference, .sidebar-tree .toctree-l1>label .icon {
@@ -306,7 +288,7 @@ code.literal {
 } */
 
 :root {
-    --color-sidebar-background: #3d3d3c
+    --color-sidebar-background: #3d3d3c;
     --color-sidebar-item-background--hover: #5a5a58;
     --color-sidebar-link-text: #fcfcfc;
 }


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
On the left sidebar of the documentation for SCT, the hover background colour is white, which does not work because the text is also white. The background colour on hover should be a lighter grey, so this pull request fixes that.

## Linked issues
Resolves https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3494
