### PR TITLE
Set a more permissive threshold for reading the qform

### DIFF
--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -13,9 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class BoundingBox(object):
-    """
-    """
-    def __init__(self, xmin=None, xmax=None, ymin=None, ymax=None, zmin=None, zmax=None):
+    def __init__(self, xmin, xmax, ymin, ymax, zmin, zmax):
         self.xmin = xmin
         self.xmax = xmax
         self.ymin = ymin
@@ -30,7 +28,12 @@ class ImageCropper(object):
         :param img_in:
         """
         self.img_in = img_in
-        self.bbox = BoundingBox()
+        # the default is to keep the whole image
+        self.bbox = BoundingBox(
+            0, img_in.dim[0]-1,
+            0, img_in.dim[1]-1,
+            0, img_in.dim[2]-1,
+        )
 
     def crop(self, background=None):
         """

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -106,7 +106,7 @@ class ImageCropper(object):
         if not len(img_ref.data.shape) == len(self.img_in.data.shape):
             logger.error("Inconsistent dimensions: n_dim(img_ref)={}; n_dim(img_in)={}"
                          .format(len(img_ref.data.shape), len(self.img_in.data.shape)))
-            raise Exception(ValueError)
+            raise ValueError('Inconsistent dimensions')
         # Fill reference data with ones
         img_ref.data[:] = 1
         # Resample new image (in reference coordinates) into input image

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -23,7 +23,7 @@ class BoundingBox(object):
         self.zmin = zmin
         self.zmax = zmax
 
-    def get_minmax(self, img=None):
+    def get_minmax(self, img):
         """
         Get voxel-based bounding box from coordinates. Replaces '-1' with max dim along each axis, '-2' with max dim
         minus 1, etc.
@@ -31,34 +31,26 @@ class BoundingBox(object):
         :param img: Image object to get dimensions
         :return:
         """
-        def _get_min_value(input):
-            if input is None:
-                return 0
-            else:
-                return input
+        def _get_min_value(val):
+            if val is None:
+                val = 0
+            return val
 
-        def _get_max_value(input, dim):
-            # If empty, return maximum dimension (i.e. no change)
-            if input is None:
-                return dim
-            # If input is "-1", return maximum dimension (i.e. no change). If input is "-2", returns maximum
-            # dimension minus one, etc.
-            elif np.sign(input) == -1:
-                return input + dim
-            # If user specified a non-negative value, use that
-            else:
-                return input
+        def _get_max_value(val, dim):
+            if val is None:
+                val = dim
+            elif val < 0:
+                val += dim
+            return val
 
-        xyz_to_num = {'x': 0, 'y': 1, 'z': 2}
-        bbox_voxel = BoundingBox()
-        for attr, value in self.__dict__.items():
-            if attr[-3:] == 'min':
-                bbox_voxel.__setattr__(attr, _get_min_value(self.__getattribute__(attr)))
-            elif attr[-3:] == 'max':
-                bbox_voxel.__setattr__(attr, _get_max_value(self.__getattribute__(attr), img.dim[xyz_to_num[attr[0]]]))
-            else:
-                raise Exception(ValueError)
-        return bbox_voxel
+        return BoundingBox(
+            xmin=_get_min_value(self.xmin),
+            ymin=_get_min_value(self.ymin),
+            zmin=_get_min_value(self.zmin),
+            xmax=_get_max_value(self.xmax, img.dim[0]),
+            ymax=_get_max_value(self.ymax, img.dim[1]),
+            zmax=_get_max_value(self.zmax, img.dim[2]),
+        )
 
 
 class ImageCropper(object):

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -57,11 +57,13 @@ class ImageCropper(object):
             # set a more permissive threshold for reading the qform
             # (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703 for details)
             img_out.hdr.quaternion_threshold = -1e-6
-            # adapt the origin in the sform and qform matrix
+            # adapt the origin in the qform matrix
             new_origin = np.dot(img_out.hdr.get_qform(), [bbox.xmin, bbox.ymin, bbox.zmin, 1])
             img_out.hdr.structarr['qoffset_x'] = new_origin[0]
             img_out.hdr.structarr['qoffset_y'] = new_origin[1]
             img_out.hdr.structarr['qoffset_z'] = new_origin[2]
