### PR TITLE
Properly escape `\` in the regex for removing `sct_env` from old RC files

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -694,7 +694,7 @@ conda deactivate >/dev/null 2>&1
 if [[ -e "$RC_FILE_PATH" ]]; then
     if grep "sct_env" "$RC_FILE_PATH"; then
       print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
-      perl -pi -e 's/^(# )?(.*bin/sct_env)/# \2/' "$RC_FILE_PATH"
+      perl -pi -e 's/^(# )?(.*bin\/sct_env)/# \2/' "$RC_FILE_PATH"
     fi
     if grep "^export MPLBACKEND=Agg" "$RC_FILE_PATH"; then
       print info "Commenting out 'export MPLBACKEND=Agg' from previous SCT installation"


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`install_sct` uses a regex-based `perl -pi -e` find and replace command to comment out any instances of the `sct_env` environment variable being set (which is no longer used).

This PR amends the `perl -pi -e` statement so that it uses the pattern that was tested by @kousu in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3805#discussion_r888226125.

(The reason for this bug is because, in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3805#discussion_r888226125, the PR "suggestion" was subtly different than what was actually tested.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3871.