### PR TITLE
Rewrite ANSI color code snippets to support terminals limited to 16-colors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-colored
 dipy
 # h5py is pinned to minor than 3 due to issues with Keras/TF
 # https://github.com/tensorflow/tensorflow/issues/44467

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -8,10 +8,10 @@ Important: model names (onnx or pt files) should have the same name as the enclo
 import os
 import json
 import logging
-import colored
 
 import spinalcordtoolbox as sct
 import spinalcordtoolbox.download
+from spinalcordtoolbox.utils import stylize
 
 
 logger = logging.getLogger(__name__)
@@ -221,29 +221,29 @@ def list_tasks():
 def display_list_tasks():
     tasks = sct.deepseg.models.list_tasks()
     # Display beautiful output
-    color = {True: 'green', False: 'red'}
+    color = {True: 'LightGreen', False: 'LightRed'}
     print("{:<30s}{:<50s}{:<15s}MODELS".format("TASK", "DESCRIPTION", "CONTRAST"))
     print("-" * 120)
     for name_task, value in tasks.items():
         path_models = [sct.deepseg.models.folder(name_model) for name_model in value['models']]
         are_models_valid = [sct.deepseg.models.is_valid(path_model) for path_model in path_models]
-        task_status = colored.stylize(name_task.ljust(30),
-                                      colored.fg(color[all(are_models_valid)]))
-        description_status = colored.stylize(value['description'].ljust(50),
-                                             colored.fg(color[all(are_models_valid)]))
-        models_status = ', '.join([colored.stylize(model_name,
-                                                   colored.fg(color[is_valid]))
+        task_status = stylize(name_task.ljust(30),
+                              color[all(are_models_valid)])
+        description_status = stylize(value['description'].ljust(50),
+                                     color[all(are_models_valid)])
+        models_status = ', '.join([stylize(model_name,
+                                           color[is_valid])
                                    for model_name, is_valid in zip(value['models'], are_models_valid)])
-        input_contrasts = colored.stylize(str(', '.join(model_name for model_name in
-                                                        get_required_contrasts(name_task))).ljust(15),
-                                          colored.fg(color[all(are_models_valid)]))
+        input_contrasts = stylize(str(', '.join(model_name for model_name in
+                                                get_required_contrasts(name_task))).ljust(15),
+                                  color[all(are_models_valid)])
 
         print("{}{}{}{}".format(task_status, description_status, input_contrasts, models_status))
 
     print(
         '\nLegend: {} | {}\n'.format(
-            colored.stylize("installed", colored.fg(color[True])),
-            colored.stylize("not installed", colored.fg(color[False]))))
+            stylize("installed", color[True]),
+            stylize("not installed", color[False])))
     exit(0)
 
 

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -28,16 +28,8 @@ import traceback
 import requirements
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser
-from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, set_loglevel
-
-
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
+from spinalcordtoolbox.utils.sys import (sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__,
+                                         __data_dir__, set_loglevel, ANSIColors16)
 
 
 def _test_condition(condition):
@@ -139,15 +131,15 @@ def print_line(string):
 
 
 def print_ok(more=None):
-    print("[{}OK{}]{}".format(bcolors.OKGREEN, bcolors.ENDC, more if more is not None else ""))
+    print("[{}OK{}]{}".format(ANSIColors16.LightGreen, ANSIColors16.ResetAll, more if more is not None else ""))
 
 
 def print_warning(more=None):
-    print("[{}WARNING{}]{}".format(bcolors.WARNING, bcolors.ENDC, more if more is not None else ""))
+    print("[{}WARNING{}]{}".format(ANSIColors16.LightYellow, ANSIColors16.ResetAll, more if more is not None else ""))
 
 
 def print_fail(more=None):
-    print("[{}FAIL{}]{}".format(bcolors.FAIL, bcolors.ENDC, more if more is not None else ""))
+    print("[{}FAIL{}]{}".format(ANSIColors16.LightRed, ANSIColors16.ResetAll, more if more is not None else ""))
 
 
 def add_bash_profile(string):

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -23,16 +23,68 @@ import tqdm
 logger = logging.getLogger(__name__)
 
 
