### PR TITLE
Skip checking `isct_propseg` on Windows

### DIFF
--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -315,9 +315,9 @@ def main(argv=None):
 
     # check PropSeg compatibility with OS
     if sys.platform.startswith('win32'):
-        pass  # sct_propseg is not yet supported on Windows (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3694)
+        print_line("Skipping PropSeg compatibility check ")
+        print("[  ] (Not supported on Windows)")
     else:
-        print_line('Check PropSeg compatibility with OS ')
         status, output = run_proc('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
         if status in (0, 1):
             print_ok()

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -313,16 +313,19 @@ def main(argv=None):
         print((status, output), '\n')
 
     # check PropSeg compatibility with OS
-    print_line('Check PropSeg compatibility with OS ')
-    status, output = run_proc('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
-    if status in (0, 1):
-        print_ok()
+    if sys.platform.startswith('win32'):
+        pass  # sct_propseg is not yet supported on Windows (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3694)
     else:
-        print_fail()
-        print(output)
-        e = 1
-    if complete_test:
-        print((status, output), '\n')
+        print_line('Check PropSeg compatibility with OS ')
+        status, output = run_proc('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
+        if status in (0, 1):
+            print_ok()
+        else:
+            print_fail()
+            print(output)
+            e = 1
+        if complete_test:
+            print((status, output), '\n')
 
     print_line('Check if figure can be opened with matplotlib')
     try:

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -316,7 +316,7 @@ def main(argv=None):
     # check PropSeg compatibility with OS
     if sys.platform.startswith('win32'):
         print_line("Skipping PropSeg compatibility check ")
-        print("[  ] (Not supported on Windows)")
+        print("[  ] (Not supported on 'native' Windows (without WSL))")
     else:
         status, output = run_proc('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
         if status in (0, 1):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

If `sct_propseg` is called on Windows, users will be directed to `sct_deepseg_sc` instead, because the underlying `isct_propseg` binary isn't yet supported on Windows. (See also: #3694, #3717)

So, there is no need to test running `isct_propseg` via `sct_check_dependencies`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3740#issuecomment-1088685708.