### PR TITLE
Attempt to fixup isct_propseg build (but ultimately skip sct_propseg on Windows)

### DIFF
--- a/dev/isct_propseg/CMakeLists.txt
+++ b/dev/isct_propseg/CMakeLists.txt
@@ -55,40 +55,5 @@ aux_source_directory(. SRC_LIST)
 aux_source_directory(./util SRC_LIST)
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 
-TARGET_LINK_LIBRARIES(isct_propseg
-ITKIONIFTI
-ITKIOImageBase
-ITKCommon
-ITKIONRRD
-ITKIOMRC
-ITKIOMeta
-ITKIOPNG
-ITKIOJPEG
-ITKIOIPL
-ITKIOLSM
-ITKIOMesh
-ITKIOTIFF
-ITKIOSiemens
-ITKIOSpatialObjects
-ITKIOVTK
-ITKIOXML
-ITKIOStimulate
-ITKIOBioRad
-ITKIOBMP
-ITKIOCSV
-ITKIOGDCM
-ITKIOGE
-ITKIOGIPL
-ITKIOHDF5
-ITKOptimizers
-ITKIOTransformBase
-vtkalglib
-vtkCommonCore
-vtkCommonDataModel
-vtkIOLegacy
-vtkCommonExecutionModel
-vtkFiltersCore
-vtkFiltersModeling
-vtkIOGeometry
-vtkFiltersGeneral
-)
+target_link_libraries(isct_propseg ${VTK_LIBRARIES} ${ITK_LIBRARIES})
+vtk_module_autoinit(TARGETS isct_propseg MODULES ${VTK_LIBRARIES} )

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -666,7 +666,9 @@ def main(argv=None):
         # This isn't *really* a parsing error, but it feels a little more official to display the help with this error
         parser.error("`sct_propseg` is not currently supported on native Windows installations. \n\n"
                      "For spinal cord segmentation, please migrate to the new and improved `sct_deepseg_sc` tool, "
-                     "or consider using WSL to install SCT instead.")
+                     "or consider using WSL to install SCT instead.\n\n"
+                     "For further updates on `sct_propseg` Windows support, please visit:\n"
+                     "https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3694")
     arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_loglevel(verbose=verbose)

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -662,6 +662,11 @@ def propseg(img_input, options_dict):
 
 def main(argv=None):
     parser = get_parser()
+    if sys.platform.startswith("win32"):
+        # This isn't *really* a parsing error, but it feels a little more official to display the help with this error
+        parser.error("`sct_propseg` is not currently supported on native Windows installations. \n\n"
+                     "For spinal cord segmentation, please migrate to the new and improved `sct_deepseg_sc` tool, "
+                     "or consider using WSL to install SCT instead.")
     arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_loglevel(verbose=verbose)

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import logging
 
@@ -9,6 +10,7 @@ from spinalcordtoolbox.scripts import sct_propseg
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
 @pytest.mark.sct_testing
 @pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_propseg_check_dice_coefficient_against_groundtruth():
@@ -27,6 +29,7 @@ def test_sct_propseg_check_dice_coefficient_against_groundtruth():
     assert dice_segmentation > 0.9
 
 
+@pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
 @pytest.mark.sct_testing
 def test_isct_propseg_compatibility():
     # TODO: Move this check to `sct_check_dependencies`. (It was in `sct_testing`, so it is put here for now.)
@@ -38,6 +41,7 @@ def test_isct_propseg_compatibility():
         'administrators.'
 
 
+@pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
 def test_sct_propseg_o_flag(tmp_path):
     argv = ['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-ofolder', str(tmp_path), '-o', 'test_seg.nii.gz']
     sct_propseg.main(argv)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR tries to apply a fix to `CMakeLists.txt` which helps with building `isct_propseg` on Windows. While the fix does address _some_ errors, it doesn't address all of them.

So, ultimately this PR then tries to skip `sct_propseg` entirely, redirecting users to `sct_deepseg_sc` instead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses #3694.