### PR TITLE
Followups for #3823

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -240,7 +240,7 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
     :param metric: Class Metric(): data to aggregate.
     :param mask: Class Metric(): mask to use for aggregating the data. Optional.
     :param slices: List[int]: Slices to aggregate metric from. If empty, select all slices.
-    :param levels: List[int]: Vertebral levels to aggregate metric from. It has priority over "slices".
+    :param levels: List[int]: Vertebral levels to aggregate metric from. It respects the restriction to "slices".
     :param distance_pmj: float: Distance from Ponto-Medullary Junction (PMJ) in mm.
     :param Bool perslice: Aggregate per slice (True) or across slices (False)
     :param Bool perlevel: Aggregate per level (True) or across levels (False). Has priority over "perslice".

--- a/testing/api/test_aggregate_slicewise.py
+++ b/testing/api/test_aggregate_slicewise.py
@@ -94,7 +94,6 @@ def dummmy_data_subject():
     return df
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_across_selected_slices(dummy_metrics):
     """Test extraction of metrics aggregation across slices: Selected slices"""
     agg_metrics = {}
@@ -114,7 +113,6 @@ def test_aggregate_across_selected_slices(dummy_metrics):
                                                            "types according to the casting rule ''safe''"
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_across_all_slices(dummy_metrics):
     """Test extraction of metrics aggregation across slices: All slices by default"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], perslice=False,
@@ -122,7 +120,6 @@ def test_aggregate_across_all_slices(dummy_metrics):
     assert agg_metric[list(agg_metric)[0]]['WA()'] == 48.0
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_per_slice(dummy_metrics):
     """Test extraction of metrics aggregation per slice: Selected slices"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[3, 4],
@@ -132,7 +129,6 @@ def test_aggregate_per_slice(dummy_metrics):
     assert agg_metric[(4,)]['WA()'] == 50.0
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_across_levels(dummy_metrics, dummy_vert_level):
     """Test extraction of metrics aggregation across vertebral levels"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], levels=[2, 3],
@@ -142,7 +138,6 @@ def test_aggregate_across_levels(dummy_metrics, dummy_vert_level):
     assert agg_metric[(0, 1, 2, 3)] == {'VertLevel': (2, 3), 'DistancePMJ': None, 'WA()': 35.0}
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_across_levels_perslice(dummy_metrics, dummy_vert_level):
     """Test extraction of metrics aggregation within selected vertebral levels and per slice"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], levels=[2, 3],
