### PR TITLE
Refactor `-param` parsing to address several bugs

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -55,6 +55,7 @@ class Param:
             if key in ['shift_AP', 'size_AP', 'size_RL', 'size_IS', 'shift_AP_visu']:
                 setattr(self, key, value)
             elif key == 'gaussian_std':
+                # TODO: remove 'gaussian_std' completely for release 6.0
                 printv('WARNING: gaussian_std parameter is currently ignored, '
                        'and will be removed in a later version.', 1, type='warning')
             else:

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+import argparse
 
 import numpy as np
 
@@ -45,15 +46,23 @@ def vertebral_detection_param(string):
     """Custom parser for vertebral_detection advanced parameters."""
     param = param_default.copy()
     for key_value in string.split(','):
-        key, value = key_value.split('=', maxsplit=1)
+        try:
+            key, value = key_value.split('=', maxsplit=1)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f'advanced parameters should be of the form "parameter=value", got "{key_value}" instead')
         if key in param:
-            param[key] = int(value)
+            try:
+                param[key] = int(value)
+            except ValueError:
+                raise argparse.ArgumentTypeError(
+                    f'advanced parameter "{key}" needs an integer value, got "{value}" instead')
         elif key == 'gaussian_std':
             # TODO(issue#3706): remove 'gaussian_std' completely for v5.7
             printv('WARNING: gaussian_std parameter is currently ignored, '
                    'and will be removed in a later version.', 1, type='warning')
         else:
-            raise ValueError(f'Unknown parameter: {key}')
+            raise argparse.ArgumentTypeError(f'Unknown advanced parameter: {key}')
     return param
 
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -272,7 +272,6 @@ def main(argv=None):
         param.update(arguments.param[0])
     remove_temp_files = arguments.r
     clean_labels = arguments.clean_labels
-    laplacian = arguments.laplacian
 
     path_tmp = tmp_create(basename="label_vertebrae")
 
@@ -399,7 +398,7 @@ def main(argv=None):
         printv('.. ' + str(init_disc), verbose)
 
         # apply laplacian filtering
-        if laplacian:
+        if arguments.laplacian:
             printv('\nApply Laplacian filter...', verbose)
             img = Image("data_straightr.nii")
 
@@ -412,7 +411,6 @@ def main(argv=None):
             # smooth data
             img.data = laplacian(img.data, sigmas)
             img.save()
-
 
         # detect vertebral levels on straight spinal cord
         init_disc[1] = init_disc[1] - 1

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -40,7 +40,6 @@ class Param:
         self.size_RL = 1  # window size in RL direction (=x) (in voxel)
         self.size_IS = 19  # window size in IS direction (=z) (in voxel)
         self.shift_AP_visu = 15  # shift AP for displaying disc values
-        self.smooth_factor = [3, 1, 1]
         self.path_qc = None
 
     # update constructor with user's parameters

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -184,12 +184,12 @@ def get_parser():
         '-param',
         metavar=Metavar.list,
         type=vertebral_detection_param,
