### PR TITLE
Revert "requirements.txt -> setup.py" PR to restore old dependency-checking behavior

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,7 +43,7 @@ jobs:
         pip freeze | grep -v "-e git+" | grep -v "torch" > requirements-freeze.txt
         conda deactivate
         echo "# Platform-specific torch requirements (See SCT Issue #2745)" >> requirements-freeze.txt
-        grep "torch" install_requirements.txt >> requirements-freeze.txt
+        grep "torch" requirements.txt >> requirements-freeze.txt
 
     - name: Update version.txt
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ spinalcordtoolbox_v*
 dev/atlas/create_atlas/results
 dev/atlas/validate_atlas/tmp.*
 sct_testing_data
-install_requirements.txt
 
 scripts/.idea/misc.xml
 scripts/.idea/modules.xml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,6 @@
 **INSTALLATION**
 
  - Allow `install_sct` to run from any directory.  [View pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3660)
- - Move dependencies from `requirements.txt` to `setup.py :: install_requires`.  [View pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3646)
  - Use `--ignore-installed` to preserve the version of `certifi` that gets installed during `conda create`.  [View pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3618)
  - Use a more reliable way to disable USER_SITE.  [View pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3606)
  - `requirements.txt`: Pin `onnxruntime>=1.7.0` rather than `==1.4.0`.  [View pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3595)

--- a/documentation/source/user_section/installation/linux.rst
+++ b/documentation/source/user_section/installation/linux.rst
@@ -120,13 +120,13 @@ Procedure:
 
    .. code:: sh
 
-      pip install -e . -f https://download.pytorch.org/whl/cpu/torch_stable.html
+      pip install -e .
 
    else:
 
    .. code:: sh
 
-      pip install --user -e . -f https://download.pytorch.org/whl/cpu/torch_stable.html
+      pip install --user -e .
 
 
 Option 4: Install with Docker

--- a/documentation/source/user_section/installation/mac.rst
+++ b/documentation/source/user_section/installation/mac.rst
@@ -111,13 +111,13 @@ Procedure:
 
    .. code:: sh
 
-      pip install -e . -f https://download.pytorch.org/whl/cpu/torch_stable.html
+      pip install -e .
 
    else:
 
    .. code:: sh
 
-      pip install --user -e . -f https://download.pytorch.org/whl/cpu/torch_stable.html
+      pip install --user -e .
 
 
 Option 4: Install with Docker

--- a/install_sct
+++ b/install_sct
@@ -624,11 +624,22 @@ fi
 python -m pip install -U "pip!=21.2.*"
 
 ## Install the spinalcordtoolbox into the Conda venv
-print info "Installing spinalcordtoolbox and its Python dependencies..."
+print info "Installing Python dependencies..."
+# Check if a frozen version of the requirements exist (for release only)
+if [[ -f "requirements-freeze.txt" ]]; then
+  print info "Using requirements-freeze.txt (release installation)"
+  REQUIREMENTS_FILE="requirements-freeze.txt"
+else
+  # Not a package
+  print info "Using requirements.txt (git installation)"
+  REQUIREMENTS_FILE="requirements.txt"
+fi
 (
   # We use "--ignore-installed" to preserve the version of `certifi` installed into the conda
   # env, which prevents https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3609
-  pip install -e . --ignore-installed certifi -f https://download.pytorch.org/whl/cpu/torch_stable.html
+  pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
+  print info "Installing spinalcordtoolbox..." &&
+  pip install -e .
 ) ||
   die "Failed running pip install: $?"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,9 @@ ivadomed
 matplotlib
 nibabel
 numpy
-# onnxruntime>=1.5.1 requires `brew install libomp` on macOS.
-# So, pin to 1.4.0 to avoid having to ask users to install libomp.
-# ivadomed==2.5.0 would also do this, but #3035 is preventing that.
-onnxruntime==1.4.0
+# 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
+# So, pin to >=1.7.0 to avoid having to ask users to install libomp.
+onnxruntime>=1.7.0
 pandas
 psutil
 pyqt5==5.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,41 @@
