### PR TITLE
Ensure that `-list-labels` is the last argument that is parsed

### DIFF
--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -271,6 +271,11 @@ def get_parser():
 
 
 def main(argv=None):
+    # Ensure that the "-list-labels" argument is always parsed last. That way, if `-f` is passed, then `-list-labels`
+    # will see the new location and look there. (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3634)
+    if "-list-labels" in argv:
+        argv.append(argv.pop(argv.index("-list-labels")))
+
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -20,6 +20,7 @@
 import sys
 import os
 import argparse
+from typing import List
 
 import numpy as np
 
@@ -270,7 +271,12 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
+    """
+    Main function. When this script is run via CLI, sys.argv[1:] is passed to 'argv'.
+
+    :param argv: A list of unparsed arguments, which is passed to ArgumentParser.parse_args()
+    """
     # Ensure that the "-list-labels" argument is always parsed last. That way, if `-f` is passed, then `-list-labels`
     # will see the new location and look there. (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3634)
     if "-list-labels" in argv:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`sct_extract_metric -list-labels` is a way to display the `info_label.txt` file contained within the folder pointed to by `-f`:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7b423e3b103faae6759b388c8e2432fc94a8c57/spinalcordtoolbox/scripts/sct_extract_metric.py#L51

However, if the user specifies a new `-f`, then the order of parsing starts to matter:

* If `sct_extract_metric -f <directory> -list-labels` is used, then `-f` will be updated first, and `-list-labels` will display correctly.
* If `sct_extract_metric -list-labels -f <directory>` is used instead, then `-list-labels` will be parsed before `-f` can be updated, and it will either crash, or display the wrong `info_label.txt` file.

To make sure that `-list-labels` always works as expected, we need to parse it last in the list of arguments, hence this PR.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3634.