@@ -153,7 +148,6 @@ def test_aggregate_across_levels_perslice(dummy_metrics, dummy_vert_level):
     assert agg_metric[(2,)] == {'VertLevel': (3,), 'DistancePMJ': None, 'WA()': 39.0}
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_per_level(dummy_metrics, dummy_vert_level):
     """Test extraction of metrics aggregation per vertebral level"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], levels=[2, 3],
@@ -163,7 +157,6 @@ def test_aggregate_per_level(dummy_metrics, dummy_vert_level):
     assert agg_metric[(2, 3)] == {'VertLevel': (3,), 'DistancePMJ': None, 'WA()': 40.0}
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_across_levels_and_slices(dummy_metrics, dummy_vert_level):
     """Test extraction of metrics aggregation across vertebral levels, while imposing a slice range
     Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3822"""
@@ -184,7 +177,6 @@ def test_aggregate_across_levels_and_slices(dummy_metrics, dummy_vert_level):
     assert agg_metric_ps[(3,)] == {'VertLevel': (3,), 'DistancePMJ': None, 'WA()': 41.0}
 
 
-# noinspection 801,PyShadowingNames
 def test_aggregate_slices_pmj(dummy_metrics):
     """Test extraction of metrics aggregation within selected slices at a PMJ distance"""
     agg_metric = aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['with float'], slices=[2, 3, 4, 5],
@@ -193,7 +185,6 @@ def test_aggregate_slices_pmj(dummy_metrics):
     assert agg_metric[(2, 3, 4, 5)] == {'VertLevel': None, 'DistancePMJ': [64], 'WA()': 45.25}
 
 
-# noinspection 801,PyShadowingNames
 def test_extract_metric(dummy_data_and_labels):
     """Test different estimation methods."""
     # Weighted average
@@ -243,7 +234,6 @@ def test_extract_metric(dummy_data_and_labels):
     assert agg_metric[list(agg_metric)[0]]['MAP()'] == pytest.approx(20.0, rel=0.01)
 
 
-# noinspection 801,PyShadowingNames
 def test_extract_metric_2d(dummy_data_and_labels_2d):
     """Test different estimation methods with 2D input array"""
     agg_metric = aggregate_slicewise.extract_metric(dummy_data_and_labels_2d[0], labels=dummy_data_and_labels_2d[1],
@@ -257,7 +247,6 @@ def test_extract_metric_2d(dummy_data_and_labels_2d):
     assert agg_metric[list(agg_metric)[0]]['MEDIAN()'] == 5.0
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv(tmp_path, dummy_metrics):
     """Test writing of output metric csv file"""
     path_out = str(tmp_path / 'tmp_file_out.csv')
@@ -281,7 +270,6 @@ def test_save_as_csv(tmp_path, dummy_metrics):
         assert next(spamreader)[1:] == [__version__, '', '3:4', '', '', '45.5', '4.5']
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv_slices(tmp_path, dummy_metrics, dummy_vert_level):
     """Make sure slices are listed in reduced form"""
     path_out = str(tmp_path / 'tmp_file_out.csv')
@@ -297,7 +285,6 @@ def test_save_as_csv_slices(tmp_path, dummy_metrics, dummy_vert_level):
         assert row['VertLevel'] == '3:4'
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv_per_level(tmp_path, dummy_metrics, dummy_vert_level):
     """Make sure slices are listed in reduced form"""
     path_out = str(tmp_path / 'tmp_file_out.csv')
@@ -313,7 +300,6 @@ def test_save_as_csv_per_level(tmp_path, dummy_metrics, dummy_vert_level):
         assert row['VertLevel'] == '3'
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv_per_slice_then_per_level(dummy_metrics, dummy_vert_level, tmp_path):
     """Test with and without specifying perlevel. See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2141"""
     path_out = str(tmp_path / 'tmp_file_out.csv')
@@ -336,7 +322,6 @@ def test_save_as_csv_per_slice_then_per_level(dummy_metrics, dummy_vert_level, t
         assert row['VertLevel'] == ''
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv_sorting(tmp_path, dummy_metrics):
     """Make sure slices are sorted in output csv file"""
     path_out = str(tmp_path / 'tmp_file_out.csv')
@@ -363,7 +348,6 @@ def test_save_as_csv_pmj(tmp_path, dummy_metrics):
         assert row['VertLevel'] == ''
 
 
-# noinspection 801,PyShadowingNames
 def test_save_as_csv_extract_metric(tmp_path, dummy_data_and_labels):
     """Test file output with extract_metric()"""
     path_out = str(tmp_path / 'tmp_file_out.csv')

--- a/testing/api/test_centerline.py
+++ b/testing/api/test_centerline.py
@@ -86,7 +86,6 @@ param_optic = [
 ]
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected', im_ctl_find_and_sort_coord)
 def test_find_and_sort_coord(img_ctl, expected):
     img = img_ctl[0].copy()
@@ -95,7 +94,6 @@ def test_find_and_sort_coord(img_ctl, expected):
     assert np.linalg.norm(centermass - img_ctl[2]) == 0
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected', im_ctl_zeroslice)
 def test_get_centerline_polyfit_minmax(img_ctl, expected):
     """Test centerline fitting with minmax=True"""
@@ -106,7 +104,6 @@ def test_get_centerline_polyfit_minmax(img_ctl, expected):
     assert arr_out.shape == expected
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
 def test_get_centerline_polyfit(img_ctl, expected, params):
     """Test centerline fitting using polyfit"""
@@ -122,7 +119,6 @@ def test_get_centerline_polyfit(img_ctl, expected, params):
         assert np.linalg.norm(find_and_sort_coord(img) - arr_out) < expected['norm']
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
 def test_get_centerline_bspline(img_ctl, expected, params):
     """Test centerline fitting using bspline"""
@@ -134,7 +130,6 @@ def test_get_centerline_bspline(img_ctl, expected, params):
     assert fit_results.laplacian_max < expected['laplacian']
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
 def test_get_centerline_linear(img_ctl, expected, params):
     """Test centerline fitting using linear interpolation"""
@@ -145,7 +140,6 @@ def test_get_centerline_linear(img_ctl, expected, params):
     assert fit_results.laplacian_max < expected['laplacian']
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
 def test_get_centerline_nurbs(img_ctl, expected, params):
     """Test centerline fitting using nurbs"""
@@ -158,7 +152,6 @@ def test_get_centerline_nurbs(img_ctl, expected, params):
     assert fit_results.laplacian_max < expected['laplacian']
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('params', param_optic)
 def test_get_centerline_optic(params):
     """Test centerline extraction with optic"""

--- a/testing/api/test_deepseg_sc.py
+++ b/testing/api/test_deepseg_sc.py
@@ -22,7 +22,6 @@ param_deepseg = [
 ]
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('params', param_deepseg)
 def test_deep_segmentation_spinalcord(params):
     """High level segmentation API"""

--- a/testing/api/test_math.py
+++ b/testing/api/test_math.py
@@ -15,7 +15,6 @@ VERBOSE = int(os.getenv('SCT_VERBOSE', 0))
 DUMP_IMAGES = bool(os.getenv('SCT_DEBUG_IMAGES', False))
 
 
-# noinspection 801,PyShadowingNames
 def test_dilate():
 
     # Create dummy image with single pixel in the middle
@@ -52,7 +51,6 @@ def test_dilate():
     assert np.array_equal(im_dil.data[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
 
 
-# noinspection 801,PyShadowingNames
 def test_erode():
     # Create dummy image with single pixel
     im = dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))

--- a/testing/api/test_process_seg.py
+++ b/testing/api/test_process_seg.py
@@ -43,7 +43,6 @@ dict_test_orientation = [
     ]
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('test_orient', dict_test_orientation)
 def test_fix_orientation(test_orient):
     assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
@@ -110,7 +109,7 @@ im_segs = [
      {'angle_corr': False, 'slice': 2})
     ]
 
-# noinspection 801,PyShadowingNames
+
 @pytest.mark.parametrize('im_seg,expected,params', im_segs)
 def test_compute_shape(im_seg, expected, params):
     metrics, fit_results = process_seg.compute_shape(im_seg,

--- a/testing/api/test_resampling.py
+++ b/testing/api/test_resampling.py
@@ -59,7 +59,6 @@ def fake_4dimage_nib():
     return nii
 
 
-# noinspection 801,PyShadowingNames
 def test_nib_resample_image_3d(fake_3dimage_nib):
     """Test resampling with 3D nibabel image"""
     img_r = resampling.resample_nib(fake_3dimage_nib, new_size=[2, 2, 1], new_size_type='factor', interpolation='nn')
@@ -70,7 +69,6 @@ def test_nib_resample_image_3d(fake_3dimage_nib):
     # nib.save(img_r, 'test_4.nii.gz')
 
 
-# noinspection 801,PyShadowingNames
 def test_nib_resample_image_3d_to_dest(fake_3dimage_nib, fake_3dimage_nib_big):
     """Test resampling with 3D nibabel image"""
     img_r = resampling.resample_nib(fake_3dimage_nib, image_dest=fake_3dimage_nib_big, interpolation='linear')
@@ -78,7 +76,6 @@ def test_nib_resample_image_3d_to_dest(fake_3dimage_nib, fake_3dimage_nib_big):
     assert img_r.get_data()[4, 4, 4] == 1.0
 
 
-# noinspection 801,PyShadowingNames
 def test_nib_resample_image_4d(fake_4dimage_nib):
     """Test resampling with 4D nibabel image"""
     img_r = resampling.resample_nib(fake_4dimage_nib, new_size=[2, 2, 1, 1], new_size_type='factor', interpolation='nn')

--- a/testing/api/test_straightening.py
+++ b/testing/api/test_straightening.py
@@ -8,7 +8,6 @@ from spinalcordtoolbox.utils import sct_test_path
 VERBOSE = 0  # Set to 2 to save images, 0 otherwise
 
 
-# noinspection 801,PyShadowingNames
 def test_straighten(tmp_path):
     """Test straightening with default params"""
     fname_t2 = sct_test_path('t2', 't2.nii.gz')  # sct_download_data -d sct_testing_data

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -39,7 +39,6 @@ def test_model_dict():
         assert('default' in value)
 
 
-# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('fname_image, fname_seg_manual, fname_out, task', [
     (sct_test_path('t2s', 't2s.nii.gz'),
      sct_test_path('t2s', 't2s_seg-deepseg.nii.gz'),


### PR DESCRIPTION
## Description

Two small followup changes after #3823:
* The `# noinspection 801,PyShadowingNames` comments in various test files are no longer necessary (see #3824).
* The docstring for `aggregate_per_slice_or_level` got out of sync with the code.

## Linked issues

Fixes #3824.