### PR TITLE
Overlap conditions when slice number and vertebral levels are both specified

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -279,6 +279,8 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
         im_vert_level = Image(vert_level).change_orientation('RPI')
         # slicegroups = [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
         slicegroups = [tuple(get_slices_from_vertebral_levels(im_vert_level, level)) for level in levels]
+        # Intersection between specified slices and each element of slicegroups
+        slicegroups = [tuple(set(slicegroup) & set(slices)) for slicegroup in slicegroups]
         if perlevel:
             # vertgroups = [(2,), (3,), (4,)]
             vertgroups = [tuple([level]) for level in levels]
@@ -293,8 +295,6 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
             slicegroups = [tuple([val for sublist in slicegroups for val in sublist])]  # flatten into single tuple
             # vertgroups = [(2, 3, 4)]
             vertgroups = [tuple([level for level in levels])]
-        # Intersection between specified slices and each element of slicegroups
-        slicegroups = [tuple(set(slicegroup) & set(slices)) for slicegroup in slicegroups]
     # aggregation based on slices
     else:
         if perslice:

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -293,6 +293,8 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
             slicegroups = [tuple([val for sublist in slicegroups for val in sublist])]  # flatten into single tuple
             # vertgroups = [(2, 3, 4)]
             vertgroups = [tuple([level for level in levels])]
+        # Intersection between specified slices and each element of slicegroups
+        slicegroups = [tuple(set(slicegroup) & set(slices)) for slicegroup in slicegroups]
     # aggregation based on slices
     else:
         if perslice:

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -191,7 +191,9 @@ def get_parser():
         '-vert',
         metavar=Metavar.str,
         default=param_default.vertebral_levels,
-        help="Vertebral levels to estimate the metric across. Example: 2:9 (for C2 to T2)"
+        help="Vertebral levels to compute the metrics across. Example: 2:9 for C2 to T2. If you also specify a range of"
+             "slices with flag `-z`, the intersection between the specified slices and vertebral levels will be "
+             "considered."
     )
     optional.add_argument(
         '-vertfile',

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -136,7 +136,9 @@ def get_parser():
     optional.add_argument(
         '-vert',
         metavar=Metavar.str,
-        help="Vertebral levels to compute the metrics across. Example: 2:9 for C2 to T2."
+        help="Vertebral levels to compute the metrics across. Example: 2:9 for C2 to T2. If you also specify a range of"
+             "slices with flag `-z`, the intersection between the specified slices and vertebral levels will be "
+             "considered."
     )
     optional.add_argument(
         '-vertfile',

--- a/testing/api/test_aggregate_slicewise.py
+++ b/testing/api/test_aggregate_slicewise.py
@@ -168,11 +168,20 @@ def test_aggregate_across_levels_and_slices(dummy_metrics, dummy_vert_level):
     """Test extraction of metrics aggregation across vertebral levels, while imposing a slice range
     Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3822"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[1, 2, 3, 4, 6],
-                                                                  levels=[2, 3], perlevel=False,
+                                                                  levels=[2, 3], perlevel=False, perslice=False,
                                                                   vert_level=dummy_vert_level,
                                                                   group_funcs=(('WA', aggregate_slicewise.func_wa),))
     assert (1, 2, 3) in agg_metric.keys()
     assert agg_metric[(1, 2, 3)] == {'VertLevel': (2, 3), 'DistancePMJ': None, 'WA()': 37.0}
+
+    agg_metric_ps = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[1, 2, 3, 4, 6],
+                                                                     levels=[2, 3], perlevel=False, perslice=True,
+                                                                     vert_level=dummy_vert_level,
+                                                                     group_funcs=(('WA', aggregate_slicewise.func_wa),))
+    assert ((1,), (2,), (3,)) == tuple(agg_metric_ps.keys())
+    assert agg_metric_ps[(1,)] == {'VertLevel': (2,), 'DistancePMJ': None, 'WA()': 31.0}
+    assert agg_metric_ps[(2,)] == {'VertLevel': (3,), 'DistancePMJ': None, 'WA()': 39.0}
+    assert agg_metric_ps[(3,)] == {'VertLevel': (3,), 'DistancePMJ': None, 'WA()': 41.0}
 
 
 # noinspection 801,PyShadowingNames

--- a/testing/api/test_aggregate_slicewise.py
+++ b/testing/api/test_aggregate_slicewise.py
@@ -164,6 +164,18 @@ def test_aggregate_per_level(dummy_metrics, dummy_vert_level):
 
 
 # noinspection 801,PyShadowingNames
+def test_aggregate_across_levels_and_slices(dummy_metrics, dummy_vert_level):
+    """Test extraction of metrics aggregation across vertebral levels, while imposing a slice range
+    Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3822"""
+    agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[1, 2, 3, 4, 6],
+                                                                  levels=[2, 3], perlevel=False,
+                                                                  vert_level=dummy_vert_level,
+                                                                  group_funcs=(('WA', aggregate_slicewise.func_wa),))
+    assert (1, 2, 3) in agg_metric.keys()
+    assert agg_metric[(1,2,3)] == {'VertLevel': (2, 3), 'DistancePMJ': None, 'WA()': 37.0}
+
+
+# noinspection 801,PyShadowingNames
 def test_aggregate_slices_pmj(dummy_metrics):
     """Test extraction of metrics aggregation within selected slices at a PMJ distance"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[2, 3, 4, 5],

--- a/testing/api/test_aggregate_slicewise.py
+++ b/testing/api/test_aggregate_slicewise.py
@@ -172,7 +172,7 @@ def test_aggregate_across_levels_and_slices(dummy_metrics, dummy_vert_level):
                                                                   vert_level=dummy_vert_level,
                                                                   group_funcs=(('WA', aggregate_slicewise.func_wa),))
     assert (1, 2, 3) in agg_metric.keys()
-    assert agg_metric[(1,2,3)] == {'VertLevel': (2, 3), 'DistancePMJ': None, 'WA()': 37.0}
+    assert agg_metric[(1, 2, 3)] == {'VertLevel': (2, 3), 'DistancePMJ': None, 'WA()': 37.0}
 
 
 # noinspection 801,PyShadowingNames


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Modified the behaviour of `aggregate_slicewise.py` so that if a user specifies both flags `-z` and `-vert`, the slices considered for the aggregation will be the intersection between the values specified by both flags. Previously, `-vert` would take precedent.

This change introduce a cross-compatibility break in behaviour, however this is not _too_ problematic because the previous behaviour was unclear anyway.

## Linked issues
Fixes #3822