### PR TITLE
Fix `include_list`/`exclude` argument ordering in call to `_filter_directories`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -505,8 +505,8 @@ def main(argv: Sequence[str]):
         parser.error('Only one of `exclude` and `exclude-list` can be used')
 
     subject_dirs = _filter_directories(subject_dirs,
-                                       arguments.include, arguments.exclude,
-                                       arguments.include_list, arguments.exclude_list)
+                                       include=arguments.include, include_list=arguments.include_list,
+                                       exclude=arguments.exclude, exclude_list=arguments.exclude_list)
 
     # Determine the number of jobs we can run simultaneously
     if arguments.jobs < 1:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This issue is a follow-on for https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3859. In that PR, a bug was merged to `master`, because the ordering of the arguments for the `_filter_directories` function call was incorrect:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/51df5fc0569c0c04571e44601b7ddf95c981631b/spinalcordtoolbox/scripts/sct_run_batch.py#L213

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/51df5fc0569c0c04571e44601b7ddf95c981631b/spinalcordtoolbox/scripts/sct_run_batch.py#L507-L509

Thank you to @valosekj for catching this. :heart: 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3598.