### PR TITLE
Restore the argparse linewrapping behavior we had prior to Python 3.7

### DIFF
--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -216,10 +216,18 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         else:
             return action.help
 
-    # this is the RawTextHelpFormatter._fill_text
     def _fill_text(self, text, width, indent):
+        """Overrides the default _fill_text method. It takes a single string
+        (`text`) and rebuilds it so that each line wraps at the specified
+        `width`, while also preserving newlines.
+
+        This method is what gets called for the parser's `description` field.
+        """
         import textwrap
+        # NB: text.splitlines() is what's used by argparse.RawTextHelpFormatter
+        #     to preserve newline characters (`\n`) in text.
         paragraphs = text.splitlines()
+        # NB: The remaining code is fully custom
         rebroken = [textwrap.wrap(tpar, width) for tpar in paragraphs]
         rebrokenstr = []
         for tlinearr in rebroken:
@@ -230,10 +238,19 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
                     rebrokenstr.append(tlinepiece)
         return '\n'.join(rebrokenstr)
 
-    # this is the RawTextHelpFormatter._split_lines
     def _split_lines(self, text, width):
+        """Overrides the default _split_lines method. It takes a single string
+        (`text`) and rebuilds it so that each line wraps at the specified
+        `width`, while also preserving newlines, as well as any offsets within
+        the text (e.g. indented lists).
+
+        This method is what gets called for each argument's `help` field.
+        """
         import textwrap
+        # NB: text.splitlines() is what's used by argparse.RawTextHelpFormatter
+        #     to preserve newline characters (`\n`) in text.
         lines = text.splitlines()
+        # NB: The remaining code is fully custom
         while lines[0] == '':  # Discard empty start lines
             lines = lines[1:]
         offsets = [re.match("^[ \t]*", l).group(0) for l in lines]

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -253,7 +253,7 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         # NB: The remaining code is fully custom
         while lines[0] == '':  # Discard empty start lines
             lines = lines[1:]
-        offsets = [re.match("^[ \t]*", l).group(0) for l in lines]
+        offsets = [re.match("^[ \t]*", line).group(0) for line in lines]
         wrapped = []
         for i, li in enumerate(lines):
             if len(li) > 0:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #3361, some custom methods were removed because they had broken. The inline comments suggested they were the same as the built-in methods: 

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/be7057cbe57270e20b2e0185a00a63e83b13be38/spinalcordtoolbox/utils/shell.py#L215-L216

As a result, they were replaced by subclassing `RawTextHelpFormatter`. 

However, these methods were actually _not_ identical. So, this PR restores all of the custom code (7178650), then adds documentation to the methods so that the purpose of each part is clearer (761700b). 

<details>
<summary> Comparison with v5.4 (identical) </summary>

![Screenshot from 2021-11-25 13-48-38](https://user-images.githubusercontent.com/16181459/143489962-31417d19-ba53-4c0c-8453-6c3089a56ac4.png)
</details>

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3562.
