### PR TITLE
Replace "argv=None" default by "argv: Sequence[str]" type hint

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -11,7 +11,7 @@
 import os
 import sys
 import pickle
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -504,7 +504,7 @@ class AnalyzeLeion:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import pickle
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -503,7 +504,7 @@ class AnalyzeLeion:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -11,7 +11,7 @@
 import os
 import sys
 import itertools
-from typing import List
+from typing import Sequence
 
 import numpy as np
 from skimage.feature import greycomatrix, greycoprops
@@ -299,7 +299,7 @@ class ParamGLCM(object):
         self.angle = '0,45,90,135'  # Rotation angles for co-occurrence matrix
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import itertools
+from typing import List
 
 import numpy as np
 from skimage.feature import greycomatrix, greycoprops
@@ -298,7 +299,7 @@ class ParamGLCM(object):
         self.angle = '0,45,90,135'  # Rotation angles for co-occurrence matrix
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -17,6 +17,7 @@
 import sys
 import os
 import functools
+from typing import List
 
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.cropping import ImageCropper
@@ -332,7 +333,7 @@ class Transform:
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     """
     Entry point for sct_apply_transfo
     :param argv: list of input arguments.

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -17,7 +17,7 @@
 import sys
 import os
 import functools
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.cropping import ImageCropper
@@ -333,7 +333,7 @@ class Transform:
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Entry point for sct_apply_transfo
     :param argv: list of input arguments.

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -24,7 +24,7 @@ import importlib
 import warnings
 import psutil
 import traceback
-from typing import List
+from typing import Sequence
 
 import requirements
 
@@ -193,7 +193,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = complete_test = arguments.complete

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -24,6 +24,7 @@ import importlib
 import warnings
 import psutil
 import traceback
+from typing import List
 
 import requirements
 
@@ -192,7 +193,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = complete_test = arguments.complete

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -12,7 +12,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -129,7 +129,7 @@ def get_parser():
 
 # main
 # =======================================================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -12,6 +12,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -128,7 +129,7 @@ def get_parser():
 
 # main
 # =======================================================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -12,7 +12,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -497,7 +497,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+from typing import List
 
 import numpy as np
 
@@ -496,7 +497,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
@@ -72,7 +73,7 @@ def mscc(di, da, db):
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
@@ -73,7 +73,7 @@ def mscc(di, da, db):
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -13,6 +13,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_loglevel
 from spinalcordtoolbox.image import Image
@@ -70,7 +71,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -13,7 +13,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_loglevel
 from spinalcordtoolbox.image import Image
@@ -71,7 +71,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -18,6 +18,7 @@
 import sys
 import os
 import json
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.qmri.mt import compute_mtsat
@@ -159,7 +160,7 @@ def fetch_metadata(fname_json, field):
         return metadata[field]
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -18,7 +18,7 @@
 import sys
 import os
 import json
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.qmri.mt import compute_mtsat
@@ -160,7 +160,7 @@ def fetch_metadata(fname_json, field):
         return metadata[field]
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -15,7 +15,7 @@
 ########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -130,7 +130,7 @@ def weighted_std(values, weights):
     return np.sqrt(variance)
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -15,6 +15,7 @@
 ########################################################################################
 
 import sys
+from typing import List
 
 import numpy as np
 
@@ -129,7 +130,7 @@ def weighted_std(values, weights):
     return np.sqrt(variance)
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -16,6 +16,7 @@
 import sys
 import os
 import functools
+from typing import List
 
 from spinalcordtoolbox.image import Image, check_dim, generate_output_file
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
@@ -29,7 +30,7 @@ class Param:
         self.fname_warp_final = 'warp_final.nii.gz'
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -16,7 +16,7 @@
 import sys
 import os
 import functools
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.image import Image, check_dim, generate_output_file
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
@@ -30,7 +30,7 @@ class Param:
         self.fname_warp_final = 'warp_final.nii.gz'
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -13,6 +13,7 @@
 # TODO: add output check in convert
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
 import spinalcordtoolbox.image as image
@@ -64,7 +65,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param args:

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -13,7 +13,7 @@
 # TODO: add output check in convert
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
 import spinalcordtoolbox.image as image
@@ -65,7 +65,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param args:

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -16,7 +16,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -121,7 +121,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -16,6 +16,7 @@
 
 import sys
 import os
+from typing import List
 
 import numpy as np
 
@@ -120,7 +121,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -8,7 +8,7 @@
 # About the license: see the file LICENSE.TXT
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.image import Image, add_suffix
@@ -132,7 +132,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -8,6 +8,7 @@
 # About the license: see the file LICENSE.TXT
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.image import Image, add_suffix
@@ -131,7 +132,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -13,7 +13,7 @@ ivadomed package.
 import os
 import sys
 import logging
-from typing import List
+from typing import Sequence
 
 from ivadomed import inference as imed_inference
 import nibabel as nib
@@ -132,7 +132,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -13,6 +13,7 @@ ivadomed package.
 import os
 import sys
 import logging
+from typing import List
 
 from ivadomed import inference as imed_inference
 import nibabel as nib
@@ -131,7 +132,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -9,7 +9,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.image import add_suffix
@@ -91,7 +91,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -9,6 +9,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
 from spinalcordtoolbox.image import add_suffix
@@ -90,7 +91,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -13,7 +13,7 @@
 
 import os
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -106,7 +106,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """Main function."""
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -105,7 +106,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """Main function."""
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -126,7 +127,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """Main function."""
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -127,7 +127,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """Main function."""
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -2,6 +2,7 @@
 
 import sys
 from time import time
+from typing import List
 
 import numpy as np
 import nibabel as nib
@@ -91,7 +92,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -2,7 +2,7 @@
 
 import sys
 from time import time
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import nibabel as nib
@@ -92,7 +92,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -24,6 +24,7 @@ About the license: see the file LICENSE.TXT
 import os
 import sys
 import logging
+from typing import List
 
 from scipy.ndimage.measurements import center_of_mass
 import nibabel as nib
@@ -282,7 +283,7 @@ class DetectPMJ:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -24,7 +24,7 @@ About the license: see the file LICENSE.TXT
 import os
 import sys
 import logging
-from typing import List
+from typing import Sequence
 
 from scipy.ndimage.measurements import center_of_mass
 import nibabel as nib
@@ -283,7 +283,7 @@ class DetectPMJ:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -12,7 +12,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
@@ -102,7 +102,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
@@ -101,7 +102,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -15,12 +15,12 @@
 
 import sys
 import math
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -15,11 +15,12 @@
 
 import sys
 import math
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
@@ -84,7 +84,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 
@@ -83,7 +84,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -9,7 +9,7 @@
 
 
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
@@ -97,7 +97,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -9,6 +9,7 @@
 
 
 import sys
+from typing import List
 
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
@@ -96,7 +97,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
@@ -54,7 +54,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
@@ -53,7 +54,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
@@ -56,7 +56,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
 
@@ -55,7 +56,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import nibabel as nib
@@ -80,7 +80,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import sys
+from typing import List
+
 import numpy as np
 import nibabel as nib
 from dipy.denoise.patch2self import patch2self
@@ -78,7 +80,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -109,7 +110,7 @@ def create_custom_legend(fig, shell_colors, bvals):
 # MAIN
 # ==========================================================================================
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -110,7 +110,7 @@ def create_custom_legend(fig, shell_colors, bvals):
 # MAIN
 # ==========================================================================================
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -28,6 +28,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
@@ -173,7 +174,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -28,7 +28,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
@@ -174,7 +174,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -16,6 +16,7 @@ import sys
 import math
 import time
 import os
+from typing import List
 
 import numpy as np
 
@@ -109,7 +110,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -16,7 +16,7 @@ import sys
 import math
 import time
 import os
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -110,7 +110,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -11,7 +11,7 @@
 #########################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_loglevel
 
@@ -56,7 +56,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -11,6 +11,7 @@
 #########################################################################################
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_loglevel
 
@@ -55,7 +56,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.download import install_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
@@ -217,7 +217,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+from typing import List
 
 from spinalcordtoolbox.download import install_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
@@ -216,7 +217,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -272,11 +272,6 @@ def get_parser():
 
 
 def main(argv: Sequence[str]):
-    """
-    Main function. When this script is run via CLI, sys.argv[1:] is passed to 'argv'.
-
-    :param argv: A list of unparsed arguments, which is passed to ArgumentParser.parse_args()
-    """
     # Ensure that the "-list-labels" argument is always parsed last. That way, if `-f` is passed, then `-list-labels`
     # will see the new location and look there. (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3634)
     if "-list-labels" in argv:

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -20,7 +20,7 @@
 import sys
 import os
 import argparse
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -271,7 +271,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function. When this script is run via CLI, sys.argv[1:] is passed to 'argv'.
 
@@ -280,7 +280,7 @@ def main(argv: List[str]):
     # Ensure that the "-list-labels" argument is always parsed last. That way, if `-f` is passed, then `-list-labels`
     # will see the new location and look there. (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3634)
     if "-list-labels" in argv:
-        argv.append(argv.pop(argv.index("-list-labels")))
+        argv = [s for s in argv if s != "-list-labels"] + ["-list-labels"]
 
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -13,6 +13,7 @@
 
 import sys
 import logging
+from typing import List
 
 from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
@@ -30,7 +31,7 @@ class Param:
         self.verbose = 1
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param fname_anat:

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -13,7 +13,7 @@
 
 import sys
 import logging
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
@@ -31,7 +31,7 @@ class Param:
         self.verbose = 1
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param fname_anat:

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -13,7 +13,7 @@
 # ######################################################################################################################
 
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -101,7 +101,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -13,6 +13,7 @@
 # ######################################################################################################################
 
 import sys
+from typing import List
 
 import numpy as np
 
@@ -100,7 +101,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -13,7 +13,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
@@ -151,7 +151,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -13,6 +13,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
@@ -150,7 +151,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from typing import List
 
 import numpy as np
 
@@ -117,7 +118,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -118,7 +118,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from typing import List, Sequence
+from typing import Sequence
 
 import numpy as np
 from nibabel import Nifti1Image
@@ -186,7 +186,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from typing import Sequence
+from typing import List, Sequence
 
 import numpy as np
 from nibabel import Nifti1Image
@@ -186,7 +186,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -232,11 +232,6 @@ def get_parser():
 # MAIN
 # ==========================================================================================
 def main(argv: Sequence[str]):
-    """
-    Main function. When this script is run via CLI, the main function is called using main(sys.argv[1:]).
-
-    :param argv: A list of unparsed arguments, which is passed to ArgumentParser.parse_args()
-    """
     for i, arg in enumerate(argv):
         if arg == '-create-seg' and len(argv) > i+1 and '-1,' in argv[i+1]:
             raise DeprecationWarning("The use of '-1' for '-create-seg' has been deprecated. Please use "

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -18,7 +18,7 @@
 
 import os
 import sys
-from typing import Sequence
+from typing import List, Sequence
 
 import numpy as np
 
@@ -231,7 +231,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: Sequence[str]):
+def main(argv: List[str]):
     """
     Main function. When this script is run via CLI, the main function is called using main(sys.argv[1:]).
 

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -18,7 +18,7 @@
 
 import os
 import sys
