### PR TITLE
Reduce logging from intermediate CLI scripts by setting `-v 0` in `main()` calls

### DIFF
--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -628,7 +628,8 @@ def moco(param):
                                              '-d', file_target,
                                              '-w', file_mat[iz][fT[it]] + 'Warp.nii.gz',
                                              '-o', file_data_splitZ_splitT_moco[fT[it]],
-                                             '-x', param.interp])
+                                             '-x', param.interp,
+                                             '-v', '0'])
             else:
                 # exit program if no transformation exists.
                 printv('\nERROR in ' + os.path.basename(__file__) + ': No good transformation exist. Exit program.\n', verbose, 'error')

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -210,7 +210,7 @@ def register_step_ants_registration(src, dest, step, masking, ants_registration_
     # N.B. no need to pad if iter = 0
     if not step.iter == '0':
         dest_pad = image.add_suffix(dest, '_pad')
-        sct_image.main(['-i', dest, '-o', dest_pad, '-pad', '0,0,' + str(padding)])
+        sct_image.main(['-i', dest, '-o', dest_pad, '-pad', '0,0,' + str(padding), '-v', '0'])
         dest = dest_pad
 
     # apply Laplacian filter
@@ -346,7 +346,7 @@ def register_step_dl_multimodal_cascaded_reg(src, dest, step, verbose=1):
                 "and bringing the source image into same space as moving image...")
     # Isotropic resolution
     dest_iso_res = image.add_suffix(dest, '_iso_res')
-    sct_resample.main(['-i', dest, '-o', dest_iso_res, '-mm', '1x1x1'])
+    sct_resample.main(['-i', dest, '-o', dest_iso_res, '-mm', '1x1x1', '-v', '0'])
     # Bring source image into same space as moving image
     src_same_space = image.add_suffix(src, '_same_space')
     # NB: `register_wrapper()` requires a 'Param' object that is defined on the fly in `sct_register_` CLI scripts

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -173,6 +173,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
                     '-d', dest[ifile],
                     '-o', add_suffix(src[ifile], '_reg'),
                     '-x', interp_step[ifile],
+                    '-v', '0',
                     '-w'] + warp_forward
                 )
                 src[ifile] = add_suffix(src[ifile], '_reg')
@@ -233,7 +234,9 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         '-d', 'dest.nii',
         '-w', 'warp_src2dest.nii.gz',
         '-o', 'src_reg.nii',
-        '-x', interp])
+        '-x', interp,
+        '-v', '0',
+    ])
 
     if generate_warpinv:
         printv('\nApply transfo dest --> source...', param.verbose)
@@ -242,7 +245,9 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
             '-d', 'src.nii',
             '-w', 'warp_dest2src.nii.gz',
             '-o', 'dest_reg.nii',
-            '-x', interp])
+            '-x', interp,
+            '-v', '0',
+        ])
 
     # come back
     os.chdir(curdir)

--- a/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
+++ b/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
@@ -120,6 +120,7 @@ def main():
         "-x", "linear",
         "-vox", str(nx * interp_factor) + 'x' + str(ny * interp_factor) + 'x' + str(nz * interp_factor),
         "-o", "data_up.nii",
+        "-v", "0",
     ])
 
     # Smooth along centerline
@@ -129,7 +130,7 @@ def main():
         "-s", "data_up.nii",
         "-smooth", str(smoothing_sigma),
         "-r", str(remove_temp_files),
-        "-v", str(verbose),
+        "-v", "0",
     ])
 
     # downsample data
@@ -139,6 +140,7 @@ def main():
         "-x", "linear",
         "-vox", str(nx) + 'x' + str(ny) + 'x' + str(nz),
         "-o", "data_up_smooth_down.nii",
+        "-v", "0",
     ])
 
     # come back

--- a/spinalcordtoolbox/scripts/isct_test_ants.py
+++ b/spinalcordtoolbox/scripts/isct_test_ants.py
@@ -96,7 +96,7 @@ def main():
 
     # # Apply rigid transformation
     # printv('\nApply rigid transformation to curved landmarks...', verbose)
