### PR TITLE
Rewrite QC test to use `Pool.close()` to avoid stalling with pytest-cov

### DIFF
--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -25,6 +25,5 @@ def test_many_qc():
         pytest.skip("Can't test parallel behaviour")
 
     with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
-        # install: sct_download_data -d sct_testing_data
         with multiprocessing.Pool(2) as p:
             p.map(gen_qc, ((i, tmpdir) for i in range(5)))

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -1,5 +1,4 @@
-
-import sys, os
+import sys
 from tempfile import TemporaryDirectory
 import pytest
 
@@ -7,10 +6,7 @@ import multiprocessing
 
 from spinalcordtoolbox.utils import sct_test_path, sct_dir_local_path
 sys.path.append(sct_dir_local_path('scripts'))
-from spinalcordtoolbox import resampling
 import spinalcordtoolbox.reports.qc as qc
-from spinalcordtoolbox.image import Image
-import spinalcordtoolbox.reports.slice as qcslice
 
 
 def gen_qc(args):

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -9,14 +9,10 @@ sys.path.append(sct_dir_local_path('scripts'))
 import spinalcordtoolbox.reports.qc as qc
 
 
-def gen_qc(args):
-    i, path_qc = args
-
+def gen_qc(path_qc):
     t2_image = sct_test_path('t2', 't2.nii.gz')
     t2_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
-
     qc.generate_qc(fname_in1=t2_image, fname_seg=t2_seg, path_qc=path_qc, process="sct_deepseg_gm")
-    return True
 
 
 def test_many_qc():
@@ -30,7 +26,7 @@ def test_many_qc():
         # This `try, finally` pattern mitigates hanging with pytest-cov
         # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1029057900
         try:
-            p.map(gen_qc, ((i, tmpdir) for i in range(5)))
+            p.map(gen_qc, [tmpdir] * 5)
         finally:
             p.close()  # Marks the pool as closed.
             p.join()   # Waits for workers to exit.

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -24,6 +24,13 @@ def test_many_qc():
     if multiprocessing.cpu_count() < 2:
         pytest.skip("Can't test parallel behaviour")
 
+    p = multiprocessing.Pool(2)
+
     with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
-        with multiprocessing.Pool(2) as p:
+        # This `try, finally` pattern mitigates hanging with pytest-cov
+        # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1029057900
+        try:
             p.map(gen_qc, ((i, tmpdir) for i in range(5)))
+        finally:
+            p.close()  # Marks the pool as closed.
+            p.join()   # Waits for workers to exit.


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR fixes the _actual_ root cause of the issue: `multiprocessing.Pool` interacts poorly with `pytest-cov` unless `p.close()` and `p.join()` are called inside a try-finally block.

Note that the `with` context manager isn't good enough for the reasons outlined in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1029070105.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3661.