### PR TITLE
Add `-ignore-ses` flag to process `sub-` directories even when `ses-` subdirectories are present

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -191,13 +191,13 @@ def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False)
           TODO: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3415
     """
     dirs = []
-    subject_dirs = sorted([f for f in os.listdir(path_data)
-                           if f.startswith(subject_prefix)
-                           and os.path.isdir(os.path.join(path_data, f))])
+    subject_dirs = sorted([d.name for d in os.scandir(path_data)
+                           if d.name.startswith(subject_prefix)
+                           and d.is_dir()])
     for sub_dir in subject_dirs:
-        session_dirs = sorted([f for f in os.listdir(os.path.join(path_data, sub_dir))
-                               if f.startswith('ses-')
-                               and os.path.isdir(os.path.join(path_data, sub_dir, f))])
+        session_dirs = sorted([d.name for d in os.scandir(os.path.join(path_data, sub_dir))
+                               if d.name.startswith('ses-')
+                               and d.is_dir()])
         if session_dirs and not ignore_ses:
             # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
             for sess_dir in session_dirs:

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -191,18 +191,20 @@ def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False)
           TODO: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3415
     """
     dirs = []
-    subject_dirs = sorted([f for f in os.listdir(path_data) if f.startswith(subject_prefix)])
+    subject_dirs = sorted([f for f in os.listdir(path_data)
+                           if f.startswith(subject_prefix)
+                           and os.path.isdir(os.path.join(path_data, f))])
     for sub_dir in subject_dirs:
-        # Only consider folders
-        if os.path.isdir(os.path.join(path_data, sub_dir)):
-            session_dirs = sorted([f for f in os.listdir(os.path.join(path_data, sub_dir)) if f.startswith('ses-')])
-            if session_dirs and not ignore_ses:
-                # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
-                for sess_dir in session_dirs:
-                    dirs.append(os.path.join(sub_dir, sess_dir))
-            else:
-                # Otherwise, consider only 'sub-' directories and don't include 'ses-' subdirectories: e.g. sub-XX
-                dirs.append(sub_dir)
+        session_dirs = sorted([f for f in os.listdir(os.path.join(path_data, sub_dir))
+                               if f.startswith('ses-')
+                               and os.path.isdir(os.path.join(path_data, sub_dir, f))])
+        if session_dirs and not ignore_ses:
+            # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
+            for sess_dir in session_dirs:
+                dirs.append(os.path.join(sub_dir, sess_dir))
+        else:
+            # Otherwise, consider only 'sub-' directories and don't include 'ses-' subdirectories: e.g. sub-XX
+            dirs.append(sub_dir)
 
     return dirs
 

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -191,14 +191,13 @@ def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False)
           TODO: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3415
     """
     dirs = []
-    subject_dirs = [f for f in os.listdir(path_data) if f.startswith(subject_prefix)]
+    subject_dirs = sorted([f for f in os.listdir(path_data) if f.startswith(subject_prefix)])
     for sub_dir in subject_dirs:
         # Only consider folders
         if os.path.isdir(os.path.join(path_data, sub_dir)):
-            session_dirs = [f for f in os.listdir(os.path.join(path_data, sub_dir)) if f.startswith('ses-')]
+            session_dirs = sorted([f for f in os.listdir(os.path.join(path_data, sub_dir)) if f.startswith('ses-')])
             if session_dirs and not ignore_ses:
                 # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
-                session_dirs.sort()
                 for sess_dir in session_dirs:
                     dirs.append(os.path.join(sub_dir, sess_dir))
             else:

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -190,22 +190,22 @@ def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False)
         - This function is a rudimentary version of the library PyBIDS: https://github.com/bids-standard/pybids.
           TODO: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3415
     """
-    subject_dirs = []
-    subject_flat_dirs = [f for f in os.listdir(path_data) if f.startswith(subject_prefix)]
-    for isub in subject_flat_dirs:
+    dirs = []
+    subject_dirs = [f for f in os.listdir(path_data) if f.startswith(subject_prefix)]
+    for sub_dir in subject_dirs:
         # Only consider folders
-        if os.path.isdir(os.path.join(path_data, isub)):
-            session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
+        if os.path.isdir(os.path.join(path_data, sub_dir)):
+            session_dirs = [f for f in os.listdir(os.path.join(path_data, sub_dir)) if f.startswith('ses-')]
             if session_dirs and not ignore_ses:
                 # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
                 session_dirs.sort()
