### PR TITLE
Import `pyplot` before `PyQt` to mitigate a finicky `libgcc_s.so.1` error

### DIFF
--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -261,6 +261,10 @@ def main(argv=None):
     else:
         print_fail()
 
+    # Import matplotlib.pyplot here (before PyQt can be imported) in order to mitigate a libgcc error
+    # See also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3511#issuecomment-912167649
+    import matplotlib.pyplot as plt
+
     for dep_pkg, dep_ver_spec in get_dependencies():
         if dep_ver_spec is None:
             print_line('Check if %s is installed' % (dep_pkg))
@@ -322,10 +326,9 @@ def main(argv=None):
     print_line('Check if figure can be opened with matplotlib')
     try:
         import matplotlib
-        import matplotlib.pyplot as plt
         # If matplotlib is using a GUI backend, the default 'show()` function will be overridden
         # See: https://github.com/matplotlib/matplotlib/issues/20281#issuecomment-846467732
-        fig = plt.figure()
+        fig = plt.figure()  # NB: `plt` was imported earlier in the script to avoid a libgcc error
         if getattr(fig.canvas.manager.show, "__func__", None) != matplotlib.backend_bases.FigureManagerBase.show:
             print_ok(f" (Using GUI backend: '{matplotlib.get_backend()}')")
         else:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Before this PR, the order we imported `PyQt` and `matplotlib.pyplot` caused a weird libgcc error. As a workaround, we import `pyplot` earlier to avoid the error. (More info here: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3511#issuecomment-912167649.)

Notes:
   * The exact cause of the issue is still unclear, even to the conda folks. 
   * This issue doesn't affect the actual SCT installation; it was just an issue in `sct_check_dependencies`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3511.
