### PR TITLE
Replace CentOS 8 with CentOS Stream 8 to address December 2021 EOL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,8 @@ jobs:
   centos-8:
     name: CentOS 8
     runs-on: ubuntu-18.04
-    # This centOS 8 image
+    # Stream8 has a 2024 EOL, while CentOS 8 has a 2021 EOL
+    # See: https://blog.centos.org/2020/12/future-is-centos-stream/
     container: quay.io/centos/centos:stream8
     steps:
       - name: Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,7 @@ jobs:
           ./.ci.sh -t
 
   centos-8:
-    name: CentOS 8
+    name: CentOS Stream 8
     runs-on: ubuntu-18.04
     # Stream8 has a 2024 EOL, while CentOS 8 has a 2021 EOL
     # See: https://blog.centos.org/2020/12/future-is-centos-stream/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,8 @@ jobs:
   centos-8:
     name: CentOS 8
     runs-on: ubuntu-18.04
-    container: centos:8
+    # This centOS 8 image
+    container: quay.io/centos/centos:stream8
     steps:
       - name: Dependencies
         run: |  # NB: mesa-libGL is needed for PyQT testing (https://stackoverflow.com/a/65408967/7584115)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a fix for the CentOS 8 EOL, which went into effect today. Quay.io is an official RHEL channel.

Also, context for this fix can be found in
https://blog.centos.org/2020/12/future-is-centos-stream/:

> When CentOS Linux 8 (the rebuild of RHEL8) ends, your best
> option will be to migrate to CentOS Stream 8, which is a
> small delta from CentOS Linux 8, and has regular updates like
> traditional CentOS Linux releases.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3675. 