### PR TITLE
`fsleyes.rst`: Fix typo (Installating -> Installing)

### DIFF
--- a/documentation/source/user_section/installation/fsleyes.rst
+++ b/documentation/source/user_section/installation/fsleyes.rst
@@ -1,8 +1,8 @@
 .. _fsleyes_installation:
 
-**********************
-Installating FSLeyes
-**********************
+******************
+Installing FSLeyes
+******************
 
 FSLeyes is a viewer for NIfTI images. SCT features a plugin script to make SCT functions integrated into
 FSLeyes' graphical user interface. To benefit from this functionality, you will need to install FSLeyes.


### PR DESCRIPTION
Noticed on https://spinalcordtoolbox.com/user_section/installation/fsleyes.html