### PR TITLE
Use CPU `--extra-index-url` to remove strict dependency pinning for `torch`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ Keras==2.3.1
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu
-ivadomed@git+https://github.com/ivadomed/ivadomed@ng/cu113
+ivadomed@git+https://github.com/ivadomed/ivadomed
+#ivadomed>=2.9.6
 matplotlib
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.
 # Installing "Microsoft Visual C++ Redistributable for Visual Studio" will fix this too, but

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ Keras==2.3.1
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu
-ivadomed@git+https://github.com/ivadomed/ivadomed
-#ivadomed>=2.9.6
+ivadomed~=2.9.6
 matplotlib
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.
 # Installing "Microsoft Visual C++ Redistributable for Visual Studio" will fix this too, but

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Keras==2.3.1
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu
-ivadomed
+ivadomed@git+https://github.com/ivadomed/ivadomed@ng/cu113
 matplotlib
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.
 # Installing "Microsoft Visual C++ Redistributable for Visual Studio" will fix this too, but

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ dipy
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
 Keras==2.3.1
+# PyTorch's Linux distribution is very large due to its GPU support,
+# but we only need that for training models. Our users only need CPU.
+--extra-index-url https://download.pytorch.org/whl/cpu
 ivadomed
 matplotlib
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.
@@ -34,16 +37,6 @@ scipy
 scikit-image
 scikit-learn
 tensorflow~=1.15.0
-# PyTorch's Linux/Windows distribution is very large due to its GPU support,
-# but we only need that for training models. For users, use the CPU-only version
-# (only available directly from the PyTorch project).
-# The macOS version has never had GPU support, so doesn't need the workaround.
--f https://download.pytorch.org/whl/torch/
--f https://download.pytorch.org/whl/torchvision/
-torch==1.5.0+cpu; sys_platform != "darwin"
-torch==1.5.0; sys_platform == "darwin"
-torchvision==0.6.0+cpu; sys_platform != "darwin"
-torchvision==0.6.0; sys_platform == "darwin"
 xlwt
 tqdm
 transforms3d


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description


At some point recently torch put up a full pip repo (`pip --extra-index-url https://download.pytorch.org/whl/cpu`) instead of just a list of files (`pip --find-links https://download.pytorch.org/whl/torch_stable.html`), meaning the officially stated version of torch (1.8.0, 1.9.0, 1.10, ...) is now orthogonal from the build variant (`cpu`, `cu101`, `cu113`, ...), so we can unpin the version and leave the choice of version encapsulated in ivadomed, especially because `torch` is not something we use directly at all, it's just something `ivadomed` calls.

The version has more to do with what APIs we can call, and the build variant has more to do with what platform the end user is actually installing on, so they are a lot better separated.


## Linked issues

Sidesteps https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3396

Also helps https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/1526; this isn't 100% clean but it will mean our install instructions to users when we do that will be:

```
pip install spinalcordtoolbox
```

or:

```
pip install --extra-index-url https://download.pytorch.org/whl/cpu spinalcordtoolbox
```

which is pretty good, until https://github.com/pytorch/pytorch/issues/26340 is finally resolved. If it's ever resolved.

I've given the same treatment to ivadomed directly at https://github.com/ivadomed/ivadomed/pull/1129.

See discussions at 

* https://github.com/ivadomed/ivadomed/pull/1000
* https://docs.google.com/document/d/19mEHKOZKFdprb3UPQYxmfO46mn0bPQfOgE-WPdeF7AQ/edit#heading=h.cxdfvr56zc7g