### PR TITLE
Update documentation build instructions

### DIFF
--- a/documentation/README.rst
+++ b/documentation/README.rst
@@ -43,6 +43,6 @@ That's pretty standard:
 
 .. code:: sh
 
-   make --directory=${SCT_SOURCE_DIR}/documentation/sphinx html
+   make --directory=${SCT_SOURCE_DIR}/documentation/ html
 
 


### PR DESCRIPTION
The `sphinx/` subdirectory of `documentation/` no longer exists.