### PR TITLE
Remove leftover unnecessary `R|` formatting

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -27,7 +27,7 @@ from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 def get_parser():
     parser = SCTArgumentParser(
-        description='R|Compute statistics on segmented lesions. The function assigns an ID value to each lesion (1, 2, '
+        description='Compute statistics on segmented lesions. The function assigns an ID value to each lesion (1, 2, '
                     '3, etc.) and then outputs morphometric measures for each lesion:\n'
                     '- volume [mm^3]\n'
                     '- length [mm]: length along the Superior-Inferior axis\n'

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -39,7 +39,7 @@ def get_parser():
     mandatoryArguments.add_argument(
         '-i',
         required=True,
-        help="R|Image to compute the SNR on. (Example: b0s.nii.gz)\n"
+        help="Image to compute the SNR on. (Example: b0s.nii.gz)\n"
              "- For '-method diff' and '-method mult', the image must be 4D, as SNR will be computed "
              "along the 4th dimension.\n"
              "- For '-method single', the image can either be 3D or 4D. If a 4D image is passed, a specific "
@@ -63,7 +63,7 @@ def get_parser():
         default='')
     optional.add_argument(
         '-method',
-        help='R|Method to use to compute the SNR (default: diff):\n'
+        help='Method to use to compute the SNR (default: diff):\n'
              "  - diff: Substract two volumes (defined by -vol) and estimate noise variance within the ROI "
              "(flag '-m' is required). Requires a 4D volume.\n"
              "  - mult: Estimate noise variance over time across volumes specified with '-vol'. Requires a 4D volume.\n"
@@ -78,7 +78,7 @@ def get_parser():
         default='diff')
     optional.add_argument(
         '-vol',
-        help="R|Volumes to compute SNR from. Separate with ',' (Example: '-vol 0,1'), or select range "
+        help="Volumes to compute SNR from. Separate with ',' (Example: '-vol 0,1'), or select range "
              "using ':' (Example: '-vol 2:50'). If this argument is not passed:\n"
              "  - For '-method mult', all volumes will be used.\n"
              "  - For '-method diff', the first two volumes will be used.\n"

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -71,7 +71,7 @@ def get_parser():
         '-p',
         default=param_default.process,
         required=True,
-        help='R|Process to generate mask.\n'
+        help='Process to generate mask.\n'
              '  <coord,XxY>: Center mask at the X,Y coordinates. (e.g. "coord,20x15")\n'
              '  <point,FILE>: Center mask at the X,Y coordinates of the label defined in input volume FILE. (e.g. "point,label.nii.gz")\n'
              '  <center>: Center mask in the middle of the FOV (nx/2, ny/2).\n'

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -37,7 +37,7 @@ def get_parser():
     mandatory.add_argument(
         "-c",
         required=True,
-        help='R|Type of image contrast.\n'
+        help='Type of image contrast.\n'
              ' t2: T2w scan with isotropic or anisotropic resolution.\n'
              ' t2_ax: T2w scan with axial orientation and thick slices.\n'
              ' t2s: T2*w scan with axial orientation and thick slices.',
@@ -53,7 +53,7 @@ def get_parser():
     )
     optional.add_argument(
         "-centerline",
-        help="R|Method used for extracting the centerline:\n"
+        help="Method used for extracting the centerline:\n"
              " svm: Automatic detection using Support Vector Machine algorithm.\n"
              " cnn: Automatic detection using Convolutional Neural Network.\n"
              " viewer: Semi-automatic detection using manual selection of a few points with an interactive viewer "

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -50,7 +50,7 @@ def get_parser():
         help="show this help message and exit")
     optional.add_argument(
         "-centerline",
-        help="R|Method used for extracting the centerline:\n"
+        help="Method used for extracting the centerline:\n"
              " svm: Automatic detection using Support Vector Machine algorithm.\n"
              " cnn: Automatic detection using Convolutional Neural Network.\n"
              " viewer: Semi-automatic detection using manual selection of a few points with an interactive viewer "

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -49,7 +49,7 @@ def get_parser():
         help="Show this help message and exit")
     optional.add_argument(
         '-method',
-        help='R|Type of method to calculate the diffusion tensor:\n'
+        help='Type of method to calculate the diffusion tensor:\n'
              ' standard: Standard equation [Basser, Biophys J 1994]\n'
              ' restore: Robust fitting with outlier detection [Chang, MRM 2005]',
         default='standard',

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -101,7 +101,7 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=list_type(',', str),
-        help=f"R|Advanced parameters. Assign value with \"=\", and separate arguments with \",\".\n"
+        help=f"Advanced parameters. Assign value with \"=\", and separate arguments with \",\".\n"
              f"  - poly [int]: Degree of polynomial function used for regularization along Z. For no regularization "
              f"set to 0. Default={param_default.poly}.\n"
              f"  - smooth [mm]: Smoothing kernel. Default={param_default.smooth}.\n"

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -123,7 +123,7 @@ def get_parser():
         '-o',
         metavar=Metavar.folder,
         action=ActionCreateFolder,
-        help="R|Path to a directory to save the downloaded data.\n"
+        help="Path to a directory to save the downloaded data.\n"
              "(Defaults to ./${dataset-name}. Directory will be created if it does not exist. Warning: existing "
              "data in the directory will be erased unless -k is provided.)\n"
     )

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -198,8 +198,8 @@ def get_parser():
         metavar=Metavar.file,
         default="./label/template/PAM50_levels.nii.gz",
         help="Vertebral labeling file. Only use with flag -vert.\n"
-            "The input Image and the vertebral labelling file must in the same voxel coordinate system "
-            "and must match the dimensions between each other."
+             "The input Image and the vertebral labelling file must in the same voxel coordinate system "
+             "and must match the dimensions between each other."
     )
     optional.add_argument(
         '-perlevel',

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -125,7 +125,7 @@ def get_parser():
         '-method',
         choices=['ml', 'map', 'wa', 'bin', 'median', 'max'],
         default=param_default.method,
-        help="R|Method to extract metrics.\n"
+        help="Method to extract metrics.\n"
              "  - ml: maximum likelihood.\n"
              "    This method is recommended for large labels and low noise. Also, this method should only be used"
              " with the PAM50 white/gray matter atlas, or with any custom atlas as long as the sum across all labels"
@@ -160,7 +160,7 @@ def get_parser():
         '-o',
         metavar=Metavar.file,
         default=param_default.fname_output,
-        help="R|File name of the output result file collecting the metric estimation results. Include the '.csv' "
+        help="File name of the output result file collecting the metric estimation results. Include the '.csv' "
              "file extension in the file name. Example: extract_metric.csv"
     )
     optional.add_argument(
@@ -175,7 +175,7 @@ def get_parser():
         '-z',
         metavar=Metavar.str,
         default=param_default.slices_of_interest,
-        help="R|Slice range to estimate the metric from. First slice is 0. Example: 5:23\n"
+        help="Slice range to estimate the metric from. First slice is 0. Example: 5:23\n"
              "You can also select specific slices using commas. Example: 0,2,3,5,12'"
     )
     optional.add_argument(
@@ -183,7 +183,7 @@ def get_parser():
         type=int,
         choices=(0, 1),
         default=param_default.perslice,
-        help="R|Whether to output one metric per slice instead of a single output metric. 0 = no, 1 = yes.\n"
+        help="Whether to output one metric per slice instead of a single output metric. 0 = no, 1 = yes.\n"
              "Please note that when methods ml or map are used, outputting a single metric per slice and then "
              "averaging them all is not the same as outputting a single metric at once across all slices."
     )
@@ -197,7 +197,7 @@ def get_parser():
         '-vertfile',
         metavar=Metavar.file,
         default="./label/template/PAM50_levels.nii.gz",
-        help="R|Vertebral labeling file. Only use with flag -vert.\n"
+        help="Vertebral labeling file. Only use with flag -vert.\n"
             "The input Image and the vertebral labelling file must in the same voxel coordinate system "
             "and must match the dimensions between each other."
     )
