### PR TITLE
Unify calls to `shutil.move` by using only `utils.fs.mv`

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -15,7 +15,6 @@ import os
 import itertools
 import warnings
 import logging
-import shutil
 import math
 from typing import Sequence
 
@@ -28,7 +27,7 @@ import transforms3d.affines as affines
 from scipy.ndimage import map_coordinates
 
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import extract_fname
+from spinalcordtoolbox.utils import extract_fname, mv
 
 logger = logging.getLogger(__name__)
 
@@ -1475,11 +1474,7 @@ def generate_output_file(fname_in, fname_out, squeeze_data=True, verbose=1):
         img.save(fname_out)
     else:
         # Generate output file without changing the extension
-        # NB: We specify `shutil.copyfile` to override the default of `shutil.copy2`.
-        #     (`copy2` copies file metadata, but doing so fails with a PermissionError on WSL installations where the
-        #     src/dest are on different devices. So, we use `copyfile` instead, which doesn't preserve file metadata.)
-        #     Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3832.
-        shutil.move(fname_in, fname_out, copy_function=shutil.copyfile)
+        mv(fname_in, fname_out, verbose=verbose)
 
     logger.info("File created: %s", os.path.join(path_out, file_out + ext_out))
     return os.path.join(path_out, file_out + ext_out)

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -220,8 +220,7 @@ def cache_save(cachefile, sig):
 
 
 def mv(src, dst, verbose=1):
-    """Move a file from src to dst, almost like os.rename
-    """
+    """Move a file from src to dst (adding a logging message)."""
     printv("mv %s %s" % (src, dst), verbose=verbose, type="code")
     os.rename(src, dst)
 

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -222,7 +222,11 @@ def cache_save(cachefile, sig):
 def mv(src, dst, verbose=1):
     """Move a file from src to dst (adding a logging message)."""
     printv("mv %s %s" % (src, dst), verbose=verbose, type="code")
-    os.rename(src, dst)
+    # NB: We specify `shutil.copyfile` to override the default of `shutil.copy2`.
+    #     (`copy2` copies file metadata, but doing so fails with a PermissionError on WSL installations where the
+    #     src/dest are on different devices. So, we use `copyfile` instead, which doesn't preserve file metadata.)
+    #     Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3832.
+    shutil.move(src, dst, copy_function=shutil.copyfile)
 
 
 def copy(src, dst, verbose=1):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR applies the feedback from https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3847#discussion_r925819500:

Clarify the misleading docstring (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3847#discussion_r925996449)
Apply the fixes from https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3833 to `mv`.
Replace direct call to `shutil.move` with `mv`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Needed for #3847.