-                for isess in session_dirs:
-                    subject_dirs.append(os.path.join(isub, isess))
+                for sess_dir in session_dirs:
+                    dirs.append(os.path.join(sub_dir, sess_dir))
             else:
                 # Otherwise, consider only 'sub-' directories and don't include 'ses-' subdirectories: e.g. sub-XX
-                subject_dirs.append(isub)
+                dirs.append(sub_dir)
 
-    return subject_dirs
+    return dirs
 
 
 def _filter_directories(dir_list, include=None, include_list=None, exclude=None, exclude_list=None):

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -182,7 +182,7 @@ def _find_nonsys32_bash_exe():
 
 def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False):
     """
-    Parse a dataset directory to find subject directories (or session subdirectories, if present).
+    Parse a dataset directory to find subject directories (and session subdirectories, if present).
 
     Notes:
         - The dataset is assumed to be structured in a (somewhat) BIDS-compliant way, see:
@@ -190,23 +190,22 @@ def _parse_dataset_directory(path_data, subject_prefix="sub-", ignore_ses=False)
         - This function is a rudimentary version of the library PyBIDS: https://github.com/bids-standard/pybids.
           TODO: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3415
     """
-    # Find subject directories within the root dataset folder
-    subject_dirs = sorted([f for f in os.listdir(path_data)
-                           if f.startswith(subject_prefix) and os.path.isdir(os.path.join(path_data, f))])
+    subject_dirs = []
+    subject_flat_dirs = [f for f in os.listdir(path_data) if f.startswith(subject_prefix)]
+    for isub in subject_flat_dirs:
+        # Only consider folders
+        if os.path.isdir(os.path.join(path_data, isub)):
+            session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
+            if session_dirs and not ignore_ses:
+                # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
+                session_dirs.sort()
+                for isess in session_dirs:
+                    subject_dirs.append(os.path.join(isub, isess))
+            else:
+                # Otherwise, consider only 'sub-' directories and don't include 'ses-' subdirectories: e.g. sub-XX
+                subject_dirs.append(isub)
 
-    # Find session subdirectories within subject directories
-    session_dirs = []
-    for sub_dir in subject_dirs:
-        path_sub = os.path.join(path_data, sub_dir)
-        subject_session_dirs = sorted([os.path.join(sub_dir, f) for f in os.listdir(path_sub)
-                                       if f.startswith("ses-") and os.path.isdir(os.path.join(path_sub, f))])
-        session_dirs.extend(subject_session_dirs)
-
-    # Determine which directories to return
-    if session_dirs and not ignore_ses:
-        return session_dirs
-    else:
-        return subject_dirs
+    return subject_dirs
 
 
 def _filter_directories(dir_list, include=None, include_list=None, exclude=None, exclude_list=None):

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -442,7 +442,7 @@ def main(argv=None):
         # Only consider folders
         if os.path.isdir(os.path.join(path_data, isub)):
             session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
-            if session_dirs and arguments.ignore_ses is not True:
+            if session_dirs and not arguments.ignore_ses:
                 # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
                 session_dirs.sort()
                 for isess in session_dirs:

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -437,14 +437,14 @@ def main(argv=None):
         # Only consider folders
         if os.path.isdir(os.path.join(path_data, isub)):
             session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
-            if not session_dirs:
-                # There is no session folder, so we consider only sub- directory: sub-XX
-                subject_dirs.append(isub)
-            else:
+            if session_dirs:
                 # There is a session folder, so we concatenate: sub-XX/ses-YY
                 session_dirs.sort()
                 for isess in session_dirs:
                     subject_dirs.append(os.path.join(isub, isess))
+            else:
+                # There is no session folder, so we consider only sub- directory: sub-XX
+                subject_dirs.append(isub)
 
     # Handle inclusion lists
     assert not ((arguments.include is not None) and (arguments.include_list is not None)),\

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -123,6 +123,11 @@ def get_parser():
                         help='Optional space separated list of subjects to exclude. Only process '
                         'a subject if they are not on this list. Inclusions are processed before exclusions. '
                         'Cannot be used with either `exclude`.', nargs='+')
+    parser.add_argument('-ignore-ses', action='store_true',
+                        help="By default, if 'ses' subfolders are present, then 'sct_run_batch' will run the script "
+                             "within each individual 'ses' subfolder. Passing `-ignore-ses` will change the behavior "
+                             "so that 'sct_run_batch' will not go into each 'ses' folder. Instead, it will run the "
+                             "script on just the top-level subject folders.")
     parser.add_argument('-path-segmanual', default='.',
                         help='Setting for environment variable: PATH_SEGMANUAL\n'
                         'A path containing manual segmentations to be used by the script program.')
