### PR TITLE
Address `[Errno 24] Too many open files` during motion correction

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -287,10 +287,9 @@ class Image(object):
                 self.loadFromPath(param, mmap, verbose)
             except OSError as e:
                 if e.errno == errno.EMFILE:
-                    raise OSError("[Errno 24] Too many open files. Please try increasing your system's file descriptor "
-                                  "limit by using the command `ulimit -Sn`.")
-                else:
-                    raise e
+                    e.strerror += (". Please try increasing your system's file descriptor "
+                                   "limit by using the command `ulimit -Sn`.")
+                raise e
         # copy constructor
         elif isinstance(param, type(self)):
             self.copy(param)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -286,16 +286,8 @@ class Image(object):
                 self.loadFromPath(param, mmap, verbose)
             except OSError as e:
                 if str(e) == "[Errno 24] Too many open files":
-                    try:
-                        # Only load images into memory if there are no more available file descriptors
-                        self.loadFromPath(param, False, verbose)
-                    except OSError as e:
-                        # If for some reason, an OSError is still thrown, then give the user a helpful error message
-                        if str(e) == "[Errno 24] Too many open files":
-                            raise OSError("[Errno 24] Too many open files. Please try increasing your system's file "
-                                          "descriptor limit by using the command `ulimit -Sn`.")
-                        else:
-                            raise e
+                    raise OSError("[Errno 24] Too many open files. Please try increasing your system's file descriptor "
+                                  "limit by using the command `ulimit -Sn`.")
                 else:
                     raise e
         # copy constructor

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -286,8 +286,16 @@ class Image(object):
                 self.loadFromPath(param, mmap, verbose)
             except OSError as e:
                 if str(e) == "[Errno 24] Too many open files":
-                    raise OSError("[Errno 24] Too many open files. Please try increasing your system's file descriptor "
-                                  "limit by using the command `ulimit -Sn`.")
+                    try:
+                        # Only load images into memory if there are no more available file descriptors
+                        self.loadFromPath(param, False, verbose)
+                    except OSError as e:
+                        # If for some reason, an OSError is still thrown, then give the user a helpful error message
+                        if str(e) == "[Errno 24] Too many open files":
+                            raise OSError("[Errno 24] Too many open files. Please try increasing your system's file "
+                                          "descriptor limit by using the command `ulimit -Sn`.")
+                        else:
+                            raise e
                 else:
                     raise e
         # copy constructor

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+import errno
 import itertools
 import warnings
 import logging
@@ -285,7 +286,7 @@ class Image(object):
             try:
                 self.loadFromPath(param, mmap, verbose)
             except OSError as e:
-                if str(e) == "[Errno 24] Too many open files":
+                if e.errno == errno.EMFILE:
                     raise OSError("[Errno 24] Too many open files. Please try increasing your system's file descriptor "
                                   "limit by using the command `ulimit -Sn`.")
                 else:

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -279,7 +279,14 @@ class Image(object):
 
         # load an image from file
         if isinstance(param, str):
-            self.loadFromPath(param, verbose)
+            try:
+                self.loadFromPath(param, verbose)
+            except OSError as e:
+                if str(e) == "[Errno 24] Too many open files":
+                    raise OSError("[Errno 24] Too many open files. Please try increasing your system's file descriptor "
+                                  "limit by using the command `ulimit -Sn`.")
+                else:
+                    raise e
         # copy constructor
         elif isinstance(param, type(self)):
             self.copy(param)

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -637,7 +637,7 @@ def moco(param):
         # Merge data along T
         file_data_splitZ_moco.append(add_suffix(file, suffix))
         if todo != 'estimate':
-            im_data_splitZ_splitT_moco = [Image(fname) for fname in file_data_splitZ_splitT_moco]
+            im_data_splitZ_splitT_moco = [Image(fname, mmap=False) for fname in file_data_splitZ_splitT_moco]
             im_out = concat_data(im_data_splitZ_splitT_moco, 3)
             im_out.absolutepath = file_data_splitZ_moco[iz]
             im_out.save(verbose=0)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

### Context

On Unix systems, when motion correction is run on a 4D image with many 3D volumes (e.g. `[x, y, z, 300]`), and the number of volumes exceeds the open file descriptor limit (e.g. `ulimit -Sn ==> 256`), then SCT will throw an `[Errno 24] Too many open files` error.

The reason for this is because of this LOC:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/7ce5ea59e213510ff0566eef99d3cefe811f0051/spinalcordtoolbox/moco.py#L640

`Image`, by default, will load the data arrays of `.nii` images as `np.memmap` objects, which keeps an open file descriptor. So, for a 300-volume dMRI image, at least 300 file descriptors will be kept open at once.

### Proposed solutions

To fix this, we can tackle the problem a number of ways:

1. Rely on the workaround of `ulimit -Sn` to increase the limit on open file descriptors. (Presented here as 6900c92cdc354dfbae1bd3e3572f272051eb6af3)
2. Avoid `np.memmap` entirely, but only in the offending L640. (Presented here as 0055c0e160cb2caf47dfc4a83cc826589b2ce5be)
3. Avoid `np.memmap` _conditionally_, based on whether or not `Image.loadFromPath` throws an `OSError`. (Presented here as cf82f856cd30cc5013bdcb39eb5275549dc60825).
4. Change the way we perform concatenation, but only in the offending L640. (Not immediately presented here, due to time complexity concerns, as well as [numerical differences](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2149#issuecomment-1245534459).)
5. Change the way we perform concatenation, by rewriting how `concat_data` processes filenames/`Image` objects. (Not immediately presented here due to increased scope caused by this change.)

I'm not quite sure of the best solution here, because each approach has various caveats and tradeoffs. I would be happy to discuss further, though!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2149 