+            # adapt the origin in the sform matrix
+            new_origin = np.dot(img_out.hdr.get_sform(), [bbox.xmin, bbox.ymin, bbox.zmin, 1])
             img_out.hdr.structarr['srow_x'][-1] = new_origin[0]
             img_out.hdr.structarr['srow_y'][-1] = new_origin[1]
             img_out.hdr.structarr['srow_z'][-1] = new_origin[2]

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -54,6 +54,9 @@ class ImageCropper(object):
             data_crop = self.img_in.data[bbox.xmin:bbox.xmax+1, bbox.ymin:bbox.ymax+1, bbox.zmin:bbox.zmax+1]
             img_out = Image(param=data_crop, hdr=self.img_in.hdr)
 
+            # set a more permissive threshold for reading the qform
+            # (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703 for details)
+            img_out.hdr.quaternion_threshold = -1e-6
             # adapt the origin in the sform and qform matrix
             new_origin = np.dot(img_out.hdr.get_qform(), [bbox.xmin, bbox.ymin, bbox.zmin, 1])
             img_out.hdr.structarr['qoffset_x'] = new_origin[0]

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -54,18 +54,12 @@ class BoundingBox(object):
 
 
 class ImageCropper(object):
-    def __init__(self, img_in, mask=None, bbox=BoundingBox(), ref=None):
+    def __init__(self, img_in):
         """
-
         :param img_in:
-        :param mask:
-        :param bbox: BoundingBox object with min and max values for each dimension, used for cropping.
-        :param ref:
         """
         self.img_in = img_in
-        self.mask = mask
-        self.bbox = bbox
-        self.ref = ref
+        self.bbox = BoundingBox()
 
     def crop(self, background=None):
         """

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -28,12 +28,8 @@ class ImageCropper(object):
         :param img_in:
         """
         self.img_in = img_in
-        # the default is to keep the whole image
-        self.bbox = BoundingBox(
-            0, img_in.dim[0]-1,
-            0, img_in.dim[1]-1,
-            0, img_in.dim[2]-1,
-        )
+        # Call one of the `get_bbox_from_*` methods to set the bounding box.
+        self.bbox = None
 
     def crop(self, background=None):
         """
@@ -44,7 +40,10 @@ class ImageCropper(object):
         :return Image: img_out
         """
         bbox = self.bbox
-
+        if bbox is None:
+            raise ValueError(
+                'Use one of the `get_bbox_from_*` methods to set the bounding '
+                'box before calling `ImageCropper.crop()`.')
         logger.info("Bounding box: x=[{}, {}], y=[{}, {}], z=[{}, {}]"
                     .format(bbox.xmin, bbox.xmax+1, bbox.ymin, bbox.ymax+1, bbox.zmin, bbox.zmax+1))
 

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -96,9 +96,10 @@ class ImageCropper(object):
         """
         data_nonzero = np.nonzero(img_mask.data)
         # find min and max boundaries of the mask
-        dim = len(data_nonzero)
-        self.bbox.xmin, self.bbox.ymin, self.bbox.zmin = [min(data_nonzero[i]) for i in range(dim)]
-        self.bbox.xmax, self.bbox.ymax, self.bbox.zmax = [max(data_nonzero[i]) for i in range(dim)]
+        self.bbox = BoundingBox(
+            min(data_nonzero[0]), max(data_nonzero[0]),
+            min(data_nonzero[1]), max(data_nonzero[1]),
+            min(data_nonzero[2]), max(data_nonzero[2]))
 
     def get_bbox_from_ref(self, img_ref):
         """
@@ -145,15 +146,11 @@ class ImageCropper(object):
         img_labels.change_orientation(native_orientation)
         cropping_coord = img_labels.getNonZeroCoordinates(sorting='value')
         # Since there is no cropping along the R-L direction, xmin/xmax are based on image dimension
