### PR TITLE
Use `--ignore-installed` to preserve the version of `certifi` that gets installed during `conda create`

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -635,7 +635,9 @@ else
   REQUIREMENTS_FILE="requirements.txt"
 fi
 (
-  pip install -r "$REQUIREMENTS_FILE" &&
+  # We use "--ignore-installed" to preserve the version of `certifi` installed into the conda
+  # env, which prevents https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3609
+  pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
   print info "Installing spinalcordtoolbox..." &&
   pip install -e .
 ) ||


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->


* When we run `conda create`, we install `python` and its dependencies (`pip`, `setuptools`, etc.) using conda packages.
* Then, when we run `pip install -r requirements.txt`, pip reinstalls 3 of those conda packages as pip packages: [`wheel`, `setuptools`, and `certifi`](https://www.diffchecker.com/mK56LAZg).
* I _think_ it's OK to reinstall `wheel` and `setuptools` using pip, but trying to reinstall `certifi` causes an error for older versions of `certifi` (#3609).

So, this PR prevents `pip` from reinstalling the version of `certifi` that gets installed during `conda create`. 

(NB: I spend a few hours trying to wrap my head around this problem, trying to answer "Does it matter which version of `certifi` gets installed? Is `certifi` even necessary? There are some interesting rabbit holes... but from what I can tell this is safe to do.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3609.