### PR TITLE
Simplify `add_suffix`

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1404,7 +1404,7 @@ def add_suffix(fname, suffix):
         add_suffix(t2.nii.gz, a) -> t2a.nii.gz
     """
     stem, ext = splitext(fname)
-    return os.path.join(stem + suffix + ext)
+    return stem + suffix + ext
 
 
 def splitext(fname):


### PR DESCRIPTION
The strings are already concatenated by `+`, and `os.path.join` with a single string argument just returns it unchanged.