### PR TITLE
Appply -symmetrize on specified dimension in `sct_maths`

### DIFF
--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -290,3 +290,15 @@ def denoise_nlmeans(data_in, patch_radius=1, block_radius=5):
     denoised = nlmeans(data_in, sigma, patch_radius=patch_radius, block_radius=block_radius)
 
     return denoised
+
+
+def symmetrize(data, dim):
+    """
+    Symmetrize data along specified dimension.
+    :param data: numpy.array 3D data.
+    :param dim: dimension of array to symmetrize along.
+
+    :return data_out: symmetrized data
+    """
+    data_out = (data + np.flip(data, axis=dim)) / 2.0
+    return data_out

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -10,14 +10,11 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
-from asyncio.log import logger
-import os
 import sys
 import pickle
 import gzip
 
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
 
 import spinalcordtoolbox.math as sct_math

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -378,7 +378,6 @@ def main(argv=None):
     elif arguments.symmetrize is not None:
         if arguments.symmetrize == 0:
             data_out = (data + data[::-1, :, :]) / float(2)
-            #data_out = (data + data[list(range(data.shape[0] - 1, -1, -1)), :, :]) / float(2)
         elif arguments.symmetrize == 1:
             data_out = (data + data[:, ::-1, :]) / float(2)
         elif arguments.symmetrize == 2:

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -376,13 +376,13 @@ def main(argv=None):
         data_out = sct_math.denoise_nlmeans(data, patch_radius=p, block_radius=b)
 
     elif arguments.symmetrize is not None:
-        if arguments.symmetrize==0:
-            data_out = (data + data[::-1,:,:]) / float(2)
+        if arguments.symmetrize == 0:
+            data_out = (data + data[::-1, :, :]) / float(2)
             #data_out = (data + data[list(range(data.shape[0] - 1, -1, -1)), :, :]) / float(2)
-        elif arguments.symmetrize==1:
-            data_out = (data + data[:,::-1,:]) / float(2)
-        elif arguments.symmetrize==2:
-            data_out = (data + data[:,:,::-1]) / float(2)
+        elif arguments.symmetrize == 1:
+            data_out = (data + data[:, ::-1, :]) / float(2)
+        elif arguments.symmetrize == 2:
+            data_out = (data + data[:, :, ::-1]) / float(2)
 
     elif arguments.mi is not None:
         # input 1 = from flag -i --> im

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -10,6 +10,7 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+from asyncio.log import logger
 import os
 import sys
 import pickle
@@ -375,7 +376,13 @@ def main(argv=None):
         data_out = sct_math.denoise_nlmeans(data, patch_radius=p, block_radius=b)
 
     elif arguments.symmetrize is not None:
-        data_out = (data + data[list(range(data.shape[0] - 1, -1, -1)), :, :]) / float(2)
+        if arguments.symmetrize==0:
+            data_out = (data + data[::-1,:,:]) / float(2)
+            #data_out = (data + data[list(range(data.shape[0] - 1, -1, -1)), :, :]) / float(2)
+        elif arguments.symmetrize==1:
+            data_out = (data + data[:,::-1,:]) / float(2)
+        elif arguments.symmetrize==2:
+            data_out = (data + data[:,:,::-1]) / float(2)
 
     elif arguments.mi is not None:
         # input 1 = from flag -i --> im

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -373,12 +373,7 @@ def main(argv=None):
         data_out = sct_math.denoise_nlmeans(data, patch_radius=p, block_radius=b)
 
     elif arguments.symmetrize is not None:
-        if arguments.symmetrize == 0:
-            data_out = (data + data[::-1, :, :]) / float(2)
-        elif arguments.symmetrize == 1:
-            data_out = (data + data[:, ::-1, :]) / float(2)
-        elif arguments.symmetrize == 2:
-            data_out = (data + data[:, :, ::-1]) / float(2)
+        data_out = sct_math.symmetrize(data, arguments.symmetrize)
 
     elif arguments.mi is not None:
         # input 1 = from flag -i --> im
@@ -512,4 +507,3 @@ def compute_similarity(img1: Image, img2: Image, fname_out: str, metric: str, me
 if __name__ == "__main__":
     init_sct()
     main(sys.argv[1:])
-

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -1,6 +1,10 @@
 import pytest
 import logging
 
+import numpy as np
+
+from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils import sct_test_path
 from spinalcordtoolbox.scripts import sct_maths
 
 logger = logging.getLogger(__name__)
@@ -28,3 +32,17 @@ def test_sct_maths_add_images_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
     sct_maths.main(argv=['-i', 'mt/mtr.nii.gz', '-add', 'mt/mtr.nii.gz', 'mt/mtr.nii.gz', '-o', 'test.nii.gz'])
+
+
+@pytest.mark.parametrize('dim', ['0', '1', '2'])
+def test_sct_maths_symmetrize(dim, tmp_path):
+    """Run the CLI script, then verify that symmetrize properly flips and
+    averages the image data."""
+    path_in = sct_test_path('t2', 't2.nii.gz')
+    path_out = str(tmp_path/f't2_sym_{dim}.nii.gz')
+    sct_maths.main(argv=['-i', path_in, '-symmetrize', str(dim),
+                         '-o', path_out])
+    im_in = Image(path_out)
+    im_out = Image(path_out)
+    assert np.array_equal(im_out.data,
+                          (im_in.data + np.flip(im_in.data, axis=int(dim))) / 2.0)


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR addresses #3649. In `sct_math` the flag `-symmetrize` is suppose to symmetrize the input image along the specified axis. However, the symmetry was always applied on the first dimension despite the specified dimension.

This PR applies the symmetrization on the specified input dimension.

## Linked issues
Fixes #3649 
