### PR TITLE
Refactor `sys.platform` checks to include Windows and use `.startswith()` idiom

### DIFF
--- a/spinalcordtoolbox/gui/base.py
+++ b/spinalcordtoolbox/gui/base.py
@@ -225,7 +225,7 @@ class BaseDialog(QtWidgets.QWidget):
         """
         ctrl_layout = QtWidgets.QHBoxLayout()
 
-        if sys.platform.lower() == 'darwin':
+        if sys.platform.startswith('darwin'):
             cmd_key = 'Cmd'
         else:
             cmd_key = 'Ctrl'

--- a/spinalcordtoolbox/gui/centerline.py
+++ b/spinalcordtoolbox/gui/centerline.py
@@ -154,7 +154,7 @@ class Centerline(base.BaseDialog):
         group.setFlat(True)
         layout = QtWidgets.QHBoxLayout()
 
-        if sys.platform.lower() == 'darwin':
+        if sys.platform.startswith('darwin'):
             cmd_key = 'Cmd'
         else:
             cmd_key = 'Ctrl'
@@ -187,7 +187,7 @@ class Centerline(base.BaseDialog):
     def _init_footer(self, parent):
         ctrl_layout = super(Centerline, self)._init_footer(parent)
 
-        if sys.platform.lower() == 'darwin':
+        if sys.platform.startswith('darwin'):
             cmd_key = 'Cmd'
         else:
             cmd_key = 'Ctrl'

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -22,7 +22,7 @@ import portalocker
 
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.reports.slice as qcslice
-from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, copy, extract_fname
+from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, copy, extract_fname, display_open
 
 logger = logging.getLogger(__name__)
 
@@ -734,26 +734,7 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
             copyfile(path_img, qc_param.abs_overlay_img_path())
 
     logger.info('Successfully generated the QC results in %s', qc_param.qc_results)
-    logger.info('Use the following command to see the results in a browser:')
-    try:
-        from sys import platform as _platform
-        if _platform == "linux" or _platform == "linux2":
-            # If user runs SCT within the official Docker distribution, the command xdg-open will not be working therefore
-            # we prefer to instruct the user to manually open the generated html file.
-            try:
-                # if user runs SCT within the official Docker distribution, the variable below is defined. More info at:
-                # https://github.com/neuropoly/sct_docker/blob/master/sct_docker.py#L84
-                os.environ["DOCKER"]
-                logger.info('please go to "%s/" and double click on the "index.html" file', path_qc)
-            except KeyError:
-                logger.info('xdg-open "%s/index.html"', path_qc)
-
-        elif _platform == "darwin":
-            logger.info('open "%s/index.html"', path_qc)
-        else:
-            logger.info('open file "%s/index.html"', path_qc)
-    except ImportError:
-        print("WARNING! Platform undetectable.")
+    display_open(file=os.path.join(path_qc, "index.html"), message="To see the results in a browser")
 
 
 def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args=None, path_qc=None,

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -235,6 +235,8 @@ def main(argv=None):
         os_running = 'linux'
     elif sys.platform.startswith('win32'):
         os_running = 'windows'
+    else:
+        os_running = 'unknown'
 
     print('OS: ' + os_running + ' (' + platform.platform() + ')')
     print('CPU cores: Available: {}, Used by ITK functions: {}'.format(psutil.cpu_count(), int(os.getenv('ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS', 0))))

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -340,7 +340,7 @@ def main(argv=None):
         print(err)
 
     print_line('Check if figure can be opened with PyQt')
-    if sys.platform == "linux" and 'DISPLAY' not in os.environ:
+    if sys.platform.startswith("linux") and 'DISPLAY' not in os.environ:
         print_fail(" ($DISPLAY not set on X11-supporting system)")
     else:
         try:

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -212,7 +212,6 @@ def main(argv=None):
     # initialization
     install_software = 0
     e = 0
-    os_running = 'not identified'
 
     # complete test
     if complete_test:

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -536,7 +536,7 @@ def main(argv=None):
                           status_message + timing_message)
 
     display_open(file=os.path.join(path_qc, "index.html"),
-                 message="To open the Quality Control (QC) report on a web-browser")
+                 message="To open the Quality Control (QC) report in a web-browser")
 
     if arguments.zip:
         file_zip = 'sct_run_batch_{}'.format(time.strftime('%Y%m%d%H%M%S'))

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -33,7 +33,7 @@ from textwrap import dedent
 import yaml
 import psutil
 
-from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_open
 from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__, __sct_dir__, set_loglevel
 from spinalcordtoolbox.utils.fs import Tee
 
@@ -535,10 +535,8 @@ def main(argv=None):
         send_notification('sct_run_batch: Run completed',
                           status_message + timing_message)
 
-    open_cmd = 'open' if sys.platform == 'darwin' else 'xdg-open'
-
-    print(f'To open the Quality Control (QC) report on a web-browser, run the following:\n'
-          f'{open_cmd} {os.path.join(path_qc, "index.html")}')
+    display_open(file=os.path.join(path_qc, "index.html"),
+                 message="To open the Quality Control (QC) report on a web-browser")
 
     if arguments.zip:
         file_zip = 'sct_run_batch_{}'.format(time.strftime('%Y%m%d%H%M%S'))

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -33,10 +33,10 @@ def display_open(file, message="\nDone! To view results"):
 
     if cmd_open:
         printv(f'{message}, type:')
-        printv(f"{cmd_open} {file}\n", verbose=1, type='info')
+        printv(f"{cmd_open} {file}\n", type='info')
     else:
         printv(f'{message}, open the following file:')
-        printv(f"{file}\n", verbose=1, type='info')
+        printv(f"{file}\n", type='info')
 
 
 def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='', verbose=1):

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -17,17 +17,26 @@ from .sys import check_exe, printv, removesuffix
 logger = logging.getLogger(__name__)
 
 
-def display_open(file):
+def display_open(file, message="\nDone! To view results"):
     """Print the syntax to open a file based on the platform."""
-    if sys.platform == 'linux':
-        printv('\nDone! To view results, type:')
-        printv('xdg-open ' + file + '\n', verbose=1, type='info')
-    elif sys.platform == 'darwin':
-        printv('\nDone! To view results, type:')
-        printv('open ' + file + '\n', verbose=1, type='info')
+    cmd_open = None
+    if sys.platform.startswith('linux'):
+        # If user runs SCT within the official Docker distribution, or in WSL, then the command xdg-open will not be
+        # working, therefore we prefer to instruct the user to manually open the file.
+        # Source for WSL environment variables: https://stackoverflow.com/a/61036356
+        if "DOCKER" not in os.environ and "IS_WSL" not in os.environ and "WSL_DISTRO_NAME" not in os.environ:
+            cmd_open = 'xdg-open'
+    elif sys.platform.startswith('darwin'):
+        cmd_open = 'open'
+    elif sys.platform.startswith('win32'):
+        cmd_open = 'start'
+
+    if cmd_open:
+        printv(f'{message}, type:')
+        printv(f"{cmd_open} {file}\n", verbose=1, type='info')
     else:
-        printv('\nDone! To view results, open the following file:')
-        printv(file + '\n', verbose=1, type='info')
+        printv(f'{message}, open the following file:')
+        printv(f"{file}\n", verbose=1, type='info')
 
 
 def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='', verbose=1):

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -17,7 +17,7 @@ from .sys import check_exe, printv, removesuffix
 logger = logging.getLogger(__name__)
 
 
-def display_open(file, message="\nDone! To view results"):
+def display_open(file, message="Done! To view results"):
     """Print the syntax to open a file based on the platform."""
     cmd_open = None
     if sys.platform.startswith('linux'):
@@ -32,10 +32,10 @@ def display_open(file, message="\nDone! To view results"):
         cmd_open = 'start'
 
     if cmd_open:
-        printv(f'{message}, type:')
+        printv(f'\n{message}, type:')
         printv(f"{cmd_open} {file}\n", type='info')
     else:
-        printv(f'{message}, open the following file:')
+        printv(f'\n{message}, open the following file:')
         printv(f"{file}\n", type='info')
 
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -533,5 +533,5 @@ def __get_git_origin(path_to_git_folder=None):
 __sct_dir__ = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 __version__ = _version_string()
 __data_dir__ = os.path.join(__sct_dir__, 'data')
-__bin_dir__ = os.path.join(__sct_dir__, 'venv_sct', 'Scripts') if sys.platform == 'win32' else os.path.join(__sct_dir__, 'bin')
+__bin_dir__ = os.path.join(__sct_dir__, 'venv_sct', 'Scripts') if sys.platform.startswith('win32') else os.path.join(__sct_dir__, 'bin')
 __deepseg_dir__ = os.path.join(__data_dir__, 'deepseg_models')

--- a/testing/cli/test_cli_sct_dmri_display_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_display_bvecs.py
@@ -17,7 +17,8 @@ def test_sct_dmri_display_bvecs_png_exists():
     os.unlink('bvecs.png')
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Script uses pyplot.show, causing macOS 10.15 CI runners to hang.")
+@pytest.mark.skipif(sys.platform.startswith("darwin"),
+                    reason="Script uses pyplot.show, causing macOS 10.15 CI runners to hang.")
 # FIXME: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3388
 def test_sct_dmri_display_bvecs_png_exists_bvec_bval_inputs():
     """Run the CLI script."""


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR looks for all instances where we check `sys.platform` to make sure that:

* Windows platforms are included whenever necessary
* `sys.platform ==` is discarded in favor of `sys.platform.startswith()`

In the process of doing this, I noticed that there were a few spots where the same check (determining whether to use `xdg-open` or `open` for QC reports, etc.) was being repeated across multiple locations. But, we already have an existing function for this called `display_open()` that we can re-use in each place.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3742.