-from typing import List, Sequence
+from typing import Sequence
 
 import numpy as np
 
@@ -231,7 +231,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function. When this script is run via CLI, the main function is called using main(sys.argv[1:]).
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -13,6 +13,7 @@
 import sys
 import os
 import argparse
+from typing import List
 
 import numpy as np
 
@@ -271,7 +272,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -13,7 +13,7 @@
 import sys
 import os
 import argparse
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -272,7 +272,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -299,11 +299,6 @@ def get_parser():
 # MAIN
 # ==========================================================================================
 def main(argv: Sequence[str]):
-    """
-    Main function
-    :param argv:
-    :return:
-    """
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -13,8 +13,9 @@
 import sys
 import pickle
 import gzip
-
 import argparse
+from typing import List
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -297,7 +298,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -14,7 +14,7 @@ import sys
 import pickle
 import gzip
 import argparse
-from typing import List
+from typing import Sequence
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -298,7 +298,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -15,7 +15,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -197,7 +197,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+from typing import List
 
 import numpy as np
 
@@ -196,7 +197,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -20,7 +20,7 @@ import sys
 import os
 import logging
 import argparse
-from typing import List
+from typing import Sequence
 
 import pandas as pd
 import numpy as np
@@ -346,7 +346,7 @@ def _make_figure(metric, fit_results):
     return fname_img
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -19,8 +19,10 @@
 import sys
 import os
 import logging
