### PR TITLE
Fix computation of estimated lesion length and diameter

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -9,7 +9,6 @@
 # About the license: see the file LICENSE.TXT
 
 import os
-import math
 import sys
 import pickle
 import shutil
@@ -439,8 +438,7 @@ class AnalyzeLeion:
                 [x_centerline_deriv[iz] * px, y_centerline_deriv[iz] * py, pz]))
 
             # compute the angle between the normal vector of the plane and the vector z
-            angle = np.arccos(np.vdot(tangent_vect, np.array([0, 0, 1])))
-            self.angles[iz] = math.degrees(angle)
+            self.angles[iz] = np.arccos(np.vdot(tangent_vect, np.array([0, 0, 1])))
 
     def label_lesion(self):
         printv('\nLabel connected regions of the masked image...', self.verbose, 'normal')

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -255,7 +255,7 @@ class AnalyzeLeion:
 
     def _measure_diameter(self, im_data, p_lst, idx):
         area_lst = [np.sum(im_data[:, :, zz]) * np.cos(self.angles[zz]) * p_lst[0] * p_lst[1] for zz in range(im_data.shape[2])]
-        diameter_cur = 2 * np.sqrt(max(area_lst) / (4 * np.pi))
+        diameter_cur = 2 * np.sqrt(max(area_lst) / np.pi)
         self.measure_pd.loc[idx, 'max_equivalent_diameter [mm]'] = diameter_cur
         printv('  Max. equivalent diameter : ' + str(np.round(diameter_cur, 2)) + ' mm', self.verbose, type='info')
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [X] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The estimated lesion length and diameter are currently computed incorrectly, because:
- the code wrongly converts some angles from radians to degrees, and
- it uses the wrong formula to compute the radius from the area of a circle.

The angles in question are the angle between the centerline of the spine and a vertical vector at each slice (in the S-I direction). They are computed using `np.arccos`, which works in radians, and only used by `np.cos`, which also works in radians. (Come to think of it, maybe we could skip both `arccos` and `cos`, since they're inverse functions, but then the array couldn't be called something nice and understandable like `angles`.)

Since these are basic computational errors, it's not clear what an appropriate unit test would be. Maybe just the reproduction steps from the linked issue?

Also, I intend to go through the file and apply many little fixes (fix typos, simplify a few computations, etc.), but that should be in a separate refactoring PR. This PR is just a minimal fix to get the formulas correct.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Part of #3633