-    # sct_apply_transfo.main(["-i", "data_src.nii.gz", "-o", "data_src_rigid.nii.gz", "-d", "data_dest.nii.gz", "-w", "curve2straight_rigid.txt", "-p", "nn"])
+    # sct_apply_transfo.main(["-i", "data_src.nii.gz", "-o", "data_src_rigid.nii.gz", "-d", "data_dest.nii.gz", "-w", "curve2straight_rigid.txt", "-p", "nn", "-v", "0"])
     #
     # # Estimate b-spline transformation curve --> straight
     # printv('\nEstimate b-spline transformation: curve --> straight...', verbose)
@@ -110,7 +110,7 @@ def main():
     #
     # # Apply deformation to input image
     # printv('\nApply transformation to input image...', verbose)
-    # sct_apply_transfo.main(["-i", "data_src.nii.gz", "-o", "data_src_warp.nii.gz", "-d", "data_dest.nii.gz", "-w", "warp_curve2straight.nii.gz", "-p", "nn"])
+    # sct_apply_transfo.main(["-i", "data_src.nii.gz", "-o", "data_src_warp.nii.gz", "-d", "data_dest.nii.gz", "-w", "warp_curve2straight.nii.gz", "-p", "nn", "-v", "0"])
     #
     # Compute DICE coefficient between src and dest
     printv('\nCompute DICE coefficient...', verbose)
@@ -118,6 +118,7 @@ def main():
         "-i", "data_dest.nii.gz",
         "-d", "data_src_reg.nii.gz",
         "-o", "dice.txt",
+        "-v", "0",
     ])
     with open("dice.txt", "r") as file_dice:
         dice = float(file_dice.read().replace('3D Dice coefficient = ', ''))

--- a/spinalcordtoolbox/scripts/msct_gmseg_utils.py
+++ b/spinalcordtoolbox/scripts/msct_gmseg_utils.py
@@ -146,7 +146,7 @@ def pre_processing(fname_target, fname_sc_seg, fname_level=None, fname_manual_gm
         size = int(np.ceil(max(size_x, size_y)))
         # create mask
         fname_mask = 'mask_pre_crop.nii.gz'
-        sct_create_mask.main(['-i', im_target_rpi.absolutepath, '-p', 'centerline,' + im_sc_seg_rpi.absolutepath, '-f', 'box', '-size', str(size), '-o', fname_mask])
+        sct_create_mask.main(['-i', im_target_rpi.absolutepath, '-p', 'centerline,' + im_sc_seg_rpi.absolutepath, '-f', 'box', '-size', str(size), '-o', fname_mask, '-v', '0'])
         # crop image
         cropper = ImageCropper(im_target_rpi)
         cropper.get_bbox_from_mask(Image(fname_mask))
@@ -459,7 +459,8 @@ def register_data(im_src, im_dest, param_reg, path_copy_warp=None, rm_tmp=True):
                                        '-d', fname_dest,
                                        '-iseg', fname_src_seg,
                                        '-dseg', fname_dest_seg,
-                                       '-param', param_reg])
+                                       '-param', param_reg,
+                                       '-v', '0'])
 
     # get registration result
     fname_src_reg = add_suffix(fname_src, '_reg')
@@ -503,7 +504,8 @@ def apply_transfo(im_src, im_dest, warp, interp='spline', rm_tmp=True):
     sct_apply_transfo.main(argv=['-i', fname_src,
                                  '-d', fname_dest,
                                  '-w', warp,
-                                 '-x', interp])
+                                 '-x', interp,
+                                 '-v', '0'])
 
     im_src_reg = Image(fname_src_reg)
     # get out of tmp dir

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -328,7 +328,7 @@ class Transform:
                     img_out = cropper.crop()
                 img_out.save(fname_out)
 
-        display_viewer_syntax([fname_dest, fname_out], verbose=verbose)
+        return fname_dest, fname_out
 
 
 # MAIN
@@ -353,12 +353,14 @@ def main(argv: Sequence[str]):
                           list_warpinv=warpinv_filename)
 
     transform.crop = arguments.crop
