### PR TITLE
Enforce `type=int` for arguments that use `choices=(0, 1)`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -32,7 +32,7 @@ class Param:
     def __init__(self):
         self.fname_out = 'merged_images.nii.gz'
         self.interp = 'linear'
-        self.rm_tmp = True
+        self.rm_tmp = 1
         self.verbose = 1
         self.almost_zero = 0.00000001
 
@@ -97,7 +97,7 @@ def get_parser():
     misc = parser.add_argument_group('MISC')
     misc.add_argument(
         "-r",
-        type=bool,
+        type=int,
         help='Remove temporary files.',
         required=False,
         default=Param().rm_tmp,

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -102,6 +102,7 @@ def get_parser():
         help="Output filename. Example: smooth_sc.nii.gz. By default, the suffix '_smooth' will be added to the input file name."),
     optional.add_argument(
         '-r',
+        type=int,
         choices=[0, 1],
         default=1,
         help="Whether to remove temporary files. 0 = no, 1 = yes"


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

For `argparse`-based arguments, if the argument has e.g. `choices=(0, 1)`, then `type=int` must be set. This is because unparsed arguments are passed as strings (e.g. `'0'`, `'1'`), which must be converted to integers to be considered a valid choice.

I did a project-wide regex search for `choices=.*0, 1.*` (this search also included results for `choices=(0, 1, 2)`). Then, I checked each search result to see if `type=int` was specified. I found two instances of this not being the case (`sct_smooth_spinalcord`, `sct_merge_images`).

This PR fixes both arguments so that they now work as intended. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3885.
Needed for the PR that will address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3883, because `isct_convert_binary_to_trilinear` has a call to `sct_smooth_spinalcord` that fails.
