### PR TITLE
Output a better error message when the initial disc is invalid

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -431,8 +431,12 @@ def main(argv=None):
 
         # detect vertebral levels on straight spinal cord
         init_disc[1] = init_disc[1] - 1
-        vertebral_detection('data_straightr.nii', 'segmentation_straight.nii', contrast, arguments.param, init_disc=init_disc,
-                            verbose=verbose, path_template=path_template, path_output=path_output, scale_dist=scale_dist)
+        try:
+            vertebral_detection('data_straightr.nii', 'segmentation_straight.nii', contrast, arguments.param, init_disc=init_disc,
+                                verbose=verbose, path_template=path_template, path_output=path_output, scale_dist=scale_dist)
+        except ValueError as e:
+            printv(f'Vertebral detection failed: {e}', 1, 'error')
+            sys.exit(1)
 
     # un-straighten labeled spinal cord
     printv('\nUn-straighten labeling...', verbose)

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -19,7 +19,7 @@ import numpy as np
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.vertebrae.core import (
     get_z_and_disc_values_from_label, vertebral_detection, expand_labels,
-    crop_labels, label_vert)
+    crop_labels, label_vert, EmptyArrayError)
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
@@ -411,7 +411,11 @@ def main(argv=None):
                                 '-v', '0'])
         # get z value and disk value to initialize labeling
         printv('\nGet z and disc values from straight label...', verbose)
-        init_disc = get_z_and_disc_values_from_label('labelz_straight.nii.gz')
+        try:
+            init_disc = get_z_and_disc_values_from_label('labelz_straight.nii.gz')
+        except EmptyArrayError:
+            printv('Vertebral detection failed: Missing label or zero label for initial disc.', 1, 'error')
+            sys.exit(1)
         printv('.. ' + str(init_disc), verbose)
 
         # apply laplacian filtering

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -141,8 +141,8 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         logger.info('Current disc: %s (z=%s). Direction: %s', current_value, current_z, direction)
         try:
             # get z corresponding to current disc on template
-            current_z_template = list_disc_z_template[current_value]
-        except IndexError:
+            current_z_template = list_disc_z_template[list_disc_value_template.index(current_value)]
+        except (ValueError, IndexError):
             # in case reached the bottom (see issue #849)
             logger.warning('Reached the bottom of the template. Stop searching.')
             break

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -86,7 +86,7 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     xct = int(np.round(nxt / 2))  # direction RL
     yct = int(np.round(nyt / 2))  # direction AP
 
-    # define mean distance (in voxel) between adjacent discs: [C1/C2 -> C2/C3], [C2/C3 -> C4/C5], ..., [L1/L2 -> L2/L3]
+    # define mean distance (in voxel) between adjacent discs: [C1/C2 -> C2/C3], [C2/C3 -> C3/C4], ..., [L1/L2 -> L2/L3]
     centerline_level = data_disc_template[xct, yct, :]
     # attribute value to each disc. Starts from max level, then decrease.
     min_level = centerline_level[centerline_level.nonzero()].min()

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -130,9 +130,7 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     # FIND DISCS
     # ===========================================================================
     logger.info('Detect intervertebral discs...')
-    # assign initial z and disc
-    current_z = init_disc[0]
-    current_disc = init_disc[1]
+    current_z, current_value = init_disc
     # create list for z and disc
     list_disc_z = []
     list_disc_value = []
@@ -140,39 +138,39 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     direction = 'superior'
     search_next_disc = True
     while search_next_disc:
-        logger.info('Current disc: %s (z=%s). Direction: %s', current_disc, current_z, direction)
+        logger.info('Current disc: %s (z=%s). Direction: %s', current_value, current_z, direction)
         try:
             # get z corresponding to current disc on template
-            current_z_template = list_disc_z_template[current_disc]
-        except:
+            current_z_template = list_disc_z_template[current_value]
+        except IndexError:
             # in case reached the bottom (see issue #849)
             logger.warning('Reached the bottom of the template. Stop searching.')
             break
         # find next disc
         # N.B. Do not search for C1/C2 disc (because poorly visible), use template distance instead
-        if current_disc != 1:
+        if current_value != 1:
             current_z = compute_corr_3d(data, data_template, x=xc, xshift=0, xsize=param['size_RL'],
                                         y=yc, yshift=param['shift_AP'], ysize=param['size_AP'],
                                         z=current_z, zshift=0, zsize=param['size_IS'],
                                         xtarget=xct, ytarget=yct, ztarget=current_z_template,
-                                        zrange=zrange, verbose=verbose, save_suffix='_disc' + str(current_disc),
+                                        zrange=zrange, verbose=verbose, save_suffix='_disc' + str(current_value),
                                         path_output=path_output)
 
         # display new disc
         if verbose == 2:
             ax_disc.scatter(yc + param['shift_AP_visu'], current_z, c='yellow', s=10)
