### PR TITLE
Generate issue log automatically, then direct users to share the log when posting on the forum

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -120,8 +120,8 @@ function finish() {
     echo ""
   else
     print error "Installation failed!\n
-Please find the file $(pwd)/install_sct_log.txt and \n
-upload it as a .txt attachment in a new topic on SCT's forum:\n
+Please find the file $(pwd)/install_sct_log.txt, 
+then upload it as a .txt attachment in a new topic on SCT's forum:
 --> http://forum.spinalcordmri.org/c/sct"
   fi
   # clean tmp_dir

--- a/install_sct
+++ b/install_sct
@@ -115,7 +115,6 @@ function finish() {
   cd "$SCT_SOURCE"
   if [[ "$value" -eq 0 ]]; then
     print info "Installation finished successfully!"
-    rm -r install_sct_log.txt  # if there's no errors, there's no need to keep this log around
   elif [[ "$value" -eq 99 ]]; then
     # Showing usage with -h
     echo ""

--- a/install_sct
+++ b/install_sct
@@ -29,6 +29,8 @@
 # Authors: PO Quirion, J Cohen-Adad, J Carretero
 # License: see the file LICENSE.TXT
 
+( # | tee install_sct_log.txt
+
 # stricter shell mode
 # https://sipb.mit.edu/doc/safe-shell/
 set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
@@ -113,13 +115,14 @@ function finish() {
   cd "$SCT_SOURCE"
   if [[ "$value" -eq 0 ]]; then
     print info "Installation finished successfully!"
+    rm -r install_sct_log.txt  # if there's no errors, there's no need to keep this log around
   elif [[ "$value" -eq 99 ]]; then
     # Showing usage with -h
     echo ""
   else
     print error "Installation failed!\n
-Please copy the output of this Terminal (starting with the command install_sct) and upload it as a .txt attachment in a new topic on SCT's forum:\n
---> http://forum.spinalcordmri.org/c/sct"
+Please find the file $(pwd)/install_sct_log.txt and \n
+attach it to a new issue in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/new so we can help you."
   fi
   # clean tmp_dir
   rm -rf "$TMP_DIR"
@@ -757,3 +760,5 @@ else
     die "Installation validation Failed!"
   fi
 fi
+
+) 2>&1 | tee install_sct_log.txt

--- a/install_sct
+++ b/install_sct
@@ -121,7 +121,8 @@ function finish() {
   else
     print error "Installation failed!\n
 Please find the file $(pwd)/install_sct_log.txt and \n
-attach it to a new issue in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/new so we can help you."
+upload it as a .txt attachment in a new topic on SCT's forum:\n
+--> http://forum.spinalcordmri.org/c/sct"
   fi
   # clean tmp_dir
   rm -rf "$TMP_DIR"


### PR DESCRIPTION
Many people post install errors on the forum without all the details
attached. This logs *the entire install log* to a file for them,
which should make getting errors reliably easier.

This kind of a silly solution but I think it will help.