@@ -206,7 +206,7 @@ def get_parser():
         type=int,
         metavar=Metavar.int,
         default=0,
-        help="R|Whether to output one metric per vertebral level instead of a single output metric. 0 = no, 1 = yes.\n"
+        help="Whether to output one metric per vertebral level instead of a single output metric. 0 = no, 1 = yes.\n"
              "Please note that this flag needs to be used with the -vert option."
     )
     optional.add_argument(
@@ -224,7 +224,7 @@ def get_parser():
         '-param',
         metavar=Metavar.str,
         default='',
-        help="R|Advanced parameters for the 'map' method. Separate with comma. All items must be listed (separated "
+        help="Advanced parameters for the 'map' method. Separate with comma. All items must be listed (separated "
              "with comma).\n"
              "  - #1: standard deviation of metrics across labels\n"
              "  - #2: standard deviation of the noise (assumed Gaussian)"
@@ -248,7 +248,7 @@ def get_parser():
         '-norm-method',
         choices=['sbs', 'whole'],
         default='',
-        help="R|Method to use for normalization:\n"
+        help="Method to use for normalization:\n"
              "  - sbs: normalization slice-by-slice\n"
              "  - whole: normalization by the metric value in the whole label for all slices."
     )

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -72,7 +72,7 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=list_type(',', str),
-        help=f"R|Advanced parameters. Assign value with \"=\"; Separate arguments with \",\".\n"
+        help=f"Advanced parameters. Assign value with \"=\"; Separate arguments with \",\".\n"
              f"  - poly [int]: Degree of polynomial function used for regularization along Z. For no regularization "
              f"set to 0. Default={param_default.poly}.\n"
              f"  - smooth [mm]: Smoothing kernel. Default={param_default.smooth}.\n"

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -50,7 +50,7 @@ def get_parser():
         "-method",
         choices=['optic', 'viewer', 'fitseg'],
         default='optic',