-            ax_disc.text(yc + param['shift_AP_visu'] + 4, current_z, str(current_disc) + '/' + str(current_disc + 1),
+            ax_disc.text(yc + param['shift_AP_visu'] + 4, current_z, str(current_value) + '/' + str(current_value + 1),
                          verticalalignment='center', horizontalalignment='left', color='yellow', fontsize=7)
 
         # append to main list
         if direction == 'superior':
             # append at the beginning
             list_disc_z.insert(0, current_z)
-            list_disc_value.insert(0, current_disc)
+            list_disc_value.insert(0, current_value)
         elif direction == 'inferior':
             # append at the end
             list_disc_z.append(current_z)
-            list_disc_value.append(current_disc)
+            list_disc_value.append(current_value)
 
         # adjust correcting factor based on already-identified discs
         if len(list_disc_z) > 1:
@@ -194,28 +192,28 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         # assign new current_z and disc value
         if direction == 'superior':
             try:
-                approx_distance_to_next_disc = list_distance[list_disc_value_template.index(current_disc - 1)]
+                approx_distance_to_next_disc = list_distance[list_disc_value_template.index(current_value - 1)]
             except ValueError:
                 logger.warning('Disc value not included in template. Using previously-calculated distance: %s', approx_distance_to_next_disc)
             # assign new current_z and disc value
             current_z = current_z + approx_distance_to_next_disc
-            current_disc = current_disc - 1
+            current_value = current_value - 1
         elif direction == 'inferior':
             try:
-                approx_distance_to_next_disc = list_distance[list_disc_value_template.index(current_disc)]
+                approx_distance_to_next_disc = list_distance[list_disc_value_template.index(current_value)]
             except ValueError:
                 logger.warning('Disc value not included in template. Using previously-calculated distance: %s', approx_distance_to_next_disc)
             # assign new current_z and disc value
             current_z = current_z - approx_distance_to_next_disc
-            current_disc = current_disc + 1
+            current_value = current_value + 1
 
         # if current_z is larger than searching zone, switch direction (and start from initial z minus approximate
         # distance from updated template distance)
-        if current_z >= nz or current_disc == 0:
+        if current_z >= nz or current_value == 0:
             logger.info('.. Switching to inferior direction.')
             direction = 'inferior'
-            current_disc = init_disc[1] + 1
-            current_z = init_disc[0] - list_distance[list_disc_value_template.index(current_disc)]
+            current_value = init_disc[1] + 1
+            current_z = init_disc[0] - list_distance[list_disc_value_template.index(current_value)]
         # if current_z is lower than searching zone, stop searching
         if current_z <= 0:
             search_next_disc = False

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -216,7 +216,11 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
             logger.info('.. Switching to inferior direction.')
             direction = 'inferior'
             current_value = init_disc[1] + 1
-            current_z = init_disc[0] - list_distance[list_disc_value_template.index(current_value)]
+            try:
+                current_z = init_disc[0] - list_distance[list_disc_value_template.index(current_value)]
+            except ValueError:
+                logger.info('No disc is inferior to the initial disc.')
+                search_next_disc = False
         # if current_z is lower than searching zone, stop searching
         if current_z <= 0:
             search_next_disc = False

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -131,6 +131,9 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     # ===========================================================================
     logger.info('Detect intervertebral discs...')
     current_z, current_value = init_disc
+    if (current_value not in list_disc_value_template) or (current_value-1 not in list_disc_value_template):
+        logger.error('Initial disk (%s) is not in template. Cannot detect intervertebral discs.', current_value)
+        raise ValueError('Initial disk is not in template.')
     # create list for z and disc
     list_disc_z = []
     list_disc_value = []

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -144,8 +144,8 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         logger.info('Current disc: %s (z=%s). Direction: %s', current_value, current_z, direction)
         try:
             # get z corresponding to current disc on template
-            current_z_template = list_disc_z_template[list_disc_value_template.index(current_value)]
-        except (ValueError, IndexError):
+            current_z_template = list_disc_z_template[current_value]
+        except IndexError:
             # in case reached the bottom (see issue #849)
             logger.warning('Reached the bottom of the template. Stop searching.')
             break

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -132,8 +132,8 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     logger.info('Detect intervertebral discs...')
     current_z, current_value = init_disc
     if (current_value not in list_disc_value_template) or (current_value-1 not in list_disc_value_template):
-        logger.error('Initial disk (%s) is not in template. Cannot detect intervertebral discs.', current_value)
-        raise ValueError('Initial disk is not in template.')
+        logger.error('Initial disc (%s) is not in template. Cannot detect intervertebral discs.', current_value)
+        raise ValueError('Initial disc is not in template.')
     # create list for z and disc
     list_disc_z = []
     list_disc_value = []

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -51,6 +51,45 @@ def test_sct_label_vertebrae_high_value_warning(caplog, tmp_path):
     assert 'Disc value not included in template.' in caplog.text
 
 
+def test_sct_label_vertebrae_initial_disc_no_inferior(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
+    sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
+                              '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                              '-c', 't2', '-initz', '40,20',
+                              '-ofolder', str(tmp_path)])
+    assert 'No disc is inferior to the initial disc.' in caplog.text
+
+
+def test_sct_label_vertebrae_initial_disc_zero(capsys, tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
+                                  '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-c', 't2', '-initz', '40,0',
+                                  '-ofolder', str(tmp_path)])
+    assert excinfo.value.code == 1
+    assert 'Missing label or zero label for initial disc.' in capsys.readouterr().out
+
+
+def test_sct_label_vertebrae_initial_disc_too_low(capsys, tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
+                                  '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-c', 't2', '-initz', '40,-1',
+                                  '-ofolder', str(tmp_path)])
+    assert excinfo.value.code == 1
+    assert 'Initial disc is not in template.' in capsys.readouterr().out
+
+
+def test_sct_label_vertebrae_initial_disc_too_high(capsys, tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
+                                  '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-c', 't2', '-initz', '40,21',
+                                  '-ofolder', str(tmp_path)])
+    assert excinfo.value.code == 1
+    assert 'Initial disc is not in template.' in capsys.readouterr().out
+
+
 def test_sct_label_vertebrae_clean_labels(tmp_path):
     im_seg = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
     dice_score = {}

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -43,6 +43,23 @@ def test_sct_label_vertebrae_initz_error():
     assert excinfo.value.code == 2
 
 
