### PR TITLE
Add `install_sct.bat` as a release asset during `create-release.yml` workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -156,7 +156,23 @@ jobs:
 
     - uses: ncipollo/release-action@v1
       name: Create release
+      id: create_release
       with:
         tag: ${{ github.event.inputs.milestone_title }}
         token: ${{ secrets.GITHUB_TOKEN }}
         bodyFile: ".github/workflows/release-body.md"
+
+    - name: Create ${{ github.event.inputs.milestone_title }} Native Windows install script
+      run: |
+        cp install_sct.bat install_sct-${{ github.event.inputs.milestone_title }}_win.bat
+        perl -pi -e 's/set git_ref=master/set git_ref=${{ github.event.inputs.milestone_title }}/' install_sct-${{ github.event.inputs.milestone_title }}_win.bat
+    
+    - uses: xresloader/upload-to-github-release@v1
+      name: Attach Native Windows install script to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        file: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat"
+        draft: false
+        tag_name: ${{ github.event.inputs.milestone_title }}
+        release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -154,6 +154,11 @@ jobs:
         git tag ${{ github.event.inputs.milestone_title }}
         git push --tags
 
+    - name: Create ${{ github.event.inputs.milestone_title }} Native Windows install script
+      run: |
+        cp install_sct.bat install_sct-${{ github.event.inputs.milestone_title }}_win.bat
+        perl -pi -e 's/set git_ref=master/set git_ref=${{ github.event.inputs.milestone_title }}/' install_sct-${{ github.event.inputs.milestone_title }}_win.bat
+
     - uses: ncipollo/release-action@v1
       name: Create release
       id: create_release
@@ -161,18 +166,4 @@ jobs:
         tag: ${{ github.event.inputs.milestone_title }}
         token: ${{ secrets.GITHUB_TOKEN }}
         bodyFile: ".github/workflows/release-body.md"
-
-    - name: Create ${{ github.event.inputs.milestone_title }} Native Windows install script
-      run: |
-        cp install_sct.bat install_sct-${{ github.event.inputs.milestone_title }}_win.bat
-        perl -pi -e 's/set git_ref=master/set git_ref=${{ github.event.inputs.milestone_title }}/' install_sct-${{ github.event.inputs.milestone_title }}_win.bat
-    
-    - uses: xresloader/upload-to-github-release@v1
-      name: Attach Native Windows install script to release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        file: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat"
-        draft: false
-        tag_name: ${{ github.event.inputs.milestone_title }}
-        release_id: ${{ steps.create_release.outputs.id }}
+        artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat"


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR updates the create release workflow so that it will modify `install_sct.bat` to make it release-ready, then attach it as an asset to the release.

The changes in this PR were tested on my fork to create https://github.com/joshuacwnewton/spinalcordtoolbox/releases/tag/5.7.5, which indeed has the batch script attached as a release asset, with the correct line changed:

```
  rem Set git ref. If no git ref is specified when calling `install_sct.bat`, use a default instead.
  if [%1]==[] (
    set git_ref=5.7.5
  ) else (
    set git_ref=%1
  )
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3763.