### PR TITLE
Set `channel_axis=None` for `pyramid_expand` to fix bug in `skimage==0.19.0`

### DIFF
--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -166,7 +166,7 @@ def _properties2d(image, dim):
     minx, miny, maxx, maxy = region.bbox
     # Use those bounding box coordinates to crop the image (for faster processing)
     image_crop = image_norm[np.clip(minx-pad, 0, image_bin.shape[0]): np.clip(maxx+pad, 0, image_bin.shape[0]),
-                 np.clip(miny-pad, 0, image_bin.shape[1]): np.clip(maxy+pad, 0, image_bin.shape[1])]
+                            np.clip(miny-pad, 0, image_bin.shape[1]): np.clip(maxy+pad, 0, image_bin.shape[1])]
     # Oversample image to reach sufficient precision when computing shape metrics on the binary mask
     # NB: channel_axis=None fixes https://github.com/scikit-image/scikit-image/issues/6092
     #     TODO: Revisit when skimage 0.19.1 is released

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -168,7 +168,9 @@ def _properties2d(image, dim):
     image_crop = image_norm[np.clip(minx-pad, 0, image_bin.shape[0]): np.clip(maxx+pad, 0, image_bin.shape[0]),
                  np.clip(miny-pad, 0, image_bin.shape[1]): np.clip(maxy+pad, 0, image_bin.shape[1])]
     # Oversample image to reach sufficient precision when computing shape metrics on the binary mask
-    image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1)
+    # NB: channel_axis=None fixes https://github.com/scikit-image/scikit-image/issues/6092
+    #     TODO: Revisit when skimage 0.19.1 is released
+    image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1, channel_axis=None)
     # Binarize image using threshold at 0. Necessary input for measure.regionprops
     image_crop_r_bin = np.array(image_crop_r > 0.5, dtype='uint8')
     # Get all closed binary regions from the image (normally there is only one)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`skimage 0.19.0` introduced a backwards incompatible change to the function `transform.pyramid_expand`. This change restores the previous behavior. More details in the linked issue.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3615.