+colored
+dipy
+# h5py is pinned to minor than 3 due to issues with Keras/TF
+# https://github.com/tensorflow/tensorflow/issues/44467
+h5py~=2.10.0
+Keras==2.3.1
+ivadomed
+matplotlib
+nibabel
+numpy
+# onnxruntime>=1.5.1 requires `brew install libomp` on macOS.
+# So, pin to 1.4.0 to avoid having to ask users to install libomp.
+# ivadomed==2.5.0 would also do this, but #3035 is preventing that.
+onnxruntime==1.4.0
+pandas
+psutil
+pyqt5==5.11.3
+pytest
+pytest-cov
+raven
+requests
+requirements-parser
+scipy
+scikit-image
+scikit-learn
+tensorflow~=1.15.0
+# PyTorch's Linux/Windows distribution is very large due to its GPU support,
+# but we only need that for training models. For users, use the CPU-only version
+# (only available directly from the PyTorch project).
+# The macOS version has never had GPU support, so doesn't need the workaround.
 -f https://download.pytorch.org/whl/cpu/torch_stable.html
--e . 
+torch==1.5.0+cpu; sys_platform != "darwin"
+torch==1.5.0; sys_platform == "darwin"
+torchvision==0.6.0+cpu; sys_platform != "darwin"
+torchvision==0.6.0; sys_platform == "darwin"
+xlwt
+tqdm
+transforms3d
+urllib3[secure]
+pytest_console_scripts
+wquantiles

--- a/setup.py
+++ b/setup.py
@@ -13,69 +13,6 @@ path_version = path.join(here, 'spinalcordtoolbox', 'version.txt')
 with open(path_version) as f:
     version = f.read().strip()
 
-
-# This function does not handle all corner cases and
-#  assumes a simple requirements.txt is fed to it
-def get_dependencies(requirements_path=None):
-    if not path.exists(requirements_path):
-        return []
-
-    with open(requirements_path) as f:
-        requirements = f.read().splitlines()
-
-    return requirements
-
-
-DEFAULT_REQUIREMENTS = [
-    'colored',
-    'dipy',
-    # h5py is pinned to minor than 3 due to issues with Keras/TF
-    # https://github.com/tensorflow/tensorflow/issues/44467
-    'h5py~=2.10.0',
-    'Keras==2.3.1',
-    'ivadomed',
-    'matplotlib',
-    'nibabel',
-    'numpy',
-    # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
-    # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
-    'onnxruntime>=1.7.0',
-    'pandas',
-    'psutil',
-    'pyqt5==5.11.3',
-    'pytest',
-    'pytest-cov',
-    'raven',
-    'requests',
-    'requirements-parser',
-    'scipy',
-    'scikit-image',
-    'scikit-learn',
-    'tensorflow~=1.15.0',
-    # PyTorch's Linux/Windows distribution is very large due to its GPU support,
-    # but we only need that for training models. For users, use the CPU-only version
-    # (only available directly from the PyTorch project).
-    # The macOS version has never had GPU support, so doesn't need the workaround.
-    'torch==1.5.0+cpu; sys_platform != "darwin"',
-    'torch==1.5.0; sys_platform == "darwin"',
-    'torchvision==0.6.0+cpu; sys_platform != "darwin"',
-    'torchvision==0.6.0; sys_platform == "darwin"',
-    'xlwt',
-    'tqdm',
-    'transforms3d',
-    'urllib3[secure]',
-    'pytest_console_scripts',
-    'wquantiles',
-]
-
-frozen_dependencies = get_dependencies(path.join(here, 'requirements-freeze.txt'))
-
-dependencies = frozen_dependencies or DEFAULT_REQUIREMENTS
-
-with open(path.join(here, "install_requirements.txt"), 'wt') as f:
-    f.write('\n'.join(dependencies))
-
-
 setup(
     name='spinalcordtoolbox',
     version=version,
@@ -105,7 +42,6 @@ setup(
                                     'install', 'testing']),
     include_package_data=True,
     python_requires="==3.7.*",
-    install_requires=dependencies,
     extras_require={
         'docs': [
             'sphinxcontrib-programoutput',

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -157,7 +157,7 @@ def add_bash_profile(string):
 
 def get_dependencies(requirements_txt=None):
     if requirements_txt is None:
-        requirements_txt = sct_dir_local_path("install_requirements.txt")
+        requirements_txt = sct_dir_local_path("requirements.txt")
 
     requirements_txt = open(requirements_txt, "r", encoding="utf-8")
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Pull request #3646 reworked how we install dependencies (as a stepping stone towards a pip-installable SCT). However, that pull request wasn't tested against the stable release installation path (see #3669), and thus the changes introduced unforeseen issues with `sct_check_dependencies`. 

I've spent the morning trying to troubleshoot these issues, but I can't find a clean, easy-to-review solution. Given the urgency of the SCT v5.5 release, I think the best path forward is to revert PR #3646, then devote more time to the original problem once we're under less time pressure.

Once this PR is merged, I'll patch the `release` branch, and then we can safely release v5.5.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3667.