-        help="R|Method used for extracting the centerline.\n"
+        help="Method used for extracting the centerline.\n"
              "  - optic: automatic spinal cord detection method\n"
              "  - viewer: manual selection a few points followed by interpolation\n"
              "  - fitseg: fit a regularized centerline on an already-existing cord segmentation. It will "

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -37,7 +37,7 @@ def get_parser():
         '-i',
         nargs='+',
         metavar=Metavar.file,
-        help='R|Input file(s). Example: "data.nii.gz"\n'
+        help='Input file(s). Example: "data.nii.gz"\n'
              'Note: Only "-concat" or "-omc" support multiple input files. In those cases, separate filenames using '
              'spaces. Example usage: "sct_image -i data1.nii.gz data2.nii.gz -concat"',
         required = True)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -40,7 +40,7 @@ def get_parser():
         help='Input file(s). Example: "data.nii.gz"\n'
              'Note: Only "-concat" or "-omc" support multiple input files. In those cases, separate filenames using '
              'spaces. Example usage: "sct_image -i data1.nii.gz data2.nii.gz -concat"',
-        required = True)
+        required=True)
     optional = parser.add_argument_group('OPTIONAL ARGUMENTS')
     optional.add_argument(
         '-h',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -90,7 +90,7 @@ def get_parser():
         '-create-seg',
         metavar=Metavar.list,
         type=list_type(':', list_type(',', int)),
-        help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
+        help="Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
              "specified using the form 'v1,v2' where 'v1' is value of the slice index along the inferior-superior "
              "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
              "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from "
@@ -101,7 +101,7 @@ def get_parser():
         '-create-seg-mid',
         metavar=Metavar.int,
         type=int,
-        help="R|Similar to '-create-seg'. This option takes a single label value, and will automatically select the "
+        help="Similar to '-create-seg'. This option takes a single label value, and will automatically select the "
              "mid-point slice in the inferior-superior direction (so there is no need for a slice index).\n"
              "This is useful for when you have centered the field of view of your data at a specific location. "
              "For example, if you already know that the C2-C3 disc is centered in the I-S direction, then "
@@ -144,7 +144,7 @@ def get_parser():
         '-vert-body',
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|From vertebral labeling, create points that are centered at the mid-vertebral levels. Separate "
+        help="From vertebral labeling, create points that are centered at the mid-vertebral levels. Separate "
              "desired levels with ','. Example: 3,8\n"
              "To get all levels, enter 0."
     )

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -109,7 +109,7 @@ def get_parser():
         '-initz',
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|Initialize using slice number and disc value. Example: 68,4 (slice 68 corresponds to disc C3/C4). "
+        help="Initialize using slice number and disc value. Example: 68,4 (slice 68 corresponds to disc C3/C4). "
              "Example: 125,3\n"
              "WARNING: Slice number should correspond to superior-inferior direction (e.g. Z in RPI orientation, but "
              "Y in LIP orientation)."
