### PR TITLE
Allow `install_sct` to run from any directory

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -46,7 +46,6 @@ shopt -s failglob # error if a glob doesn't find any files, instead of remaining
 
 # Where tmp file are stored
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
-# Source directory
 SCT_SOURCE="$PWD"
 DATA_DIR="data"
 PYTHON_DIR="python"

--- a/install_sct
+++ b/install_sct
@@ -29,6 +29,11 @@
 # Authors: PO Quirion, J Cohen-Adad, J Carretero
 # License: see the file LICENSE.TXT
 
+# Change directory to where the script is, for the duration of the script.
+# This lives outside the subshell below to guarantee the corresponding
+# popd gets run, no matter how the installation script exits.
+pushd -- "${BASH_SOURCE[0]%/*}/" || exit 1
+
 ( # | tee install_sct_log.txt
 
 # stricter shell mode
@@ -39,10 +44,9 @@ shopt -s failglob # error if a glob doesn't find any files, instead of remaining
 
 # set -v  # v: verbose
 
-
 # Where tmp file are stored
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
-# Start Directory So we go back there at the end of the Script
+# Source directory
 SCT_SOURCE="$PWD"
 DATA_DIR="data"
 PYTHON_DIR="python"
@@ -111,8 +115,6 @@ function run() {
 function finish() {
   # Catch the last return code
   value="$?"
-  # Get back to starting point
-  cd "$SCT_SOURCE"
   if [[ "$value" -eq 0 ]]; then
     print info "Installation finished successfully!"
   elif [[ "$value" -eq 99 ]]; then
@@ -120,7 +122,7 @@ function finish() {
     echo ""
   else
     print error "Installation failed!\n
-Please find the file $(pwd)/install_sct_log.txt, 
+Please find the file \"$SCT_SOURCE/install_sct_log.txt\",
 then upload it as a .txt attachment in a new topic on SCT's forum:
 --> http://forum.spinalcordmri.org/c/sct"
   fi
@@ -405,8 +407,7 @@ check_requirements
 if [[ -e "spinalcordtoolbox/version.txt" ]]; then
   SCT_VERSION="$(cat spinalcordtoolbox/version.txt)"
 else
-  die "ERROR: version.txt not found. \n
-The install_sct script must be executed from the source directory"
+  die "ERROR: version.txt not found."
 fi
 
 # Get installation type (from git or from package) if not already specified
@@ -744,3 +745,5 @@ else
 fi
 
 ) 2>&1 | tee install_sct_log.txt
+
+popd

--- a/install_sct
+++ b/install_sct
@@ -744,6 +744,6 @@ else
 fi
 
 ) 2>&1 | tee install_sct_log.txt
-status=$?
+status=${PIPESTATUS[0]}
 popd >/dev/null
-exit $status
+exit "$status"

--- a/install_sct
+++ b/install_sct
@@ -32,7 +32,7 @@
 # Change directory to where the script is, for the duration of the script.
 # This lives outside the subshell below to guarantee the corresponding
 # popd gets run, no matter how the installation script exits.
-pushd -- "${BASH_SOURCE[0]%/*}/" || exit 1
+pushd -- "${BASH_SOURCE[0]%/*}/" >/dev/null || exit 1
 
 ( # | tee install_sct_log.txt
 
@@ -746,4 +746,4 @@ fi
 
 ) 2>&1 | tee install_sct_log.txt
 
-popd
+popd >/dev/null

--- a/install_sct
+++ b/install_sct
@@ -602,7 +602,7 @@ find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
 # For more information, see:
 # * Issue details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3067
 # * Fix details: https://github.com/conda/conda/issues/7173#issuecomment-980496682
-echo "include-system-site-packages = false" > $SCT_DIR/$PYTHON_DIR/envs/venv_sct/pyvenv.cfg
+echo "include-system-site-packages = false" > "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/pyvenv.cfg"
 
 # activate miniconda
 # shellcheck disable=SC1091

--- a/install_sct
+++ b/install_sct
@@ -744,5 +744,6 @@ else
 fi
 
 ) 2>&1 | tee install_sct_log.txt
-
+status=$?
 popd >/dev/null
+exit $status


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Allow the `install_sct` script to run from any location, by first changing directory to the script location, and changing back to the original directory at the end.

Possibly this could have been integrated into the existing `finish()` function, but this way seems nicely self-contained to me. The downside is that it's not logged in `install_sct_log.txt`.

The script passes ShellCheck version 0.8.0, and a test run from a different directory worked fine on my machine.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3647