+# At least for the (default) PAM50 template, there are 3 cases
+# when using a high initial disc value:
+#
+# value=19: the code does the 'superior' direction of the loop,
+#   then does two iterations in the 'inferior' direction, and emits
+#   a warning for 'Disc value not included in template.'
+#
+# value=20: the code does the 'superior' direction of the loop,
+#   then tries to switch to the 'inferior' direction, but
+#   notices that the initial disc was the most 'inferior' disc already.
+#   This is arguably not an error but may be surprising,
+#   so the code emits an informational log.
+#
+# value=21 (or more): the initial disc value is outside the
+#   template, so the code detects this condition and errors out
+#   with a sensible error message.
+
 def test_sct_label_vertebrae_high_value_warning(caplog, tmp_path):
     sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
                               '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
@@ -60,6 +77,16 @@ def test_sct_label_vertebrae_initial_disc_no_inferior(caplog, tmp_path):
     assert 'No disc is inferior to the initial disc.' in caplog.text
 
 
+def test_sct_label_vertebrae_initial_disc_too_high(capsys, tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
+                                  '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-c', 't2', '-initz', '40,21',
+                                  '-ofolder', str(tmp_path)])
+    assert excinfo.value.code == 1
+    assert 'Initial disc is not in template.' in capsys.readouterr().out
+
+
 def test_sct_label_vertebrae_initial_disc_zero(capsys, tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
@@ -75,16 +102,6 @@ def test_sct_label_vertebrae_initial_disc_too_low(capsys, tmp_path):
         sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
                                   '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                   '-c', 't2', '-initz', '40,-1',
-                                  '-ofolder', str(tmp_path)])
-    assert excinfo.value.code == 1
-    assert 'Initial disc is not in template.' in capsys.readouterr().out
-
-
-def test_sct_label_vertebrae_initial_disc_too_high(capsys, tmp_path):
-    with pytest.raises(SystemExit) as excinfo:
-        sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),
-                                  '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
-                                  '-c', 't2', '-initz', '40,21',
                                   '-ofolder', str(tmp_path)])
     assert excinfo.value.code == 1
     assert 'Initial disc is not in template.' in capsys.readouterr().out


### PR DESCRIPTION
## Description
When calling `vertebral_detection` with an invalid initial disc (that is, a disc label that's not in the PAM50 template), the result is a very unfriendly error message:

```python
Traceback (most recent call last):
  File "/icometrix-install/spinalcordtoolbox-5.3.0/spinalcordtoolbox/vertebrae/core.py", line 206, in vertebral_detection
    approx_distance_to_next_disc = list_distance[list_disc_value_template.index(current_disc - 1)]
ValueError: -2 is not in list
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/icometrix-install/spinalcordtoolbox-5.3.0/spinalcordtoolbox/scripts/sct_label_vertebrae.py", line 482, in <module>
    main(sys.argv[1:])
  File "/icometrix-install/spinalcordtoolbox-5.3.0/spinalcordtoolbox/scripts/sct_label_vertebrae.py", line 419, in main
    verbose=verbose, path_template=path_template, path_output=path_output, scale_dist=scale_dist)
  File "/icometrix-install/spinalcordtoolbox-5.3.0/spinalcordtoolbox/vertebrae/core.py", line 208, in vertebral_detection
    logger.warning('Disc value not included in template. Using previously-calculated distance: %s', approx_distance_to_next_disc)
UnboundLocalError: local variable 'approx_distance_to_next_disc' referenced before assignment
```

(This can only happen in the first iteration through the loop in `vertebral_detection()`. In further iterations, the error is caught, a warning is displayed, and the previous iteration's value of `approx_distance_to_next_disc` is used.)

This PR adds a check to detect this condition up-front and output a (hopefully) friendlier message to the user.

This is not a complete fix for the linked issue (#3673, see also [the original forum post](https://forum.spinalcordmri.org/t/inconsistency-in-spinalcord-segmentation-leads-to-error-in-in-sct-label-vertebrae-version-5-3-0/809)), but is likely the best we can do in time for the 5.6 release.

## Linked issues
Part of #3673.