### PR TITLE
Use `spawn` multiprocessing start method to avoid hanging for Ubuntu coverage CI

### DIFF
--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -28,6 +28,10 @@ def test_many_qc():
     if multiprocessing.cpu_count() < 2:
         pytest.skip("Can't test parallel behaviour")
 
+    # 'spawn' fix needed to avoid hanging when running tests with coverage
+    # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1026179554
+    multiprocessing.set_start_method('spawn')
+
     with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
         # install: sct_download_data -d sct_testing_data
         with multiprocessing.Pool(2) as p:

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -26,9 +26,9 @@ def test_many_qc():
 
     # 'spawn' fix needed to avoid hanging when running tests with coverage
     # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1026179554
-    multiprocessing.set_start_method('spawn')
+    ctx = multiprocessing.get_context("spawn")
 
     with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
         # install: sct_download_data -d sct_testing_data
-        with multiprocessing.Pool(2) as p:
+        with ctx.Pool(2) as p:
             p.map(gen_qc, ((i, tmpdir) for i in range(5)))

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -1,5 +1,4 @@
-
-import sys, os
+import sys
 from tempfile import TemporaryDirectory
 import pytest
 
@@ -7,10 +6,7 @@ import multiprocessing
 
 from spinalcordtoolbox.utils import sct_test_path, sct_dir_local_path
 sys.path.append(sct_dir_local_path('scripts'))
-from spinalcordtoolbox import resampling
 import spinalcordtoolbox.reports.qc as qc
-from spinalcordtoolbox.image import Image
-import spinalcordtoolbox.reports.slice as qcslice
 
 
 def gen_qc(args):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Ubuntu uses `fork` by default, which seems to hang when interacting with `pytest --cov`.

(This PR also removes some unused imports from the file, which would otherwise trigger the linter.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3661.
