### PR TITLE
`shell.py`: Let `Metavar` inherit from `str` to silence PyCharm type warning

### DIFF
--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -244,7 +244,7 @@ def list_type(delimiter, subtype):
     return list_typecast_func
 
 
-class Metavar(Enum):
+class Metavar(str, Enum):
     """
     This class is used to display intuitive input types via the metavar field of argparse
     """


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

(This is a tiny developer QOL change.)

Currently, SCT uses a custom Enum class called `Metavar` to print `<type>` strings in argparse help descriptions:

![image](https://user-images.githubusercontent.com/16181459/188906490-986b5251-94a3-4720-9da9-aa0e69b2eff1.png)

PyCharm doesn't like the fact that we're using a bare `Enum`, though:

![image](https://user-images.githubusercontent.com/16181459/188906671-29dd7607-b459-4bbf-857e-f2a297ec590b.png)

We can fix this by adding `str` to the list of types that `Metavar` inherits, though:

![image](https://user-images.githubusercontent.com/16181459/188906898-aea3f88c-8099-4836-93b9-aeca1c539770.png)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A.
