### PR TITLE
Exclude `certifi @ file` from pip freeze to work around upstream conda bug

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -54,11 +54,12 @@ jobs:
         git checkout ${{ env.RELEASE_BRANCH }}
         git merge --no-ff ${{ env.MAIN_BRANCH }}
 
+    # TODO: "grep certifi" should be removed following an upstream fix for: https://github.com/conda/conda/issues/11580
     - name: Update requirements-freeze.txt
       run: |
         source python/etc/profile.d/conda.sh
         conda activate venv_sct
-        pip freeze | grep -v "-e git+" | grep -v "torch" > requirements-freeze.txt
+        pip freeze | grep -v "-e git+" | grep -v "torch" | grep -v "certifi @ file" > requirements-freeze.txt
         conda deactivate
         echo "# Platform-specific torch requirements (See SCT Issue #2745)" >> requirements-freeze.txt
         grep "torch" requirements.txt >> requirements-freeze.txt


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a temporary bugfix for an upstream conda issue. 

Right now, `pip freeze` is broken in conda environments, as it spits out nonsense file identifiers for certain packages. In our case, this affects only `certifi`, which is already installed by default in fresh conda environments, so it's safe to exclude from the `pip freeze`.

This fix was tested in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3798.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3817.