@@ -437,13 +442,13 @@ def main(argv=None):
         # Only consider folders
         if os.path.isdir(os.path.join(path_data, isub)):
             session_dirs = [f for f in os.listdir(os.path.join(path_data, isub)) if f.startswith('ses-')]
-            if session_dirs:
-                # There is a session folder, so we concatenate: sub-XX/ses-YY
+            if session_dirs and arguments.ignore_ses is not True:
+                # There is a 'ses-' subdirectory AND arguments.ignore_ses = False, so we concatenate: e.g. sub-XX/ses-YY
                 session_dirs.sort()
                 for isess in session_dirs:
                     subject_dirs.append(os.path.join(isub, isess))
             else:
-                # There is no session folder, so we consider only sub- directory: sub-XX
+                # Otherwise, consider only 'sub-' directories and don't include 'ses-' subdirectories: e.g. sub-XX
                 subject_dirs.append(isub)
 
     # Handle inclusion lists

--- a/testing/cli/test_sct_run_batch.py
+++ b/testing/cli/test_sct_run_batch.py
@@ -115,6 +115,29 @@ def test_directory_inclusion_exclusion():
     assert filter_dirs(sess_dir_list, exclude_list=['sub01', 'sub02']) == ['sub03/ses01', 'sub03/ses02']
 
 
+def test_directory_parsing(tmp_path):
+    """
+    Test that subject and session subdirectories are parsed correctly within a sample dataset structure.
+    """
+
+    parse_dir = sct_run_batch._parse_dataset_directory  # for brevity
+
+    subject_names = ['sub-001', 'sub-002', 'sub-003']
+    for sub in subject_names:
+        (tmp_path / sub).mkdir()
+        (tmp_path / f"{sub}.txt").touch()  # Add false positive files to ensure only directories are returned
+    assert parse_dir(tmp_path) == subject_names
+    assert parse_dir(tmp_path, subject_prefix="subject-") == []
+
+    session_names = ['ses-001', 'ses-002']
+    for sub in subject_names:
+        for ses in session_names:
+            (tmp_path / sub / ses).mkdir()
+            (tmp_path / sub / f"{ses}.txt").touch()  # Add false positive files to ensure only directories are returned
+    assert parse_dir(tmp_path) == [os.path.join(sub, ses) for sub in subject_names for ses in session_names]
+    assert parse_dir(tmp_path, ignore_ses=True) == subject_names
+
+
 def test_non_executable_task(tmp_path, dummy_script):
     """
     Test that sct_run_batch can still process a non-executable script. (sct_run_batch will attempt

--- a/testing/cli/test_sct_run_batch.py
+++ b/testing/cli/test_sct_run_batch.py
@@ -130,11 +130,12 @@ def test_directory_parsing(tmp_path):
     assert parse_dir(tmp_path, subject_prefix="subject-") == []
 
     session_names = ['ses-001', 'ses-002']
-    for sub in subject_names:
+    for sub in subject_names[:-1]:  # Skip creating 'ses' dirs in [-1] to test a mix of 'sub' and 'sub/ses' directories
         for ses in session_names:
             (tmp_path / sub / ses).mkdir()
             (tmp_path / sub / f"{ses}.txt").touch()  # Add false positive files to ensure only directories are returned
-    assert parse_dir(tmp_path) == [os.path.join(sub, ses) for sub in subject_names for ses in session_names]
+    assert parse_dir(tmp_path) == ([os.path.join(sub, ses) for sub in subject_names[:-1] for ses in session_names]
+                                   + [subject_names[-1]])  # Last subject shouldn't have any session subdirectories
     assert parse_dir(tmp_path, ignore_ses=True) == subject_names
 
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR provides an option that allows users to process `sub-` directories on their own, even when `ses-` subdirectories are present.

Without `-ignore-ses`:

![image](https://user-images.githubusercontent.com/16181459/185201447-09e5a4d8-96c8-4352-bd1b-ce0f12935805.png)

With `-ignore-ses`:

![image](https://user-images.githubusercontent.com/16181459/185201004-826022f7-20cd-414f-8d12-b1a2eb3c3146.png)

I've used `action='store_true'` here because it preserves the existing behavior, so there should be no changes unless users choose to opt-in.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3809.
