### PR TITLE
Use furo-theme sanctioned dark mode colour controls.

### DIFF
--- a/documentation/source/_static/css/custom.css
+++ b/documentation/source/_static/css/custom.css
@@ -286,33 +286,3 @@ code.literal {
     border-right: 1px solid var(--color-sidebar-background-border);
     background: #3d3d3c !important;
 } */
-
-:root {
-    --color-sidebar-background: #3d3d3c;
-    --color-sidebar-item-background--hover: #5a5a58;
-    --color-sidebar-link-text: #fcfcfc;
-}
-
-/* Light Mode */
-
-@media (prefers-color-scheme: light) {
-    :root {
-        --color-background-primary: #fcfcfc;
-        --color-sidebar-background: #3d3d3c !important;
-        --color-admonition-title-background: #EAF6FF;
-        --color-admonition-title: #c2e2fb;
-        --color-admonition-title-background--note: #30c42626;
-        --color-admonition-title--note: #30c42659;
-    }
-}
-
-
-/* Dark Mode */
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --color-sidebar-background: #1a1c1e !important;
-        --color-admonition-title: #0054af;
-        --color-admonition-title-background: #0054af5c;
-    }
-}


### PR DESCRIPTION
Setting CSS variables both in our custom.css and via furo's theme options
led to a twisty CSS bug where the <body> would take the colour from furo's
CSS and the <html> would take it from ours, so that in dark mode,
scrolling down revealed illegible light-on-white text.

See https://github.com/pradyunsg/furo/pull/332#issuecomment-991695885

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

In dark mode this happens:

![Screenshot 2021-12-18 at 12-47-09 Spinal Cord Toolbox documentation](https://user-images.githubusercontent.com/987487/146650862-3c2e7770-94b2-48af-bb2c-0d4ea2d936bb.png)

This happened before, but it's been made a lot more obvious by #3624, which updated `furo` and brought with it a new theme switcher button.

## Linked issues

* Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3487#issuecomment-889390712
* An attempt to fix this was in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3489 but it evidently didn't go far enough?
* The diagnosis: https://github.com/pradyunsg/furo/pull/332#issuecomment-991685833
* The fix suggested by our helpful upstream dev: https://github.com/pradyunsg/furo/pull/332#issuecomment-991695885