@@ -177,7 +177,7 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=list_type(',', str),
-        help=f"R|Advanced parameters. Assign value with \"=\"; Separate arguments with \",\"\n"
+        help=f"Advanced parameters. Assign value with \"=\"; Separate arguments with \",\"\n"
              f"  - shift_AP [mm]: AP shift of centerline for disc search. Default={param_default.shift_AP}.\n"
              f"  - size_AP [mm]: AP window size for disc search. Default={param_default.size_AP}.\n"
              f"  - size_RL [mm]: RL window size for disc search. Default={param_default.size_RL}.\n"

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -109,7 +109,7 @@ def get_parser():
         "-adap",
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|Threshold image using Adaptive algorithm (from skimage). Provide 2 values separated by ',' that "
+        help="Threshold image using Adaptive algorithm (from skimage). Provide 2 values separated by ',' that "
              "correspond to the parameters below. For example, '-adap 7,0' corresponds to a block size of 7 and an "
              "offset of 0.\n"
              "  - Block size: Odd size of pixel neighborhood which is used to calculate the threshold value. \n"
@@ -120,7 +120,7 @@ def get_parser():
         "-otsu-median",
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|Threshold image using Median Otsu algorithm (from dipy). Provide 2 values separated by ',' that "
+        help="Threshold image using Median Otsu algorithm (from dipy). Provide 2 values separated by ',' that "
              "correspond to the parameters below. For example, '-otsu-median 3,5' corresponds to a filter size of 3 "
              "repeated over 5 iterations.\n"
              "  - Size: Radius (in voxels) of the applied median filter.\n"
@@ -164,7 +164,7 @@ def get_parser():
         required=False)
     mathematical.add_argument(
         '-shape',
-        help="R|Shape of the structuring element for the mathematical morphology operation. Default: ball.\n"
+        help="Shape of the structuring element for the mathematical morphology operation. Default: ball.\n"
              "If a 2D shape {'disk', 'square'} is selected, -dim must be specified.",
         required=False,
         choices=('square', 'cube', 'disk', 'ball'),
@@ -196,7 +196,7 @@ def get_parser():
         required=False)
     filtering.add_argument(
         '-denoise',
-        help='R|Non-local means adaptative denoising from P. Coupe et al. as implemented in dipy. Separate with ". Example: p=1,b=3\n'
+        help='Non-local means adaptative denoising from P. Coupe et al. as implemented in dipy. Separate with ". Example: p=1,b=3\n'
              ' p: (patch radius) similar patches in the non-local means are searched for locally, inside a cube of side 2*p+1 centered at each voxel of interest. Default: p=1\n'
              ' b: (block radius) the size of the block to be used (2*b+1) in the blockwise non-local means implementation. Default: b=5 '
              '    Note, block radius must be smaller than the smaller image dimension: default value is lowered for small images)\n'

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -142,7 +142,7 @@ def get_parser():
         '-vertfile',
         metavar=Metavar.str,
         default='./label/template/PAM50_levels.nii.gz',
-        help="R|Vertebral labeling file. Only use with flag -vert.\n"
+        help="Vertebral labeling file. Only use with flag -vert.\n"
         "The input and the vertebral labelling file must in the same voxel coordinate system "
         "and must match the dimensions between each other. "
     )
@@ -213,7 +213,7 @@ def get_parser():
         metavar=Metavar.list,
         action=SeparateNormArgs,
         nargs="+",
