### PR TITLE
Convert input file to float32 before compute MTR

### DIFF
--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -44,8 +44,14 @@ def compute_mtr(nii_mt1, nii_mt0, threshold_mtr=100):
     :param threshold_mtr: float: value above which number will be clipped
     :return: nii_mtr
     """
+    # Convert input to avoid numerical errors from int16 data
+    # Related issue: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3636
+    nii_mt1.change_type('float32')
+    nii_mt0.change_type('float32')
+
     # Initialize Image object
     nii_mtr = nii_mt1.copy()
+
     # Compute MTR
     nii_mtr.data = divide_after_removing_zero(100 * (nii_mt0.data - nii_mt1.data), nii_mt0.data, threshold_mtr)
     return nii_mtr

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -32,7 +32,7 @@ def test_sct_compute_mtr_with_int16_image_type(tmp_path):
     mtr_output_path = str(tmp_path / 'mtr_output.nii.gz')
 
     # Generate int16 test file based on sct_testing_data existing one
-    mt0 = Image('mt/mt0.nii.gz')
+    mt0 = Image('mt/mt0_reg_slicereg_goldstandard.nii.gz')
     mt0.save(mt0_path, dtype='int16')
     mt1 = Image('mt/mt1.nii.gz')
     mt1.save(mt1_path, dtype='int16')

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -43,4 +43,8 @@ def test_sct_compute_mtr_with_int16_image_type(tmp_path):
     ground_truth_mtr = Image('mt/mtr.nii.gz')
     output_mtr = Image(mtr_output_path)
 
-    assert numpy.linalg.norm(ground_truth_mtr.data - output_mtr.data) <= 0.001
+    # NB: numpy.isfinite is used to exclude nan/inf elements from comparison
+    diff = (ground_truth_mtr.data[numpy.isfinite(ground_truth_mtr.data)] -
+            output_mtr.data[numpy.isfinite(output_mtr.data)])
+
+    assert numpy.abs(numpy.average(diff)) <= 0.5

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -1,6 +1,8 @@
 import pytest
 import logging
+import numpy
 
+from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_compute_mtr
 
 logger = logging.getLogger(__name__)
@@ -8,7 +10,37 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.sct_testing
 @pytest.mark.usefixtures("run_in_sct_testing_data_dir")
-def test_sct_compute_mtr_no_checks():
-    """Run the CLI script without checking results.
-    TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_compute_mtr.main(argv=['-mt0', 'mt/mt0.nii.gz', '-mt1', 'mt/mt1.nii.gz'])
+def test_sct_compute_mtr_no_checks(tmp_path):
+    """Run the CLI script without checking results."""
+    mtr_output_path = str(tmp_path / 'mtr_output.nii.gz')
+
+    sct_compute_mtr.main(argv=['-mt0', 'mt/mt0.nii.gz', '-mt1', 'mt/mt1.nii.gz', '-o', mtr_output_path])
+
+    # Comparate ground truth mtr file to new generated one
+    ground_truth_mtr = Image('mt/mtr.nii.gz')
+    output_mtr = Image(mtr_output_path)
+    assert numpy.linalg.norm(ground_truth_mtr.data - output_mtr.data) <= 0.001
+
+
+@pytest.mark.sct_testing
+@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
+def test_sct_compute_mtr_with_int16_image_type(tmp_path):
+    """Run the CLI script with int_16 image type"""
+
+    mt0_path = str(tmp_path / 'mt0_int16.nii.gz')
+    mt1_path = str(tmp_path / 'mt1_int16.nii.gz')
+    mtr_output_path = str(tmp_path / 'mtr_output.nii.gz')
+
+    # Generate int16 test file based on sct_testing_data existing one
+    mt0 = Image('mt/mt0.nii.gz')
+    mt0.save(mt0_path, dtype='int16')
+    mt1 = Image('mt/mt1.nii.gz')
+    mt1.save(mt1_path, dtype='int16')
+
+    sct_compute_mtr.main(argv=['-mt0', mt0_path, '-mt1', mt1_path, '-o', mtr_output_path])
+
+    # Comparate ground truth mtr file to new generated one
+    ground_truth_mtr = Image('mt/mtr.nii.gz')
+    output_mtr = Image(mtr_output_path)
+
+    assert numpy.linalg.norm(ground_truth_mtr.data - output_mtr.data) <= 0.001

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -48,7 +48,7 @@ def test_sct_compute_mtr_with_dummy_highvalue_int16_data(tmp_path):
     mtr_truth_path = str(tmp_path / 'mtr_dummy_truth.nii.gz')
 
     # Generate dummy files of inputs and output comparison
-    nx, ny, nz = 9, 9, 9  # image dimension # center location
+    nx, ny, nz = 9, 9, 9  # image dimension
 
     data = numpy.zeros((nx, ny, nz), dtype=numpy.int16)
     data[4, 4, 4] = 1000

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -36,8 +36,6 @@ def test_sct_compute_mtr_results_are_identical(tmp_path):
                              output_mtr.data[numpy.isfinite(output_mtr.data)])
 
 
-@pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_compute_mtr_with_dummy_highvalue_int16_data(tmp_path):
     """
     Test that high-valued int16 data doesn't result in clipping. See also:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
**Contributing documentation link is broken**
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
When we use `sct_compute_mtr`, we have an issue with the results when using non `float32` NIFTI images for MT0 and MT1. The values obtained are inconsistent. We need to convert the type of input to float32 before compute the MTR result.

## Linked issues
Fixes #3636 

## Actual status of this PR

Some things need to be cleaned-up but i need some informations/help to know the way we work here:

 - The testing dataset are dynamically download from [sct_testing_data repository](https://github.com/spinalcordtoolbox/sct_testing_data) but i need to test the script with a int_16 file in place of a float_32. What is the process to add a new file of testing (ie: PR ? Request to the team ?) or do i just convert the file first directly in the test ?
 
  - I don't have the PR labels information since the link for the contribution guideline is broken on severals places: https://www.neuro.polymtl.ca/software/contributing#pr_labels
  
  - The actual `sct_compute_mtr` tests does not check the results. Do you have some tips before i go on it ? I will be able to add them also on the initial test already existing.