-        self.bbox.xmin, self.bbox.ymin, self.bbox.zmin = (
-            0,
+        self.bbox = BoundingBox(
+            0, img_labels.dim[0],
             min(cropping_coord[0].y, cropping_coord[1].y),
-            min(cropping_coord[0].z, cropping_coord[1].z),
-        )
-        self.bbox.xmax, self.bbox.ymax, self.bbox.zmax = (
-            img_labels.dim[0],
             max(cropping_coord[0].y, cropping_coord[1].y),
-            max(cropping_coord[0].z, cropping_coord[1].z),
-        )
+            min(cropping_coord[0].z, cropping_coord[1].z),
+            max(cropping_coord[0].z, cropping_coord[1].z))
         # Put back input image in native orientation
         self.img_in.change_orientation(native_orientation)

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -23,35 +23,6 @@ class BoundingBox(object):
         self.zmin = zmin
         self.zmax = zmax
 
-    def get_minmax(self, img):
-        """
-        Get voxel-based bounding box from coordinates. Replaces '-1' with max dim along each axis, '-2' with max dim
-        minus 1, etc.
-
-        :param img: Image object to get dimensions
-        :return:
-        """
-        def _get_min_value(val):
-            if val is None:
-                val = 0
-            return val
-
-        def _get_max_value(val, dim):
-            if val is None:
-                val = dim
-            elif val < 0:
-                val += dim
-            return val
-
-        return BoundingBox(
-            xmin=_get_min_value(self.xmin),
-            ymin=_get_min_value(self.ymin),
-            zmin=_get_min_value(self.zmin),
-            xmax=_get_max_value(self.xmax, img.dim[0]),
-            ymax=_get_max_value(self.ymax, img.dim[1]),
-            zmax=_get_max_value(self.zmax, img.dim[2]),
-        )
-
 
 class ImageCropper(object):
     def __init__(self, img_in):
@@ -99,11 +70,18 @@ class ImageCropper(object):
 
         return img_out
 
-    def get_bbox_from_minmax(self, bbox=None):
+    def get_bbox_from_minmax(self, xmin, xmax, ymin, ymax, zmin, zmax):
         """
-        Get voxel bounding box from xmin, xmax, ymin, ymax, zmin, zmax user input
+        Get voxel bounding box from xmin, xmax, ymin, ymax, zmin, zmax user input.
+        Replaces '-1' with max dim along each axis, '-2' with max dim minus 1, etc.
         """