-import pandas as pd
 import argparse
+from typing import List
+
+import pandas as pd
 import numpy as np
 from matplotlib.ticker import MaxNLocator
 
@@ -344,7 +346,7 @@ def _make_figure(metric, fit_results):
     return fname_img
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -17,7 +17,7 @@ import os
 import pathlib
 import sys
 import logging
-from typing import List
+from typing import Sequence
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -669,7 +669,7 @@ def propseg(img_input, options_dict):
     return Image(fname_seg)
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     if sys.platform.startswith("win32"):
         # This isn't *really* a parsing error, but it feels a little more official to display the help with this error

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import sys
 import logging
+from typing import List
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -668,7 +669,7 @@ def propseg(img_input, options_dict):
     return Image(fname_seg)
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     if sys.platform.startswith("win32"):
         # This isn't *really* a parsing error, but it feels a little more official to display the help with this error

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -9,7 +9,7 @@
 
 import os
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser
 
@@ -74,7 +74,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser
 
@@ -73,7 +74,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -34,7 +34,7 @@ import sys
 import os
 import time
 from copy import deepcopy
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -305,7 +305,7 @@ class Param:
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -34,6 +34,7 @@ import sys
 import os
 import time
 from copy import deepcopy
+from typing import List
 
 import numpy as np
 