-    transform.output_filename = arguments.o
+    transform.output_filename = fname_out = arguments.o
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = verbose
 
     transform.apply()
+
+    display_viewer_syntax([fname_dest, fname_out], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -328,8 +328,6 @@ class Transform:
                     img_out = cropper.crop()
                 img_out.save(fname_out)
 
-        return fname_dest, fname_out
-
 
 # MAIN
 # ==========================================================================================

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -398,12 +398,13 @@ def resample_image(fname, suffix='_resampled.nii.gz', binary=False, npx=0.3, npy
         if nz == 1:
             # when data is 2d: we convert it to a 3d image in order to avoid conversion problem with 2d data
             # TODO: check if this above problem is still present (now that we are using nibabel instead of nipy)
-            sct_image.main(['-i', ','.join([fname, fname]), '-concat', 'z', '-o', fname])
+            sct_image.main(['-i', ','.join([fname, fname]), '-concat', 'z', '-o', fname, '-v', '0'])
 
-        sct_resample.main(['-i', fname, '-mm', str(npx) + 'x' + str(npy) + 'x' + str(pz), '-o', name_resample, '-x', interpolation])
+        sct_resample.main(['-i', fname, '-mm', str(npx) + 'x' + str(npy) + 'x' + str(pz), '-o', name_resample,
+                           '-x', interpolation, '-v', '0'])
 
         if nz == 1:  # when input data was 2d: re-convert data 3d-->2d
-            sct_image.main(['-i', name_resample, '-split', 'z'])
+            sct_image.main(['-i', name_resample, '-split', 'z', '-v', '0'])
             im_split = Image(name_resample.split('.nii.gz')[0] + '_Z0000.nii.gz')
             im_split.save(name_resample)
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -86,7 +86,7 @@ def main(argv: Sequence[str]):
     # save MTR file
     nii_mtr.save(fname_mtr, dtype='float32')
 
-    display_viewer_syntax([arguments.mt0, arguments.mt1, fname_mtr])
+    display_viewer_syntax([arguments.mt0, arguments.mt1, fname_mtr], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -151,7 +151,7 @@ def main(argv: Sequence[str]):
     # run main program
     create_mask(param)
 
-    display_viewer_syntax([param.fname_data, param.fname_out], colormaps=['gray', 'red'], opacities=['', '0.5'])
+    display_viewer_syntax([param.fname_data, param.fname_out], colormaps=['gray', 'red'], opacities=['', '0.5'], verbose=verbose)
 
 
 def create_mask(param):

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -151,6 +151,8 @@ def main(argv: Sequence[str]):
     # run main program
     create_mask(param)
 
+    display_viewer_syntax([param.fname_data, param.fname_out], colormaps=['gray', 'red'], opacities=['', '0.5'])
+
 
 def create_mask(param):
     # parse argument for method
@@ -263,8 +265,6 @@ def create_mask(param):
     if param.remove_temp_files == 1:
         printv('\nRemove temporary files...', param.verbose)
         rmtree(path_tmp)
-
-    display_viewer_syntax([param.fname_data, param.fname_out], colormaps=['gray', 'red'], opacities=['', '0.5'])
 
 
 def create_line(param, fname, coord, nz):

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -170,7 +170,7 @@ def main(argv: Sequence[str]):
         fname_out = arguments.o
     img_crop.save(fname_out)
 
-    display_viewer_syntax([arguments.i, fname_out])
+    display_viewer_syntax([arguments.i, fname_out], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -245,7 +245,7 @@ def main(argv: Sequence[str]):
         fname_prior = fname_seg
 
     for output_filename in output_filenames:
-        display_viewer_syntax([arguments.i[0], output_filename], colormaps=['gray', 'red'], opacities=['', '0.7'])
+        display_viewer_syntax([arguments.i[0], output_filename], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -165,7 +165,7 @@ def main(argv: Sequence[str]):
                                                  extract_fname(fname_image)[2]))
         im_ctr.save(fname_ctr)
 
-    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -206,7 +206,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_image, fname_seg=fname_seg, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_deepseg_sc')
-    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -344,7 +344,7 @@ def main(argv: Sequence[str]):
             generate_qc(fname_in, fname_seg=fname_out, args=argv, path_qc=os.path.abspath(path_qc),
                         process='sct_detect_pmj')
 
-        display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'])
+        display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -246,7 +246,8 @@ class DetectPMJ:
             self.rl_coord = int(img.dim[2] / 2)  # Right_left coordinate
             del img
 
-        sct_crop_image.main(['-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1), '-o', self.slice2D_im])
+        sct_crop_image.main(['-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1),
+                             '-o', self.slice2D_im, '-v', '0'])
 
     def extract_pmj_symmetrical_sagittal_slice(self):
         """Extract a slice that is symmetrical about the estimated PMJ location."""
@@ -258,7 +259,8 @@ class DetectPMJ:
         self.rl_coord = compute_cross_corr_3d(image.change_orientation('RPI'), [self.rl_coord, self.pa_coord, self.is_coord, ])  # Find R-L symmetry
 
         # Replace the mid-sagittal slice, to be used for the "main" PMJ detection
-        sct_crop_image.main(['-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1), '-o', self.slice2D_im])
+        sct_crop_image.main(['-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1),
+                             '-o', self.slice2D_im, '-v', '0'])
 
     def orient2pir(self):
         """Orient input data to PIR orientation."""

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -137,7 +137,7 @@ def main(argv: Sequence[str]):
     nib.save(nii_denoised, output_file_name_denoised)
     nib.save(nii_diff, output_file_name_diff)
 
-    display_viewer_syntax([file_to_denoise, output_file_name_denoised, output_file_name_diff])
+    display_viewer_syntax([file_to_denoise, output_file_name_denoised, output_file_name_diff], verbose=verbose)
 
 
 if __name__ == '__main__':

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -218,7 +218,7 @@ def main(argv: Sequence[str]):
                     args=argv, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
                     subject=qc_subject, process='sct_dmri_moco')
 
-    display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho')
+    display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho', verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -58,7 +58,7 @@ def main(argv: Sequence[str]):
     fname_out = add_suffix(fname_anat, '_flatten')
     im_anat_flattened.save(fname_out)
 
-    display_viewer_syntax([fname_anat, fname_out])
+    display_viewer_syntax([fname_anat, fname_out], verbose=verbose)
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -58,8 +58,6 @@ class Tsnr:
         nii_tsnr.data = data_tsnr
         nii_tsnr.save(fname_tsnr, dtype=np.float32)
 
-        display_viewer_syntax([fname_tsnr])
-
 
 # PARSER
 # ==========================================================================================
@@ -118,6 +116,8 @@ def main(argv: Sequence[str]):
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)
     tsnr.compute()
+
+    display_viewer_syntax([fname_dst])
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -117,7 +117,7 @@ def main(argv: Sequence[str]):
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)
     tsnr.compute()
 
-    display_viewer_syntax([fname_dst])
+    display_viewer_syntax([fname_dst], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -194,7 +194,7 @@ def main(argv: Sequence[str]):
                     args=argv, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
                     subject=qc_subject, process='sct_fmri_moco')
 
-    display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho')
+    display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho', verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -189,7 +189,7 @@ def main(argv: Sequence[str]):
         generate_qc(fname_input_data, fname_seg=file_output, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_get_centerline')
 
-    display_viewer_syntax([fname_input_data, file_output], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    display_viewer_syntax([fname_input_data, file_output], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -363,14 +363,14 @@ def main(argv: Sequence[str]):
             for i_dim in range(3):
                 l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + dim_list[i_dim].upper()))
                 im_out[i_dim].save(l_fname_out[i_dim], verbose=verbose)
-            display_viewer_syntax(fname_out)
+            display_viewer_syntax(fname_out, verbose=verbose)
         if arguments.split is not None:
             # use input file name and add _"DIM+NUMBER". Keep the same extension
             l_fname_out = []
             for i, im in enumerate(im_out):
                 l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + dim_list[dim].upper() + str(i).zfill(4)))
                 im.save(l_fname_out[i])
-            display_viewer_syntax(l_fname_out)
+            display_viewer_syntax(l_fname_out, verbose=verbose)
 
     elif arguments.getorient:
         printv(orient)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -553,12 +553,12 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
         fname_grid = 'grid_' + str(step) + '.nii.gz'
         im_grid.save(fname_grid)
         fname_grid_resample = add_suffix(fname_grid, '_resample')
-        sct_resample.main(argv=['-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
+        sct_resample.main(argv=['-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample, '-v', '0'])
         fname_grid = os.path.join(tmp_dir, fname_grid_resample)
         os.chdir(curdir)
     path_warp, file_warp, ext_warp = extract_fname(fname_warp)
     grid_warped = os.path.join(path_warp, extract_fname(fname_grid)[1] + '_' + file_warp + ext_warp)
-    sct_apply_transfo.main(argv=['-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped])
+    sct_apply_transfo.main(argv=['-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped, '-v', '0'])
     if rm_tmp:
         rmtree(tmp_dir)
 

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -313,7 +313,7 @@ def main(argv: Sequence[str]):
 
     printv("Generating output files...")
     out.save(path=output_fname, dtype=dtype)
-    display_viewer_syntax([input_filename, output_fname])
+    display_viewer_syntax([input_filename, output_fname], verbose=verbose)
 
     if arguments.qc is not None:
         generate_qc(fname_in1=input_filename, fname_seg=output_fname, args=argv,

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -323,7 +323,7 @@ def main(argv: Sequence[str]):
         copy(os.path.join(curdir, "warp_straight2curve.nii.gz"), 'warp_straight2curve.nii.gz')
         copy(os.path.join(curdir, "straight_ref.nii.gz"), 'straight_ref.nii.gz')
         # apply straightening
-        sct_apply_transfo.main(['-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
+        sct_apply_transfo.main(['-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii', '-v', '0'])
     else:
         sct_straighten_spinalcord.main(argv=[
             '-i', 'data.nii',
@@ -335,7 +335,7 @@ def main(argv: Sequence[str]):
 
     # resample to 0.5mm isotropic to match template resolution
     printv('\nResample to 0.5mm isotropic...', verbose)
-    sct_resample.main(['-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii'])
+    sct_resample.main(['-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii', '-v', '0'])
 
     # Apply straightening to segmentation
     # N.B. Output is RPI
@@ -357,7 +357,7 @@ def main(argv: Sequence[str]):
         # Apply straightening to disc-label
         printv('\nApply straightening to disc labels...', verbose)
         sct_apply_transfo.main(['-i', fname_disc, '-d', 'data_straightr.nii', '-w', 'warp_curve2straight.nii.gz',
-                                '-o', 'labeldisc_straight.nii.gz', '-x', 'label'])
+                                '-o', 'labeldisc_straight.nii.gz', '-x', 'label', '-v', '0'])
         label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
 
     else:
@@ -460,7 +460,8 @@ def main(argv: Sequence[str]):
                             '-d', 'segmentation.nii',
                             '-w', 'warp_straight2curve.nii.gz',
                             '-o', 'segmentation_labeled_disc.nii',
-                            '-x', 'label'])
+                            '-x', 'label',
+                            '-v', '0'])
     # come back
     os.chdir(curdir)
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -489,7 +489,7 @@ def main(argv: Sequence[str]):
         generate_qc(fname_in, fname_seg=labeled_seg_file, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
-    display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'subcortical'], opacities=['1', '0.5'])
+    display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'subcortical'], opacities=['1', '0.5'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -225,7 +225,7 @@ def main(argv: Sequence[str]):
     # merge src images to destination image
     merge_images(list_fname_src, fname_dest, list_fname_warp, param)
 
-    display_viewer_syntax([fname_dest, os.path.abspath(param.fname_out)])
+    display_viewer_syntax([fname_dest, os.path.abspath(param.fname_out)], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -161,7 +161,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
             '-w', list_fname_warp[i_file],
             '-x', param.interp,
             '-o', 'src_' + str(i_file) + '_template.nii.gz',
-            '-v', str(param.verbose)])
+            '-v', '0'])
 
         # create binary mask from input file by assigning one to all non-null voxels
         img = Image(fname_src)
@@ -175,7 +175,8 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
             '-d', fname_dest,
             '-w', list_fname_warp[i_file],
             '-x', param.interp,
-            '-o', 'src_' + str(i_file) + '_template_partialVolume.nii.gz'])
+            '-o', 'src_' + str(i_file) + '_template_partialVolume.nii.gz',
+            '-v', '0'])
 
         # open data
         data[:, :, :, i_file] = Image('src_' + str(i_file) + '_template.nii.gz').data

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -455,7 +455,7 @@ def main(argv: Sequence[str]):
                 # Save extrapolated centerline
                 im_ctl.save(fname_ctl)
                 # Generated centerline smoothed in RL direction for visualization (and QC report)
-                sct_maths.main(['-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth])
+                sct_maths.main(['-i', fname_ctl, '-smooth', '10,1,1', '-o', fname_ctl_smooth, '-v', '0'])
 
                 generate_qc(fname_in1=get_absolute_path(arguments.qc_image),
                             # NB: For this QC figure, the centerline has to be first in the list in order for the centerline

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -692,7 +692,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_in1=fname_input_data, fname_seg=fname_seg, args=argv,
                     path_qc=os.path.abspath(path_qc), dataset=qc_dataset, subject=qc_subject, process='sct_propseg')
-    display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '1'])
+    display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '1'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -547,7 +547,9 @@ def main(argv: Sequence[str]):
                 '-i', ftmp_seg,
                 '-w', 'warp_curve2straight.nii.gz',
                 '-d', 'straight_ref.nii.gz',
-                '-o', add_suffix(ftmp_seg, '_straight')])
+                '-o', add_suffix(ftmp_seg, '_straight',),
+                '-v', '0',
+            ])
         else:
             from spinalcordtoolbox.straightening import SpinalCordStraightener
             sc_straight = SpinalCordStraightener(ftmp_seg, ftmp_seg)
