### PR TITLE
Remove `channel=None` bugfix that was superseded by upstream `skimage=0.19.1` patch

### DIFF
--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -168,8 +168,6 @@ def _properties2d(image, dim):
     image_crop = image_norm[np.clip(minx-pad, 0, image_bin.shape[0]): np.clip(maxx+pad, 0, image_bin.shape[0]),
                             np.clip(miny-pad, 0, image_bin.shape[1]): np.clip(maxy+pad, 0, image_bin.shape[1])]
     # Oversample image to reach sufficient precision when computing shape metrics on the binary mask
-    # NB: channel_axis=None fixes https://github.com/scikit-image/scikit-image/issues/6092
-    #     TODO: Revisit when skimage 0.19.1 is released
     image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1)
     # Binarize image using threshold at 0. Necessary input for measure.regionprops
     image_crop_r_bin = np.array(image_crop_r > 0.5, dtype='uint8')

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -170,7 +170,7 @@ def _properties2d(image, dim):
     # Oversample image to reach sufficient precision when computing shape metrics on the binary mask
     # NB: channel_axis=None fixes https://github.com/scikit-image/scikit-image/issues/6092
     #     TODO: Revisit when skimage 0.19.1 is released
-    image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1, channel_axis=None)
+    image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1)
     # Binarize image using threshold at 0. Necessary input for measure.regionprops
     image_crop_r_bin = np.array(image_crop_r > 0.5, dtype='uint8')
     # Get all closed binary regions from the image (normally there is only one)


### PR DESCRIPTION

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
THis PR addresses #3651. A fix was added for the version 0.19.0 of scikit-image (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3615), adding the argument `channel_axis=None`. Since the package scikit image has been upgrated to 0.19.1, it is no longer necessary, we can remove it.

## Linked issues
Resolves #3651 
