### PR TITLE
Fix argument parsing to ensure only the requested files are output

### DIFF
--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -447,7 +447,7 @@ def propseg(img_input, options_dict):
         fname_out = os.path.basename(add_suffix(fname_data, "_seg"))
 
     if arguments.ofolder is not None:
-        folder_output = arguments.ofolder
+        folder_output = os.path.abspath(arguments.ofolder)
     else:
         folder_output = str(pathlib.Path(fname_out).parent)
     if not os.path.isdir(folder_output) and os.path.exists(folder_output):

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -54,12 +54,12 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_
     im_centerline = convert(Image(fname_centerline))
     im_centerline.save(os.path.join(path_tmp, "tmp.centerline.nii.gz"), mutable=True, verbose=0)
 
-    # go to tmp folder
+    # go to tmp folder (and store original info to use when converting back at the end)
+    fname_seg_absolute = os.path.abspath(fname_segmentation)
     curdir = os.getcwd()
     os.chdir(path_tmp)
 
-    # convert input to RPI (and store original info to use when converting back at the end)
-    fname_seg_absolute = os.path.abspath(fname_segmentation)
+    # convert input to RPI
     image_input_orientation = im_seg.orientation
     sct_image.main("-i tmp.segmentation.nii.gz -setorient RPI -o tmp.segmentation_RPI.nii.gz -v 0".split())
     sct_image.main("-i tmp.centerline.nii.gz -setorient RPI -o tmp.centerline_RPI.nii.gz -v 0".split())

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -469,19 +469,19 @@ def propseg(img_input, options_dict):
         cmd += ["-verbose"]
 
     # Output options
-    if arguments.mesh is not None:
+    if arguments.mesh:
         cmd += ["-mesh"]
-    if arguments.centerline_binary is not None:
+    if arguments.centerline_binary:
         cmd += ["-centerline-binary"]
-    if arguments.CSF is not None:
+    if arguments.CSF:
         cmd += ["-CSF"]
-    if arguments.centerline_coord is not None:
+    if arguments.centerline_coord:
         cmd += ["-centerline-coord"]
-    if arguments.cross is not None:
+    if arguments.cross:
         cmd += ["-cross"]
-    if arguments.init_tube is not None:
+    if arguments.init_tube:
         cmd += ["-init-tube"]
-    if arguments.low_resolution_mesh is not None:
+    if arguments.low_resolution_mesh:
         cmd += ["-low-resolution-mesh"]
     # TODO: Not present. Why is this here? Was this renamed?
     # if arguments.detect_nii is not None:

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -38,7 +38,9 @@ def test_isct_propseg_compatibility():
         'administrators.'
 
 
-def test_sct_propseg_o_flag(tmp_path):
-    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-o', os.path.join(str(tmp_path), 'test_seg.nii.gz')]
+def test_sct_propseg_o_flags(tmp_path):
+    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-ofolder', str(tmp_path), '-o', 'test_seg.nii.gz']
     sct_propseg.main(argv)
-    assert os.path.isfile(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
+    output_files = [f for f in os.listdir(tmp_path)
+                    if os.path.isfile(os.path.join(tmp_path, f))]
+    assert output_files == ['test_seg.nii.gz', 't2_centerline.nii.gz']

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -41,6 +41,6 @@ def test_isct_propseg_compatibility():
 def test_sct_propseg_o_flags(tmp_path):
     argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-ofolder', str(tmp_path), '-o', 'test_seg.nii.gz']
     sct_propseg.main(argv)
-    output_files = [f for f in os.listdir(tmp_path)
-                    if os.path.isfile(os.path.join(tmp_path, f))]
-    assert output_files == ['test_seg.nii.gz', 't2_centerline.nii.gz']
+    output_files = sorted([f for f in os.listdir(tmp_path)
+                          if os.path.isfile(os.path.join(tmp_path, f))])
+    assert output_files == ['t2_centerline.nii.gz', 'test_seg.nii.gz']


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In issue #3608, we came across a case where running `sct_propseg` with the options `-CSF -cross` will cause the script to stall for specific kinds of data. This PR doesn't fix the root cause of that issue, but it _does_ fix 2 bugs that were discovered in the process:

1. Make sure boolean args are checked correctly, so that we stop outputting extra files that the user didn't ask for
2.  Make sure `check_and_correct_segmentation` outputs the corrected segmentation to the right folder, to prevent a failure when `-ofolder` is passed.

Fix 1. will help mitigate the original issue, because that bug was causing `-CSF -cross` to be run even when those options weren't specified by the user!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses #3608.