-        self.bbox = bbox.get_minmax(img=self.img_in)
+        if xmax < 0:
+            xmax += self.img_in.dim[0]
+        if ymax < 0:
+            ymax += self.img_in.dim[1]
+        if zmax < 0:
+            zmax += self.img_in.dim[2]
+        self.bbox = BoundingBox(xmin, xmax, ymin, ymax, zmin, zmax)
 
     def get_bbox_from_mask(self, img_mask):
         """

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -9,7 +9,6 @@
 # About the license: see the file LICENSE.TXT
 
 import sys
-import os
 
 from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
 from spinalcordtoolbox.image import Image, add_suffix

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -10,7 +10,7 @@
 
 import sys
 
-from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
+from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 
@@ -156,10 +156,9 @@ def main(argv=None):
         cropper.get_bbox_from_ref(Image(arguments.ref))
     else:
         cropper.get_bbox_from_minmax(
-            BoundingBox(arguments.xmin, arguments.xmax,
-                        arguments.ymin, arguments.ymax,
-                        arguments.zmin, arguments.zmax)
-        )
+            arguments.xmin, arguments.xmax,
+            arguments.ymin, arguments.ymax,
+            arguments.zmin, arguments.zmax)
 
     # Crop image
     img_crop = cropper.crop(background=arguments.b)

--- a/testing/batch_processing/test_batch_processing.py
+++ b/testing/batch_processing/test_batch_processing.py
@@ -46,7 +46,9 @@ def test_batch_processing_results(csv_filepath, row, column):
     # These values should be considered a failure, but because the cause is known, skipping the
     # test saves us the intermittent interruptions on PRs until we can fix the issue.
     # TODO: Remove this skip once we can implement a long-term workaround for the issue
-    if actual_value in [0.780605541771859, 0.77461183127549, 54.42425823974834]:
+    if (actual_value == pytest.approx(0.780605541771859) or
+            actual_value == pytest.approx(0.77461183127549) or
+            actual_value == pytest.approx(54.42425823974834)):
         pytest.skip("Values associated with Xeon(R) Platinum 8370C CPU detected!")
     else:
         assert actual_value == pytest.approx(expected_value)  # Default rel_tolerance: 1e-6

--- a/testing/cli/test_cli_sct_crop_image.py
+++ b/testing/cli/test_cli_sct_crop_image.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
     ('t2/t2.nii.gz', 't2_crop_xyz.nii', ['-xmin', '1', '-xmax', '-3', '-ymin', '2', '-ymax', '10'], (57, 9, 52)),
     ('t2/t2.nii.gz', 't2_crop_mask.nii', ['-m', 't2/t2_seg-manual.nii.gz'], (11, 55, 13)),
     ('t2/t2.nii.gz', 't2_crop_ref.nii', ['-ref', 'mt/mt0.nii.gz'], (37, 55, 34)),
+    ('qform/bad_quaternion.nii.gz', 'bad_quaternion_crop.nii', [], (2, 3, 4)),
 ])
 def test_sct_crop_image_output_has_expected_dimensions(path_in, path_out, remaining_args, expected_dim):
     """Run the CLI script and verify cropped image has the expected dimensions."""

--- a/testing/cli/test_cli_sct_crop_image.py
+++ b/testing/cli/test_cli_sct_crop_image.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
     ('t2/t2.nii.gz', 't2_crop_xyz.nii', ['-xmin', '1', '-xmax', '-3', '-ymin', '2', '-ymax', '10'], (57, 9, 52)),
     ('t2/t2.nii.gz', 't2_crop_mask.nii', ['-m', 't2/t2_seg-manual.nii.gz'], (11, 55, 13)),
     ('t2/t2.nii.gz', 't2_crop_ref.nii', ['-ref', 'mt/mt0.nii.gz'], (37, 55, 34)),
-    ('qform/bad_quaternion.nii.gz', 'bad_quaternion_crop.nii', [], (2, 3, 4)),
 ])
 def test_sct_crop_image_output_has_expected_dimensions(path_in, path_out, remaining_args, expected_dim):
     """Run the CLI script and verify cropped image has the expected dimensions."""
@@ -21,3 +20,26 @@ def test_sct_crop_image_output_has_expected_dimensions(path_in, path_out, remain
     # The last 5 dimension values [nt, px, py, pz, pt] should remain the same, so grab them from the input image
     expected_dim += Image(path_in).dim[3:8]
     assert Image(path_out).dim == expected_dim
+
+
+@pytest.mark.sct_testing
+@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
+def test_sct_crop_image_permissive_qform(tmp_path):
+    """
+    Check that we can load an image with a slightly bad qform.
+    (That is, an image where the sum-of-squares the of the
+    b, c, d quaternions is slightly larger than 1.)
+    """
+    # Prepare the image
+    im = Image('t2/t2.nii.gz')
+    im.header['quatern_b'] = 1.0
+    im.header['quatern_c'] = 0.0
+    im.header['quatern_d'] = 0.9e-3
+    im.save(tmp_path / 'bad_quaternion.nii.gz')
+    # Try cropping it
+    sct_crop_image.main(argv=[
+        '-i', str(tmp_path / 'bad_quaternion.nii.gz'),
+        '-o', str(tmp_path / 'cropped.nii.gz'),
+        ])
+    Image(str(tmp_path / 'cropped.nii.gz'))
+    # We're happy if no exceptions are raised


### PR DESCRIPTION
## Description
When cropping a nifti file which has a slightly bad qform (which could happen because of rounding errors), nibabel throws an error. This PR implements proposed solution number 3 from issue #3703, which is to set the image's `quaternion_threshold` to `-1e-6` before getting its qform. (This value comes from a suggestion in https://github.com/nipy/nibabel/issues/626 and seems reasonable, see [this comment](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703#issuecomment-1049221586).)

The PR also adds a test case for an image with a slightly bad qform, which fails before the main code change, and passes afterwards. See https://github.com/spinalcordtoolbox/sct_testing_data/pull/10 for the actual test file. Either this PR can wait until we do a new release of `sct_testing_data`, or else we can split off the new test case as a future PR.

And while I was editing the code, I took the opportunity to simplify the code surrounding `BoundingBox` (with individual refactoring steps broken down as separate commits).

## Linked issues
Fixes #3703