-        help="R|Normalize CSA values ('MEAN(area)').\n"
+        help="Normalize CSA values ('MEAN(area)').\n"
              "Two models are available:\n"
              "    1. sex, brain-volume, thalamus-volume.\n"
              "    2. sex, brain-volume.\n"

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -278,7 +278,7 @@ def get_parser():
     optional.add_argument(
         '-init-centerline',
         metavar=Metavar.file,
-        help="R|Filename of centerline to use for the propagation. Use format .txt or .nii; see file structure in "
+        help="Filename of centerline to use for the propagation. Use format .txt or .nii; see file structure in "
              "documentation.\n"
              "Replace filename by 'viewer' to use interactive viewer for providing centerline. Example: "
              "-init-centerline viewer"
@@ -292,7 +292,7 @@ def get_parser():
     optional.add_argument(
         '-init-mask',
         metavar=Metavar.file,
-        help="R|Mask containing three center of the spinal cord, used to initiate the propagation.\n"
+        help="Mask containing three center of the spinal cord, used to initiate the propagation.\n"
              "Replace filename by 'viewer' to use interactive viewer for providing mask. Example: -init-mask viewer"
     )
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -157,7 +157,7 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=list_type(':', str),
-        help=(f"R|Parameters for registration. Separate arguments with \",\". Separate steps with \":\".\n"
+        help=(f"Parameters for registration. Separate arguments with \",\". Separate steps with \":\".\n"
               f"Example: step=1,type=seg,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MI,iter=5,"
               f"shrink=2\n"
               f"  - step: <int> Step number (starts at 1, except for type=label).\n"

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -152,7 +152,7 @@ def get_parser():
     optional.add_argument(
         '-l',
         metavar=Metavar.file,
-        help="R|One or two labels (preferred) located at the center of the spinal cord, on the mid-vertebral slice. "
+        help="One or two labels (preferred) located at the center of the spinal cord, on the mid-vertebral slice. "
              "Example: anat_labels.nii.gz\n"
              "For more information about label creation, please see: "
              "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%%5FCourse%%5F20200121 (p47)"
@@ -160,7 +160,7 @@ def get_parser():
     optional.add_argument(
         '-ldisc',
         metavar=Metavar.file,
-        help="R|File containing disc labels. Labels can be located either at the posterior edge "
+        help="File containing disc labels. Labels can be located either at the posterior edge "
              "of the intervertebral discs, or at the orthogonal projection of each disc onto "
              "the spinal cord (e.g.: the file 'xxx_seg_labeled_discs.nii.gz' output by sct_label_vertebrae).\n"
              "If you are using more than 2 labels, all discs covering the region of interest should be provided. "
@@ -171,7 +171,7 @@ def get_parser():
     optional.add_argument(
         '-lspinal',
         metavar=Metavar.file,
-        help="R|Labels located in the center of the spinal cord, at the superior-inferior level corresponding to the "
+        help="Labels located in the center of the spinal cord, at the superior-inferior level corresponding to the "
              "mid-point of the spinal level. Example: anat_labels.nii.gz\n"
              "Each label is a single voxel, which value corresponds to the spinal level (e.g.: 2 for spinal level 2). "
              "If you are using more than 2 labels, all spinal levels covering the region of interest should be "
@@ -206,7 +206,7 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=list_type(':', str),
-        help=(f"R|Parameters for registration (see sct_register_multimodal). Default:"
+        help=(f"Parameters for registration (see sct_register_multimodal). Default:"
               f"\n"
               f"step=0\n"
               f"  - type={paramregmulti.steps['0'].type}\n"

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -59,7 +59,7 @@ def get_parser():
     resample_types.add_argument(
         '-f',
         metavar=Metavar.str,
-        help="R|Resampling factor in each dimensions (x,y,z). Separate with 'x'. Example: 0.5x0.5x1\n"
+        help="Resampling factor in each dimensions (x,y,z). Separate with 'x'. Example: 0.5x0.5x1\n"
              "For 2x upsampling, set to 2. For 2x downsampling set to 0.5"
     )
     resample_types.add_argument(

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -53,7 +53,7 @@ def get_parser():
     )
 
     parser.add_argument('-config', '-c',
-                        help='R|'
+                        help=''
                         'A json (.json) or yaml (.yml|.yaml) file with arguments. All arguments to the configuration '
                         'file are the same as the command line arguments, except all dashes (-) are replaced with '
                         'underscores (_). Using command line flags can be used to override arguments provided in '
@@ -74,7 +74,7 @@ def get_parser():
                             }\n
                             """))
     parser.add_argument('-jobs', type=int, default=1,
-                        help='R|The number of jobs to run in parallel. Either an integer greater than or equal to one '
+                        help='The number of jobs to run in parallel. Either an integer greater than or equal to one '
                         'specifying the number of cores, 0 or a negative integer specifying number of cores minus '
                         'that number. For example \'-jobs -1\' will run with all the available cores minus one job in '
                         'parallel. Set \'-jobs 0\' to use all available cores.\n'
@@ -82,21 +82,21 @@ def get_parser():
                         'parallelism. You may need to tweak both to find a balance that works best for your system.',
                         metavar=Metavar.int)
     parser.add_argument('-itk-threads', type=int, default=1,
-                        help='R|Sets the environment variable "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS".\n'
+                        help='Sets the environment variable "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS".\n'
                         'Number of threads to use for ITK based programs including ANTs. Increasing this can '
                         'provide a performance boost for high-performance (multi-core) computing environments. '
                         'However, increasing the number of threads may also result in a large increase in memory.\n'
                         'This argument enables thread-based parallelism, while \'-jobs\' enables process-based '
                         'parallelism. You may need to tweak both to find a balance that works best for your system.',
                         metavar=Metavar.int)
-    parser.add_argument('-path-data', help='R|Setting for environment variable: PATH_DATA\n'
+    parser.add_argument('-path-data', help='Setting for environment variable: PATH_DATA\n'
                         'Path containing subject directories in a consistent format')
     parser.add_argument('-subject-prefix', default='sub-',
                         help='Subject prefix, defaults to "sub-" which is the prefix used for BIDS directories. '
                         'If the subject directories do not share a common prefix, an empty string can be '
                         'passed here.')
     parser.add_argument('-path-output', default='./',
-                        help='R|Base directory for environment variables:\n'
+                        help='Base directory for environment variables:\n'
                         'PATH_DATA_PROCESSED=' + os.path.join('<path-output>', 'data_processed') + '\n'
                         'PATH_RESULTS=' + os.path.join('<path-output>', 'results') + '\n'
                         'PATH_QC=' + os.path.join('<path-output>', 'qc') + '\n'
@@ -124,7 +124,7 @@ def get_parser():
                         'a subject if they are not on this list. Inclusions are processed before exclusions. '
                         'Cannot be used with either `exclude`.', nargs='+')
     parser.add_argument('-path-segmanual', default='.',
-                        help='R|Setting for environment variable: PATH_SEGMANUAL\n'
+                        help='Setting for environment variable: PATH_SEGMANUAL\n'
                         'A path containing manual segmentations to be used by the script program.')
     parser.add_argument('-script-args', default='',
                         help='A quoted string with extra flags and arguments to pass to the script. '

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -138,7 +138,7 @@ def get_parser():
     optional.add_argument(
         "-param",
         metavar=Metavar.list,
-        help="R|Parameters for spinal cord straightening. Separate arguments with \",\".\n"
+        help="Parameters for spinal cord straightening. Separate arguments with \",\".\n"
              "  - precision: Float [1, inf) Precision factor of straightening, related to the number of slices. Increasing this parameter increases the precision along with increased computational time. Not taken into account with Hanning fitting method. Default=2\n"
              "  - threshold_distance: Float [0, inf) Threshold at which voxels are not considered into displacement. Increase this threshold if the image is blackout around the spinal cord too much. Default=10\n"
              "  - accuracy_results: {0, 1} Disable/Enable computation of accuracy results after straightening. Default=0\n"

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -197,22 +197,20 @@ class Metavar(Enum):
 
 
 class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
-    """
-    Custom formatter that inherits from HelpFormatter, which adjusts the default width to the current Terminal size,
-    and that gives the possibility to bypass argparse's default formatting by adding "R|" at the beginning of the text.
-    Inspired from: https://pythonhosted.org/skaff/_modules/skaff/cli.html
-    """
-
+    """Custom formatter that inherits from HelpFormatter to apply the same
+    tweaks across all of SCT's scripts."""
     def __init__(self, *args, **kw):
         self._add_defaults = None
         super(SmartFormatter, self).__init__(*args, **kw)
-        # Update _width to match Terminal width
+        # Tweak: Update argparse's '_width' to match Terminal width
         try:
             self._width = shutil.get_terminal_size()[0]
         except (KeyError, ValueError):
             logger.warning('Not able to fetch Terminal width. Using default: %s', self._width)
 
     def _get_help_string(self, action):
+        """Overrides the default _get_help_string method to skip writing the
+        '(default: )' text for arguments that have an empty default value."""
         if action.default not in [None, "", [], (), {}]:
             return super()._get_help_string(action)
         else:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a tiny PR with just cosmetic changes: With #3361, [raw-text formatting](https://docs.python.org/3/library/argparse.html#argparse.RawTextHelpFormatter) is now applied by default to all descriptions (without the need for `R|`), so I removed those bits of text.

Also, while I was here, I cleaned up the docstrings for SmartFormatter in f3da9b9ca2c95b77e9883428158b37f0d1101814, since one of them referenced `R|`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3546.