### PR TITLE
Add utility function to strip '.py' extensions

### DIFF
--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -19,7 +19,7 @@ from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, strip_py
 
 
 def get_parser():
@@ -269,7 +269,7 @@ def main(argv=None):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         generate_qc(fname_straight, args=arguments, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process=os.path.basename(__file__.strip('.py')))
+                    dataset=qc_dataset, subject=qc_subject, process=os.path.basename(strip_py(__file__)))
 
     display_viewer_syntax([fname_straight], verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -19,7 +19,7 @@ from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, strip_py
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, removesuffix
 
 
 def get_parser():
@@ -269,7 +269,7 @@ def main(argv=None):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         generate_qc(fname_straight, args=arguments, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process=os.path.basename(strip_py(__file__)))
+                    dataset=qc_dataset, subject=qc_subject, process=removesuffix(os.path.basename(__file__), ".py"))
 
     display_viewer_syntax([fname_straight], verbose=verbose)
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -12,7 +12,7 @@ import inspect
 
 from enum import Enum
 
-from .sys import check_exe, printv
+from .sys import check_exe, printv, strip_py
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class SCTArgumentParser(argparse.ArgumentParser):
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
         frame = inspect.stack()[1]
         module = inspect.getmodule(frame[0])
-        update_parent_default('prog', os.path.basename(module.__file__).strip(".py"))
+        update_parent_default('prog', strip_py(os.path.basename(module.__file__)))
 
         # Disable "add_help", because it won't properly add '-h' to our custom argument groups
         # (We use custom argument groups because of https://stackoverflow.com/a/24181138)

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -12,7 +12,7 @@ import inspect
 
 from enum import Enum
 
-from .sys import check_exe, printv, strip_py
+from .sys import check_exe, printv, removesuffix
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class SCTArgumentParser(argparse.ArgumentParser):
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
         frame = inspect.stack()[1]
         module = inspect.getmodule(frame[0])
-        update_parent_default('prog', strip_py(os.path.basename(module.__file__)))
+        update_parent_default('prog', removesuffix(os.path.basename(module.__file__), ".py"))
 
         # Disable "add_help", because it won't properly add '-h' to our custom argument groups
         # (We use custom argument groups because of https://stackoverflow.com/a/24181138)

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -87,6 +87,7 @@ def set_loglevel(verbose):
         # the loglevel changes from leaking: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3341
         pass
 
+
 def strip_py(fname):
     """
     Strip ".py" suffix from the string `fname`, if present.
@@ -95,6 +96,7 @@ def strip_py(fname):
     :return: a stripped copy of `fname`
     """
     return fname[:-3] if fname.endswith('.py') else fname
+
 
 # TODO: add test
 def init_sct():

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -100,6 +100,7 @@ def removesuffix(self: str, suffix: str) -> str:
     else:
         return self[:]
 
+
 # TODO: add test
 def init_sct():
     """

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -87,6 +87,14 @@ def set_loglevel(verbose):
         # the loglevel changes from leaking: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3341
         pass
 
+def strip_py(fname):
+    """
+    Strip ".py" suffix from the string `fname`, if present.
+
+    :param fname: str: a filename
+    :return: a stripped copy of `fname`
+    """
+    return fname[:-3] if fname.endswith('.py') else fname
 
 # TODO: add test
 def init_sct():
@@ -126,7 +134,7 @@ def init_sct():
     # Display command (Only if called from CLI: check for .py in first arg)
     # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
     if '.py' in next(iter(sys.argv), None):
-        script = os.path.basename(sys.argv[0]).strip(".py")
+        script = strip_py(os.path.basename(sys.argv[0]))
         arguments = ' '.join(sys.argv[1:])
         logger.info(f"{script} {arguments}\n"
                     f"--\n")

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -88,15 +88,17 @@ def set_loglevel(verbose):
         pass
 
 
-def strip_py(fname):
+def removesuffix(self: str, suffix: str) -> str:
     """
-    Strip ".py" suffix from the string `fname`, if present.
+    Source: https://www.python.org/dev/peps/pep-0616/
 
-    :param fname: str: a filename
-    :return: a stripped copy of `fname`
+    TODO: Replace with built-in str.removesuffix method after upgrading to Python 3.9
     """
-    return fname[:-3] if fname.endswith('.py') else fname
-
+    # suffix='' should not call self[:-0].
+    if suffix and self.endswith(suffix):
+        return self[:-len(suffix)]
+    else:
+        return self[:]
 
 # TODO: add test
 def init_sct():
@@ -136,7 +138,7 @@ def init_sct():
     # Display command (Only if called from CLI: check for .py in first arg)
     # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
     if '.py' in next(iter(sys.argv), None):
-        script = strip_py(os.path.basename(sys.argv[0]))
+        script = removesuffix(os.path.basename(sys.argv[0]), ".py")
         arguments = ' '.join(sys.argv[1:])
         logger.info(f"{script} {arguments}\n"
                     f"--\n")

--- a/testing/api/test_utils.py
+++ b/testing/api/test_utils.py
@@ -7,23 +7,6 @@ import pytest
 from spinalcordtoolbox import utils
 
 
-def test_strip_py():
-    """
-    Test that utils.strip_py() correctly removes '.py' suffix if present.
-    """
-    # The happy path
-    assert utils.strip_py("basename.py") == "basename"
-    assert utils.strip_py("basename") == "basename"
-
-    # A short string
-    assert utils.strip_py("a") == "a"
-
-    # Permutations and prefixes should not be removed
-    assert utils.strip_py("ppp.yyy") == "ppp.yyy"
-    assert utils.strip_py("no_dot_py") == "no_dot_py"
-    assert utils.strip_py(".py_prefix") == ".py_prefix"
-
-
 def test_parse_num_list_inv():
     assert utils.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
     assert utils.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'

--- a/testing/api/test_utils.py
+++ b/testing/api/test_utils.py
@@ -7,6 +7,23 @@ import pytest
 from spinalcordtoolbox import utils
 
 
+def test_strip_py():
+    """
+    Test that utils.strip_py() correctly removes '.py' suffix if present.
+    """
+    # The happy path
+    assert utils.strip_py("basename.py") == "basename"
+    assert utils.strip_py("basename") == "basename"
+
+    # A short string
+    assert utils.strip_py("a") == "a"
+
+    # Permutations and prefixes should not be removed
+    assert utils.strip_py("ppp.yyy") == "ppp.yyy"
+    assert utils.strip_py("no_dot_py") == "no_dot_py"
+    assert utils.strip_py(".py_prefix") == ".py_prefix"
+
+
 def test_parse_num_list_inv():
     assert utils.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
     assert utils.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The previous use of `str.strip(".py")` is a bug waiting to happen,
because it strips from both sides of the string (instead of just
the end), and more importantly, treats `".py"` as a set of
characters rather than a substring to look for (see [the docs](https://docs.python.org/3/library/stdtypes.html#str.strip)):

```
$ python3
>>> "ppp.yyy".strip(".py")
''
>>> "no_dot_py".strip(".py")
'no_dot_'
>>> ".py_prefix".strip(".py")
'_prefix'
```

All uses of `.strip(".py")` are either in `utils/sys.py` itself or import this module, so it seemed like the natural place to add this utility function.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