-        default=param_default.copy(),
-        help=f'Advanced parameters. Assign value with "="; Separate arguments with ","\n'
-             f'  - shift_AP [mm]: AP shift of centerline for disc search (default: {param_default["shift_AP"]})\n'
-             f'  - size_AP [mm]: AP window size for disc search (default: {param_default["size_AP"]})\n'
-             f'  - size_RL [mm]: RL window size for disc search (default: {param_default["size_RL"]})\n'
-             f'  - size_IS [mm]: IS window size for disc search (default: {param_default["size_IS"]})\n',
+        default=','.join(f'{key}={value}' for key, value in param_default.items()),
+        help='Advanced parameters. Assign value with "="; Separate arguments with ","\n'
+             '  - shift_AP [mm]: AP shift of centerline for disc search\n'
+             '  - size_AP [mm]: AP window size for disc search\n'
+             '  - size_RL [mm]: RL window size for disc search\n'
+             '  - size_IS [mm]: IS window size for disc search\n',
     )
     optional.add_argument(
         '-r',

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -40,7 +40,6 @@ class Param:
         self.size_RL = 1  # window size in RL direction (=x) (in voxel)
         self.size_IS = 19  # window size in IS direction (=z) (in voxel)
         self.shift_AP_visu = 15  # shift AP for displaying disc values
-        self.path_qc = None
 
     # update constructor with user's parameters
     def update(self, param_user):
@@ -209,7 +208,6 @@ def get_parser():
         '-qc',
         metavar=Metavar.folder,
         action=ActionCreateFolder,
-        default=param_default.path_qc,
         help="The path where the quality control generated content will be saved."
     )
     optional.add_argument(
@@ -245,7 +243,6 @@ def main(argv=None):
     path_template = os.path.abspath(arguments.t)
     scale_dist = arguments.scale_dist
     path_output = os.path.abspath(arguments.ofolder)
-    param.path_qc = arguments.qc
     if arguments.discfile is not None:
         fname_disc = os.path.abspath(arguments.discfile)
     else:
@@ -470,7 +467,7 @@ def main(argv=None):
         rmtree(path_tmp)
 
     # Generate QC report
-    if param.path_qc is not None:
+    if arguments.qc is not None:
         path_qc = os.path.abspath(arguments.qc)
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -35,26 +35,31 @@ from spinalcordtoolbox.scripts import sct_straighten_spinalcord, sct_apply_trans
 class Param:
     # The constructor
     def __init__(self):
-        self.shift_AP = 32  # 0#32  # shift the centerline towards the spine (in voxel).
-        self.size_AP = 11  # 41#11  # window size in AP direction (=y) (in voxel)
-        self.size_RL = 1  # 1 # window size in RL direction (=x) (in voxel)
+        self.shift_AP = 32  # shift the centerline towards the spine (in voxel).
+        self.size_AP = 11  # window size in AP direction (=y) (in voxel)
+        self.size_RL = 1  # window size in RL direction (=x) (in voxel)
         self.size_IS = 19  # window size in IS direction (=z) (in voxel)
-        self.shift_AP_visu = 15  # 0#15  # shift AP for displaying disc values
-        self.smooth_factor = [3, 1, 1]  # [3, 1, 1]
-        self.gaussian_std = 1.0  # STD of the Gaussian function, centered at the most rostral point of the image, and used to weight C2-C3 disk location finding towards the rostral portion of the FOV. Values to set between 0.1 (strong weighting) and 999 (no weighting).
+        self.shift_AP_visu = 15  # shift AP for displaying disc values
+        self.smooth_factor = [3, 1, 1]
         self.path_qc = None
 
     # update constructor with user's parameters
     def update(self, param_user):
-        list_objects = param_user.split(',')
-        for object in list_objects:
-            if len(object) < 2:
+        for param in param_user.split(','):
+            try:
+                key, value = param.split('=', maxsplit=1)
+                value = int(value)
+            except ValueError:
                 printv('ERROR: Wrong usage.', 1, type='error')
-            obj = object.split('=')
-            if obj[0] == 'gaussian_std':
-                setattr(self, obj[0], float(obj[1]))
+                sys.exit(1)
+            if key in ['shift_AP', 'size_AP', 'size_RL', 'size_IS', 'shift_AP_visu']:
+                setattr(self, key, value)
+            elif key == 'gaussian_std':
+                printv('WARNING: gaussian_std parameter is currently ignored, '
+                       'and will be removed in a later version.', 1, type='warning')
             else:
-                setattr(self, obj[0], int(obj[1]))
+                printv('ERROR: Wrong usage.', 1, type='error')
+                sys.exit(1)
 
 
 def get_parser():
@@ -182,10 +187,6 @@ def get_parser():
              f"  - size_AP [mm]: AP window size for disc search. Default={param_default.size_AP}.\n"
              f"  - size_RL [mm]: RL window size for disc search. Default={param_default.size_RL}.\n"
              f"  - size_IS [mm]: IS window size for disc search. Default={param_default.size_IS}.\n"
-             f"  - gaussian_std [mm]: STD of the Gaussian function, centered at the most rostral point of the "
-             f"image, and used to weight C2-C3 disk location finding towards the rostral portion of the FOV. Values "
-             f"to set between 0.1 (strong weighting) and 999 (no weighting). "
-             f"Default={param_default.gaussian_std}.\n"
     )
     optional.add_argument(
         '-r',

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -126,15 +126,15 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         ax_disc = fig_disc.add_subplot(111)
         # ax_disc = fig_disc.add_axes((0, 0, 1, 1))
         # get percentile for automatic contrast adjustment
-        data_display = np.mean(data[xc - param.size_RL:xc + param.size_RL, :, :], axis=0).transpose()
+        data_display = np.mean(data[xc - param['size_RL']:xc + param['size_RL'], :, :], axis=0).transpose()
         percmin = np.percentile(data_display, 10)
         percmax = np.percentile(data_display, 90)
         # display image
         ax_disc.matshow(data_display, cmap='gray', clim=[percmin, percmax], origin='lower')
         ax_disc.set_title('Anatomical image')
         # ax.autoscale(enable=False)  # to prevent autoscale of axis when displaying plot
-        ax_disc.scatter(yc + param.shift_AP_visu, init_disc[0], c='yellow', s=10)
-        ax_disc.text(yc + param.shift_AP_visu + 4, init_disc[0], str(init_disc[1]) + '/' + str(init_disc[1] + 1),
+        ax_disc.scatter(yc + param['shift_AP_visu'], init_disc[0], c='yellow', s=10)
+        ax_disc.text(yc + param['shift_AP_visu'] + 4, init_disc[0], str(init_disc[1]) + '/' + str(init_disc[1] + 1),
                      verticalalignment='center', horizontalalignment='left', color='pink', fontsize=7)
 
     # FIND DISCS
@@ -161,18 +161,18 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         # find next disc
         # N.B. Do not search for C1/C2 disc (because poorly visible), use template distance instead
         if current_disc != 1:
-            current_z = compute_corr_3d(data, data_template, x=xc, xshift=0, xsize=param.size_RL,
-                                        y=yc, yshift=param.shift_AP, ysize=param.size_AP,
-                                        z=current_z, zshift=0, zsize=param.size_IS,
+            current_z = compute_corr_3d(data, data_template, x=xc, xshift=0, xsize=param['size_RL'],
+                                        y=yc, yshift=param['shift_AP'], ysize=param['size_AP'],
+                                        z=current_z, zshift=0, zsize=param['size_IS'],
                                         xtarget=xct, ytarget=yct, ztarget=current_z_template,
                                         zrange=zrange, verbose=verbose, save_suffix='_disc' + str(current_disc),
                                         path_output=path_output)
 
         # display new disc
         if verbose == 2:
-            ax_disc.scatter(yc + param.shift_AP_visu, current_z, c='yellow', s=10)
-            ax_disc.text(yc + param.shift_AP_visu + 4, current_z, str(current_disc) + '/' + str(current_disc + 1),
-                    verticalalignment='center', horizontalalignment='left', color='yellow', fontsize=7)
+            ax_disc.scatter(yc + param['shift_AP_visu'], current_z, c='yellow', s=10)
+            ax_disc.text(yc + param['shift_AP_visu'] + 4, current_z, str(current_disc) + '/' + str(current_disc + 1),
+                         verticalalignment='center', horizontalalignment='left', color='yellow', fontsize=7)
 
         # append to main list
         if direction == 'superior':

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -82,7 +82,8 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     data = im_input.data
 
     # smooth data
-    data = gaussian_filter(data, param.smooth_factor, output=None, mode="reflect")
+    smooth_factor = [3, 1, 1]
+    data = gaussian_filter(data, smooth_factor, output=None, mode="reflect")
 
     # get dimension of src
     nx, ny, nz = data.shape


### PR DESCRIPTION
## Checklist

#### PR contents

- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR began with the `gaussian_std` parameter in `-param`. This parameter has been silently ignored since it was introduced, and `sct_label_vertebrae` uses `gaussian_std=999` instead.

Getting rid of the Gaussian altogether should have minimal impact, since using 999 is very close to 1.0:
```py3
>>> from scipy.signal import gaussian
>>> gaussian(20*2, std=20*999)[:20]
array([0.99999952, 0.99999957, 0.99999962, 0.99999966, 0.9999997 ,
       0.99999974, 0.99999977, 0.9999998 , 0.99999983, 0.99999986,
       0.99999989, 0.99999991, 0.99999993, 0.99999995, 0.99999996,
       0.99999997, 0.99999998, 0.99999999, 1.        , 1.        ])
```

However, in the course of this PR, several additional bugs were discovered within `-param`:

* Any comma-separated parameters passed to `-param` beyond the first would be ignored.
* The `laplacian` parameter accidentally overwrote the `laplacian` _function_ due to a name collision.
* Several unrelated parameters were grouped into `-param` for no particular reason.
* Errors with `-param` parsing would not display the argparse `-help`

So, `-param` has been refactored further to address these issues.

## Linked issues

Fixes #3698 