### PR TITLE
Account for `None` orientation strings when printing image headers

### DIFF
--- a/contrib/fslhd.py
+++ b/contrib/fslhd.py
@@ -119,6 +119,7 @@ INTENT_STRINGS = {
 }
 
 ORIENTATION_STRINGS = {
+    None: "Unknown",
     'R': "Left-to-Right",
     'L': "Right-to-Left",
     'A': "Posterior-to-Anterior",


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I tried running `fslhd` on the same warping field that produced the error from https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3814, and got the following output:

```console
joshua@tadpole:/tmp/pytest-of-joshua/pytest-0/test_sct_register_multimodal_mcurrent$ fslhd warp_mt02mt1.nii.gz 
filename	warp_mt02mt1.nii.gz

sizeof_hdr	348
data_type	FLOAT32
dim0		5
dim1		40
dim2		40
dim3		5
dim4		1
dim5		3
dim6		1
dim7		1
vox_units	mm
time_units	Unknown
datatype	16
nbyper		4
bitpix		32
pixdim0		-1.000000
pixdim1		0.843750
pixdim2		0.843750
pixdim3		17.000000
pixdim4		0.000000
pixdim5		0.000000
pixdim6		0.000000
pixdim7		0.000000
vox_offset	352
cal_max		0.000000
cal_min		0.000000
scl_slope	1.000000
scl_inter	0.000000
phase_dim	0
freq_dim	0
slice_dim	0
slice_name	Unknown
slice_code	0
slice_start	0
slice_end	0
slice_duration	0.000000
toffset		0.000000
intent		Vector
intent_code	1007
intent_name	
intent_p1	0.000000
intent_p2	0.000000
intent_p3	0.000000
qform_name	Scanner Anat
qform_code	1
qto_xyz:1	-0.843379 -0.000000 -0.503756 10.726137 
qto_xyz:2	-0.001874 0.841376 1.273740 -17.241285 
qto_xyz:3	-0.024932 -0.063247 16.944729 -25.065205 
qto_xyz:4	0.000000 0.000000 0.000000 1.000000 
qform_xorient	Right-to-Left
qform_yorient	Posterior-to-Anterior
qform_zorient	Inferior-to-Superior
sform_name	Scanner Anat
sform_code	0
sto_xyz:1	0.000000 0.000000 0.000000 0.000000 
sto_xyz:2	0.000000 0.000000 0.000000 0.000000 
sto_xyz:3	0.000000 0.000000 0.000000 0.000000 
sto_xyz:4	0.000000 0.000000 0.000000 1.000000 
sform_xorient	Unknown
sform_yorient	Unknown
sform_zorient	Unknown
file_type	NIFTI-1+
file_code	1
descrip		
aux_file
```

The relevant part of this is:

```
sform_xorient	Unknown
sform_yorient	Unknown
sform_zorient	Unknown
```

So, I've added an entry to the orientation dict to print `Unknown` for orientation strings `nib` interprets as `None`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3814.