### PR TITLE
Allow `install_sct.bat` file execution from double click

### DIFF
--- a/install_sct.bat
+++ b/install_sct.bat
@@ -89,4 +89,5 @@ if "%cached_errorlevel%"=="" set cached_errorlevel=0
 popd
 where deactivate
 if %errorlevel% EQU 0 call deactivate
+PAUSE
 exit /b %cached_errorlevel%

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -19,7 +19,7 @@ if exist spinalcordtoolbox\ (
   echo ### Previous spinalcordtoolbox installation found at %HOMEPATH%\spinalcordtoolbox.
   rem NB: The rmdir command will output 'spinalcordtoolbox\, Are you sure (Y/N)?', so we don't need our own Y/N prompt
   rem     We also use "echo set /p=" here in order to make sure that Y/N text is output on the same line.
-  echo|set /p="### Continuing will overwrite the existing installation directory " || goto error
+  echo|set /p="### Continuing will overwrite the existing installation directory "
   rmdir /s spinalcordtoolbox\ || goto error
   if exist spinalcordtoolbox\ (
     echo ### spinalcordtoolbox\ not removed. Quitting installation...


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
Allow `install_sct.bat` to be usable from a simple double click in place of a command line execution. It will make it a lot more easy for windows user that don't have a lot of technical knowledge.

## Linked issues
#3762 
