### PR TITLE
Throw error when labels are lost during the straightening transform

### DIFF
--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -592,6 +592,7 @@ def main(argv: Sequence[str]):
 
             # Apply straightening to labels
             printv('\nApply straightening to labels...', verbose)
+            label_vals_src = {coord.value for coord in Image(ftmp_label).getCoordinatesAveragedByValue()}
             sct_apply_transfo.main(argv=[
                 '-i', ftmp_label,
                 '-o', add_suffix(ftmp_label, '_straight'),
@@ -599,6 +600,12 @@ def main(argv: Sequence[str]):
                 '-w', 'warp_curve2straight.nii.gz',
                 '-x', 'nn'])
             ftmp_label = add_suffix(ftmp_label, '_straight')
+            label_vals_out = {coord.value for coord in Image(ftmp_label).getCoordinatesAveragedByValue()}
+            missing_labels = label_vals_src - label_vals_out
+            if missing_labels:
+                raise RuntimeError(f"Labels {missing_labels} were lost during straightening transform. This can be "
+                                   f"caused by the labels being outside the ROI of the spinal cord segmentation. "
+                                   f"Please make sure all labels are within the ROI of the spinal cord segmentation.")
 
             # Compute rigid transformation straight landmarks --> template landmarks
             printv('\nEstimate transformation for step #0...', verbose)

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -603,9 +603,11 @@ def main(argv: Sequence[str]):
             label_vals_out = {coord.value for coord in Image(ftmp_label).getCoordinatesAveragedByValue()}
             missing_labels = label_vals_src - label_vals_out
             if missing_labels:
-                raise RuntimeError(f"Labels {missing_labels} were lost during straightening transform. This can be "
-                                   f"caused by the labels being outside the ROI of the spinal cord segmentation. "
-                                   f"Please make sure all labels are within the ROI of the spinal cord segmentation.")
+                printv(
+                    f"ERROR: Labels {missing_labels} were lost during straightening transform. This can be caused by "
+                    f"the labels being outside the ROI of the spinal cord segmentation. Please make sure all labels "
+                    f"are within the ROI of the spinal cord segmentation.", type='error'
+                )
 
             # Compute rigid transformation straight landmarks --> template landmarks
             printv('\nEstimate transformation for step #0...', verbose)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR adds a new error to halt registration when labels are lost during the straightening transform, and gives some advice to address situations like https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3873#issue-1363434092.

I've thrown an error here because, if not caught, this problem would result in an error later in processing due to a mismatch between template labels and image labels. (See [this forum post](https://forum.spinalcordmri.org/t/labels-for-lumbar-spinal-level/737/11?u=joshuacwnewton) for an example.) The purpose of this change is just to make the root cause of the issue clearer.

One caveat here is that the output is a little ugly, specifically because of issue https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3877.

<details>

![image](https://user-images.githubusercontent.com/16181459/189388607-2482f066-c2b0-4e48-8701-53383c258200.png)

</details>

However, this is very easily solved by e.g. setting `-v 0` in the call to `sct_apply_transfo`:

<details>

![image](https://user-images.githubusercontent.com/16181459/189388544-4f30a0f5-5e1f-4f98-b9e2-c0fe80a0bfd3.png)

</details>

I plan to do this next as part of a fix for #3877.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3873.