@@ -597,7 +599,9 @@ def main(argv: Sequence[str]):
                 '-o', add_suffix(ftmp_label, '_straight'),
                 '-d', add_suffix(ftmp_seg, '_straight'),
                 '-w', 'warp_curve2straight.nii.gz',
-                '-x', 'nn'])
+                '-x', 'nn',
+                '-v', '0',
+            ])
             ftmp_label = add_suffix(ftmp_label, '_straight')
 
             # Compute rigid transformation straight landmarks --> template landmarks
@@ -624,14 +628,18 @@ def main(argv: Sequence[str]):
             '-i', ftmp_data,
             '-o', add_suffix(ftmp_data, '_straightAffine'),
             '-d', ftmp_template,
-            '-w', 'warp_curve2straightAffine.nii.gz'])
+            '-w', 'warp_curve2straightAffine.nii.gz',
+            '-v', '0',
+        ])
         ftmp_data = add_suffix(ftmp_data, '_straightAffine')
         sct_apply_transfo.main(argv=[
             '-i', ftmp_seg,
             '-o', add_suffix(ftmp_seg, '_straightAffine'),
             '-d', ftmp_template,
             '-w', 'warp_curve2straightAffine.nii.gz',
-            '-x', 'linear'])
+            '-x', 'linear',
+            '-v', '0',
+        ])
         ftmp_seg = add_suffix(ftmp_seg, '_straightAffine')
 
         """
@@ -672,13 +680,13 @@ def main(argv: Sequence[str]):
         # sub-sample in z-direction
         # TODO: refactor to use python module instead of doing i/o
         printv('\nSub-sample in z-direction (for faster processing)...', verbose)
-        sct_resample.main(['-i', ftmp_template, '-o', add_suffix(ftmp_template, '_sub'), '-f', '1x1x' + zsubsample])
+        sct_resample.main(['-i', ftmp_template, '-o', add_suffix(ftmp_template, '_sub'), '-f', '1x1x' + zsubsample, '-v', '0'])
         ftmp_template = add_suffix(ftmp_template, '_sub')
-        sct_resample.main(['-i', ftmp_template_seg, '-o', add_suffix(ftmp_template_seg, '_sub'), '-f', '1x1x' + zsubsample])
+        sct_resample.main(['-i', ftmp_template_seg, '-o', add_suffix(ftmp_template_seg, '_sub'), '-f', '1x1x' + zsubsample, '-v', '0'])
         ftmp_template_seg = add_suffix(ftmp_template_seg, '_sub')
-        sct_resample.main(['-i', ftmp_data, '-o', add_suffix(ftmp_data, '_sub'), '-f', '1x1x' + zsubsample])
+        sct_resample.main(['-i', ftmp_data, '-o', add_suffix(ftmp_data, '_sub'), '-f', '1x1x' + zsubsample, '-v', '0'])
         ftmp_data = add_suffix(ftmp_data, '_sub')
-        sct_resample.main(['-i', ftmp_seg, '-o', add_suffix(ftmp_seg, '_sub'), '-f', '1x1x' + zsubsample])
+        sct_resample.main(['-i', ftmp_seg, '-o', add_suffix(ftmp_seg, '_sub'), '-f', '1x1x' + zsubsample, '-v', '0'])
         ftmp_seg = add_suffix(ftmp_seg, '_sub')
 
         # Registration straight spinal cord to template
@@ -756,8 +764,8 @@ def main(argv: Sequence[str]):
         os.rename(warp_inverse, 'warp_anat2template.nii.gz')
 
     # Apply warping fields to anat and template
-    sct_apply_transfo.main(['-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '0'])
-    sct_apply_transfo.main(['-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '0'])
+    sct_apply_transfo.main(['-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '0', '-v', '0'])
+    sct_apply_transfo.main(['-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '0', '-v', '0'])
 
     # come back
     os.chdir(curdir)

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -114,6 +114,7 @@ def main(argv: Sequence[str]):
     arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_loglevel(verbose=verbose)
+    param.verbose = verbose
 
     param.fname_data = arguments.i
     arg = 0

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -210,9 +210,9 @@ def main(argv: Sequence[str]):
         copy(os.path.join(curdir, 'warp_straight2curve.nii.gz'), 'warp_straight2curve.nii.gz')
         copy(os.path.join(curdir, 'straight_ref.nii.gz'), 'straight_ref.nii.gz')
         # apply straightening
-        sct_apply_transfo.main(['-i', fname_anat_rpi, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'anat_rpi_straight.nii', '-x', 'spline'])
+        sct_apply_transfo.main(['-i', fname_anat_rpi, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'anat_rpi_straight.nii', '-x', 'spline', '-v', '0'])
     else:
-        sct_straighten_spinalcord.main(['-i', fname_anat_rpi, '-o', 'anat_rpi_straight.nii', '-s', fname_centerline_rpi, '-x', 'spline', '-param', 'algo_fitting=' + param.algo_fitting])
+        sct_straighten_spinalcord.main(['-i', fname_anat_rpi, '-o', 'anat_rpi_straight.nii', '-s', fname_centerline_rpi, '-x', 'spline', '-param', 'algo_fitting=' + param.algo_fitting, '-v', '0'])
         cache_save(cachefile, cache_sig)
         # move warping fields and straight reference file from the tmpdir to the localdir (to use caching next time)
         copy('straight_ref.nii.gz', os.path.join(curdir, 'straight_ref.nii.gz'))
@@ -236,7 +236,7 @@ def main(argv: Sequence[str]):
 
     # Apply the reversed warping field to get back the curved spinal cord
     printv('\nApply the reversed warping field to get back the curved spinal cord...')
-    sct_apply_transfo.main(['-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline'])
+    sct_apply_transfo.main(['-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline', '-v', '0'])
 
     # replace zeroed voxels by original image (issue #937)
     printv('\nReplace zeroed voxels by original image...', verbose)

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -136,7 +136,8 @@ class SpinalCordStraightener(object):
             sct_resample.main([
                 '-i', 'centerline_rpi_native.nii.gz',
                 '-mm', str(px_r) + 'x' + str(py_r) + 'x' + str(pz_r),
-                '-o', 'centerline_rpi.nii.gz'
+                '-o', 'centerline_rpi.nii.gz',
+                '-v', '0',
             ])
             image_centerline = Image('centerline_rpi.nii.gz')
             nx, ny, nz, nt, px, py, pz, pt = image_centerline.dim
@@ -259,6 +260,7 @@ class SpinalCordStraightener(object):
                     '-i', 'centerline_rpi_native.nii.gz',
                     '-o', 'tmp.centerline_pad_native.nii.gz',
                     '-pad', '0,0,' + str(padding_z),
+                    '-v', '0',
                 ])
                 image_centerline_pad = Image('centerline_rpi_native.nii.gz')
                 nx, ny, nz, nt, px, py, pz, pt = image_centerline_pad.dim

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -40,7 +40,7 @@ def display_open(file, message="Done! To view results"):
 SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'itksnap']
 
 
-def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='', verbose=1):
+def display_viewer_syntax(files, verbose, colormaps=[], minmax=[], opacities=[], mode=''):
     """
     Print the syntax to open a viewer and display images for QC. To use default values, enter empty string: ''
     Parameters