-class bcolors(object):
-    normal = '\033[0m'
-    red = '\033[91m'
-    green = '\033[92m'
-    yellow = '\033[93m'
-    blue = '\033[94m'
-    magenta = '\033[95m'
-    cyan = '\033[96m'
-    bold = '\033[1m'
-    underline = '\033[4m'
+class ANSIColors16(object):
+    """This class defines the ANSI color escape codes for terminals that support 16 colors.
+
+    Notes:
+        - Most terminals support 8 colors (base color set) or 16 colors (base colors + light colors).
+        - We use these codes instead of dedicated color packages (colored, colorama) because those packages
+          are meant for 256-color coloring, which only some terminals support. (Notably, the Windows Command Prompt
+          does not support 256 colors.)
+        - Further reading: https://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#rich-text
+        - Source for codes: https://pkg.go.dev/github.com/whitedevops/colors
+    """
+    ResetAll = "\033[0m"
+
+    Bold = "\033[1m"
+    Dim = "\033[2m"
+    Underlined = "\033[4m"
+    Blink = "\033[5m"
+    Reverse = "\033[7m"
+    Hidden = "\033[8m"
+
+    ResetBold = "\033[21m"
+    ResetDim = "\033[22m"
+    ResetUnderlined = "\033[24m"
+    ResetBlink = "\033[25m"
+    ResetReverse = "\033[27m"
+    ResetHidden = "\033[28m"
+
+    Default = "\033[39m"
+    Black = "\033[30m"
+    Red = "\033[31m"
+    Green = "\033[32m"
+    Yellow = "\033[33m"
+    Blue = "\033[34m"
+    Magenta = "\033[35m"
+    Cyan = "\033[36m"
+    LightGray = "\033[37m"
+    DarkGray = "\033[90m"
+    LightRed = "\033[91m"
+    LightGreen = "\033[92m"
+    LightYellow = "\033[93m"
+    LightBlue = "\033[94m"
+    LightMagenta = "\033[95m"
+    LightCyan = "\033[96m"
+    White = "\033[97m"
+
+    BackgroundDefault = "\033[49m"
+    BackgroundBlack = "\033[40m"
+    BackgroundRed = "\033[41m"
+    BackgroundGreen = "\033[42m"
+    BackgroundYellow = "\033[43m"
+    BackgroundBlue = "\033[44m"
+    BackgroundMagenta = "\033[45m"
+    BackgroundCyan = "\033[46m"
+    BackgroundLightGray = "\033[47m"
+    BackgroundDarkGray = "\033[100m"
+    BackgroundLightRed = "\033[101m"
+    BackgroundLightGreen = "\033[102m"
+    BackgroundLightYellow = "\033[103m"
+    BackgroundLightBlue = "\033[104m"
+    BackgroundLightMagenta = "\033[105m"
+    BackgroundLightCyan = "\033[106m"
+    BackgroundWhite = "\033[107m"
 
 
 if os.getenv('SENTRY_DSN', None):
@@ -363,8 +415,10 @@ def printv(string, verbose=1, type='normal', file=None):
     Enables to print color-coded messages, depending on verbose status. Only use in command-line programs (e.g.,
     sct_propseg).
     """
-    colors = {'normal': bcolors.normal, 'info': bcolors.green, 'warning': bcolors.yellow + bcolors.bold, 'error': bcolors.red + bcolors.bold,
-              'code': bcolors.blue, 'bold': bcolors.bold, 'process': bcolors.magenta}
+    colors = {'normal': ANSIColors16.ResetAll, 'info': ANSIColors16.LightGreen, 
+              'warning': ANSIColors16.LightYellow + ANSIColors16.Bold,
+              'error': ANSIColors16.LightRed + ANSIColors16.Bold,
+              'code': ANSIColors16.LightBlue, 'bold': ANSIColors16.Bold, 'process': ANSIColors16.LightMagenta}
 
     if file is None:
         # replicate the logic from print()
@@ -376,8 +430,8 @@ def printv(string, verbose=1, type='normal', file=None):
         try:
             # Print color only if the output is the terminal
             if file.isatty():
-                color = colors.get(type, bcolors.normal)
-                print(color + string + bcolors.normal, file=file)
+                color = colors.get(type, ANSIColors16.ResetAll)
+                print(color + string + ANSIColors16.ResetAll, file=file)
             else:
                 print(string, file=file)
         except Exception as e:

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -442,7 +442,7 @@ def printv(string, verbose=1, type='normal', file=None):
                 print(color + string + ANSIColors16.ResetAll, file=file)
             else:
                 print(string, file=file)
-        except Exception as e:
+        except Exception:
             print(string)
 
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -23,6 +23,14 @@ import tqdm
 logger = logging.getLogger(__name__)
 
 
+def stylize(string, styles):
+    """Helper function that mimics colored.stylize to reduce boilerplate when coloring text."""
+    if not isinstance(styles, list):
+        styles = [styles]
+    style_codes = "".join([getattr(ANSIColors16, style, ANSIColors16.ResetAll) for style in styles])
+    return style_codes + string + ANSIColors16.ResetAll
+
+
 class ANSIColors16(object):
     """This class defines the ANSI color escape codes for terminals that support 16 colors.
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -423,7 +423,7 @@ def printv(string, verbose=1, type='normal', file=None):
     Enables to print color-coded messages, depending on verbose status. Only use in command-line programs (e.g.,
     sct_propseg).
     """
-    colors = {'normal': ANSIColors16.ResetAll, 'info': ANSIColors16.LightGreen, 
+    colors = {'normal': ANSIColors16.ResetAll, 'info': ANSIColors16.LightGreen,
               'warning': ANSIColors16.LightYellow + ANSIColors16.Bold,
               'error': ANSIColors16.LightRed + ANSIColors16.Bold,
               'code': ANSIColors16.LightBlue, 'bold': ANSIColors16.Bold, 'process': ANSIColors16.LightMagenta}


### PR DESCRIPTION
## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The `colored` module uses the extended 256 color set, and so it doesn't support Windows terminals, which causes grayscale text when running `sct_deepseg -list-tasks`. So, this PR:

  - Rewrites the `bcolors` code snippets so that it's clearer that we're limited to ANSI 16-color escape codes.
  - Replaces the use of `colored.stylize` with a new equivalent function that uses these 16-color escape codes.

Now, `sct_deepseg -list-tasks` properly shows coloured output:

![image](https://user-images.githubusercontent.com/16181459/165145599-066fb10a-280a-46fd-b4e7-8decbff71932.png)

And our previous color usage is unaffected:

![image](https://user-images.githubusercontent.com/16181459/165145677-6277d7e2-83b9-46d0-95eb-83bfad90ec79.png)

Further refactoring is definitely possibly (e.g. by using `stylize` in `sct_check_dependencies`), but I wanted to keep this PR as simple to review as possible when first starting out, by minimizing the changes in the diffs.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3780