@@ -304,7 +305,7 @@ class Param:
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -17,7 +17,7 @@
 import sys
 import os
 import time
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -299,7 +299,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -17,6 +17,7 @@
 import sys
 import os
 import time
+from typing import List
 
 import numpy as np
 
@@ -298,7 +299,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -13,7 +13,7 @@
 # TODO: add possiblity to resample to destination image
 
 import sys
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 import spinalcordtoolbox.resampling
@@ -109,7 +109,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -13,6 +13,7 @@
 # TODO: add possiblity to resample to destination image
 
 import sys
+from typing import List
 
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
 import spinalcordtoolbox.resampling
@@ -108,7 +109,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -28,6 +28,7 @@ import json
 import tempfile
 import warnings
 import shutil
+from typing import List
 from types import SimpleNamespace
 from textwrap import dedent
 
@@ -300,7 +301,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     return res
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -28,7 +28,7 @@ import json
 import tempfile
 import warnings
 import shutil
-from typing import List
+from typing import Sequence
 from types import SimpleNamespace
 from textwrap import dedent
 
@@ -301,7 +301,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     return res
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -15,7 +15,7 @@
 import sys
 import os
 import time
-from typing import List
+from typing import Sequence
 
 import numpy as np
 
@@ -119,7 +119,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import time
+from typing import List
 
 import numpy as np
 
@@ -118,7 +119,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -14,7 +14,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
@@ -189,7 +189,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+from typing import List
 
 from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
@@ -188,7 +189,7 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(argv=None):
+def main(argv: List[str]):
     """
     Main function
     :param argv:

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -13,6 +13,7 @@
 
 import sys
 import os
+from typing import List
 
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
@@ -229,7 +230,7 @@ def get_parser():
     return parser
 
 
-def main(argv=None):
+def main(argv: List[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -13,7 +13,7 @@
 
 import sys
 import os
-from typing import List
+from typing import Sequence
 
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
@@ -230,7 +230,7 @@ def get_parser():
     return parser
 
 
-def main(argv: List[str]):
+def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v


### PR DESCRIPTION
## Description
This PR replaces the `def main(argv=None)` pattern in SCT scripts with ~~`def main(argv: List[str])`~~ `def main(argv: Sequence[str])`, since we never call `main()` without specifying `argv`, and since the object passed in is always a list of strings. ~~It uses `List` rather than the more generic `Sequence` because one script (sct_extract_metric.py) relies on specific list methods (namely, `append`).~~

I've also updated the [dev wiki](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming:-CLI-script-structure) to reflect this change.

## Linked issues
Fixes #3176.