--- a/testing/api/test_utils.py
+++ b/testing/api/test_utils.py
@@ -66,7 +66,8 @@ def test_display_viewer_syntax(temporary_viewers):
         colormaps=['gray', 'gray', 'red', 'gray'],
         minmax=['', '0,1', '0.25,0.75', ''],
         opacities=['', '0.7', '1.0', ''],
-        mode="test"
+        mode="test",
+        verbose=1,
     )
     for viewer in temporary_viewers:
         assert viewer in syntax_strings.keys()


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

### Context

In many places in SCT's codebase, a CLI script (e.g. `sct_label_vertebrae`) will call another CLI script (e.g. `sct_straighten_spinalcord`). 

Historically, the secondary CLI script will be called using a subprocess (via the [`run_proc`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/7ce5ea59e213510ff0566eef99d3cefe811f0051/spinalcordtoolbox/utils/sys.py#L368-L416) function). Over the past year, however, SCT has migrated from using `run_proc("sct_script")` to `import sct_script; sct_script.main()`. 

### Problem

While there have been benefits to this change, one unintended outcome of this change has been an increase in logging:

* `run_proc` is quiet; it prints only the command that was run, but outputs nothing else by default. 
* `sct_script.main()` is noisy; it outputs _everything_ exactly as it would if the CLI script was run from the terminal.

As a result, the logs for a CLI script now include additional _nested_ logs for any intermediate CLI scripts called, too.

This problem is partially highlighted in #3877, but beyond `display_viewer_syntax`, _any_ `printv` commands will be included in the output, too.

### Solution

To fix this problem, this PR:

1. Ensures that `-v 0` is set for every intermediate `sct_script.main()` call.
2. Ensures that this verbose setting propagates to any corresponding `display_viewer_syntax()` calls, too.

### Caveats

The main caveat with setting `-v 0` for intermediate calls is that SCT is not consistent with how it propagates `arguments.v` (i.e. `verbose`) to `printv`.

There are 272 instances of `printv` with verbose:

![image](https://user-images.githubusercontent.com/16181459/189721913-1d128ec2-1a33-4ff5-b853-6a5a184db70e.png)

Compared to 215 instances of `printv` _without_ verbose:

![image](https://user-images.githubusercontent.com/16181459/189721695-2bf5ed75-0f2f-47df-b3cd-c5f56908da02.png)

Meaning that `-v 0` will silence some, but not all output from intermediate scripts. 

For this reason, it might be better to leave `-v` and `printv` alone, temporarily accept the increased `printv` output, and instead focus solely on `display_viewer_syntax`, as per https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3877#issuecomment-1239647067.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3877.