### PR TITLE
Call `parser.error` properly

### DIFF
--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -50,7 +50,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
     elif type(image) == Image:
         img = nib.nifti1.Nifti1Image(image.data, image.hdr.get_best_affine())
     else:
-        raise Exception(TypeError)
+        raise TypeError(f'Invalid image type: {type(image)}')
 
     if image_dest is None:
         # Get dimensions of data
@@ -108,7 +108,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         elif type(image_dest) == Image:
             reference = nib.nifti1.Nifti1Image(image_dest.data, image_dest.hdr.get_best_affine())
         else:
-            raise Exception(TypeError)
+            raise TypeError(f'Invalid image type: {type(image_dest)}')
 
     if img.ndim == 3:
         # we use mode 'nearest' to overcome issue #2453

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -149,7 +149,7 @@ def main(argv=None):
     # Check parameters
     if method in ['diff', 'single']:
         if not fname_mask:
-            raise parser.error(f"Argument '-m' must be specified when using '-method {method}'.")
+            parser.error(f"Argument '-m' must be specified when using '-method {method}'.")
 
     # Load data
     im_data = Image(fname_data)
@@ -242,7 +242,7 @@ def main(argv=None):
         if fname_mask_noise:
             mask_noise = Image(fname_mask_noise).data
         else:
-            raise parser.error("A noise mask is mandatory with '-method single'.")
+            parser.error("A noise mask is mandatory with '-method single'.")
         # Check dimensionality of the noise mask
         if len(mask_noise.shape) != 3:
             raise ValueError(f"Input noise mask dimension: {dim}. Input dimension for the noise mask should be 3.")

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -204,7 +204,7 @@ def main(argv=None):
     mutually_inclusive_args = (path_qc, qc_seg)
     is_qc_none, is_seg_none = [arg is None for arg in mutually_inclusive_args]
     if not (is_qc_none == is_seg_none):
-        raise parser.error("Both '-qc' and '-qc-seg' are required in order to generate a QC report.")
+        parser.error("Both '-qc' and '-qc-seg' are required in order to generate a QC report.")
 
     # run moco
     fname_output_image = moco_wrapper(param)

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -180,7 +180,7 @@ def main(argv=None):
     mutually_inclusive_args = (path_qc, qc_seg)
     is_qc_none, is_seg_none = [arg is None for arg in mutually_inclusive_args]
     if not (is_qc_none == is_seg_none):
-        raise parser.error("Both '-qc' and '-qc-seg' are required in order to generate a QC report.")
+        parser.error("Both '-qc' and '-qc-seg' are required in order to generate a QC report.")
 
     # run moco
     fname_output_image = moco_wrapper(param)

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -56,8 +56,8 @@ class ParseDataOrScalarArgument(argparse.Action):
                 if data.shape == data_in.shape:
                     data_out.append(data)
                 else:
-                    raise parser.error(f"Dimensions of '{val}' ({data.shape}) "
-                                       f"must match input image ({data_in.shape}).")
+                    parser.error(f"Dimensions of '{val}' ({data.shape}) "
+                                 f"must match input image ({data_in.shape}).")
 
         setattr(namespace, self.dest, data_out)
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -45,11 +45,11 @@ class SeparateNormArgs(argparse.Action):
         pred = values[::2]
         val = values[1::2]
         if len(pred) != len(val):
-            raise parser.error("Values for normalization need to be specified for each predictor.")
+            parser.error("Values for normalization need to be specified for each predictor.")
         try:
             data_subject = {p: float(v) for p, v in zip(pred, val)}
         except ValueError as e:
-            raise parser.error(f"Non-numeric value passed to '-normalize': {e}")
+            parser.error(f"Non-numeric value passed to '-normalize': {e}")
         setattr(namespace, self.dest, data_subject)
 
 
@@ -452,7 +452,7 @@ def main(argv=None):
         path_model = os.path.join(__sct_dir__, 'data', 'csa_normalization_models',
                                   '_'.join(sorted(data_subject.columns)) + '.csv')
         if not os.path.isfile(path_model):
-            raise parser.error('Invalid choice of predictors in -normalize. Please specify sex and brain-volume or sex, brain-volume and thalamus-volume.')
+            parser.error('Invalid choice of predictors in -normalize. Please specify sex and brain-volume or sex, brain-volume and thalamus-volume.')
         # Get normalization model
         # Models are generated with https://github.com/sct-pipeline/ukbiobank-spinalcord-csa/blob/master/pipeline_ukbiobank/cli/compute_stats.py
         # TODO update link with release tag.
@@ -495,7 +495,7 @@ def main(argv=None):
                             subject=qc_subject,
                             process='sct_process_segmentation')
             else:
-                raise parser.error('-qc-image is required to display QC report.')
+                parser.error('-qc-image is required to display QC report.')
         else:
             logger.warning('QC report only available for PMJ-based CSA. QC report not generated.')
 


### PR DESCRIPTION
This PR removes the `raise parser.error(...)` anti-pattern from the codebase.

The function `parser.error()` from `argparse` never returns with a value; it either exits the program, or raises an exception. There's no need to raise the non-existent return value.

All other `raise` statements look like they raise actual exceptions (maybe not always the most appropriate one, but at least an exception). While checking this, I couldn't ignore two cases of `raise Exception(TypeError)`, so I fixed those as well.