### PR TITLE
Improve handling of case where `algo` is specified alongside `type='label'`

### DIFF
--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -424,18 +424,11 @@ def register(src, dest, step, param):
                '\nERROR: ANTs failed. Exit program.\n', 1, 'error')
     else:
         # rename warping fields
-        if step.type in ['label']:
-            # if label-based registration is used --> outputs .txt file
-            warp_forward = 'warp_forward_' + str(step.step) + '.txt'
+        _, _, output_ext = extract_fname(warp_forward_out)
+        if output_ext in ['.txt', '.mat']:
+            warp_forward = 'warp_forward_' + str(step.step) + output_ext
             os.rename(warp_forward_out, warp_forward)
-            warp_inverse = '-warp_forward_' + str(step.step) + '.txt'
-        elif (step.algo.lower() in ['rigid', 'affine', 'translation'] and
-                step.slicewise == '0'):
-            # if ANTs is used with affine/rigid --> outputs .mat file
-            warp_forward = 'warp_forward_' + str(step.step) + '.mat'
-            os.rename(warp_forward_out, warp_forward)
-            warp_inverse = '-warp_forward_' + str(step.step) + '.mat'
-
+            warp_inverse = '-warp_forward_' + str(step.step) + output_ext
         else:
             warp_forward = 'warp_forward_' + str(step.step) + '.nii.gz'
             warp_inverse = 'warp_inverse_' + str(step.step) + '.nii.gz'

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -344,7 +344,7 @@ def register(src, dest, step, param):
     # # landmark-based registration
     if step.type in ['label']:
         if step.algo:
-            printv(f"Specifying 'algo={step.algo}' has no effect for 'type=label' registration.", type='warning')
+            printv(f"Parameter 'algo={step.algo}' has no effect for 'type=label' registration.", type='warning')
         warp_forward_out, warp_inverse_out = algorithms.register_step_label(
             src=src,
             dest=dest,

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -15,6 +15,8 @@
 
 import os
 
+import logging
+
 from spinalcordtoolbox.registration import algorithms
 
 from spinalcordtoolbox.image import Image, add_suffix, generate_output_file
@@ -22,6 +24,8 @@ from spinalcordtoolbox.utils.fs import extract_fname, rmtree, tmp_create
 from spinalcordtoolbox.utils.shell import printv
 from spinalcordtoolbox.utils.sys import run_proc
 from spinalcordtoolbox.scripts import sct_apply_transfo
+
+logger = logging.getLogger(__name__)
 
 
 def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg='', fname_dest_seg='', fname_src_label='',
@@ -339,6 +343,8 @@ def register(src, dest, step, param):
 
     # # landmark-based registration
     if step.type in ['label']:
+        if step.algo:
+            logger.warning(f"Specifying 'algo={step.algo}' has no effect for 'type=label' registration.")
         warp_forward_out, warp_inverse_out = algorithms.register_step_label(
             src=src,
             dest=dest,

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -344,7 +344,7 @@ def register(src, dest, step, param):
     # # landmark-based registration
     if step.type in ['label']:
         if step.algo:
-            logger.warning(f"Specifying 'algo={step.algo}' has no effect for 'type=label' registration.")
+            printv(f"Specifying 'algo={step.algo}' has no effect for 'type=label' registration.", type='warning')
         warp_forward_out, warp_inverse_out = algorithms.register_step_label(
             src=src,
             dest=dest,

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -424,17 +424,18 @@ def register(src, dest, step, param):
                '\nERROR: ANTs failed. Exit program.\n', 1, 'error')
     else:
         # rename warping fields
-        if (step.algo.lower() in ['rigid', 'affine', 'translation'] and
+        if step.type in ['label']:
+            # if label-based registration is used --> outputs .txt file
+            warp_forward = 'warp_forward_' + str(step.step) + '.txt'
+            os.rename(warp_forward_out, warp_forward)
+            warp_inverse = '-warp_forward_' + str(step.step) + '.txt'
+        elif (step.algo.lower() in ['rigid', 'affine', 'translation'] and
                 step.slicewise == '0'):
             # if ANTs is used with affine/rigid --> outputs .mat file
             warp_forward = 'warp_forward_' + str(step.step) + '.mat'
             os.rename(warp_forward_out, warp_forward)
             warp_inverse = '-warp_forward_' + str(step.step) + '.mat'
-        elif step.type in ['label']:
-            # if label-based registration is used --> outputs .txt file
-            warp_forward = 'warp_forward_' + str(step.step) + '.txt'
-            os.rename(warp_forward_out, warp_forward)
-            warp_inverse = '-warp_forward_' + str(step.step) + '.txt'
+
         else:
             warp_forward = 'warp_forward_' + str(step.step) + '.nii.gz'
             warp_inverse = 'warp_inverse_' + str(step.step) + '.nii.gz'

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -145,5 +145,6 @@ def test_sct_register_multimodal_with_labels(capsys, tmp_path, algo):
                                   '-ofolder', str(tmp_path)])
     for file in ['t2_dest_reg.nii.gz', 't2_src_reg.nii.gz', 'warp_t22t2.nii.gz']:
         assert os.path.isfile(tmp_path / file)
-    if algo:
-        assert "has no effect for 'type=label' registration." in capsys.readouterr().out
+    # NB: Right now, a warning will be thrown regardless of whether `algo` is explicitly
+    #     specified by the user, because `algo` has a default, non-empty setting.
+    assert "has no effect for 'type=label' registration." in capsys.readouterr().out

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -121,7 +121,7 @@ def test_sct_register_multimodal_with_softmask(tmp_path):
 
 
 @pytest.mark.parametrize('algo', [',algo=rigid', ''])
-def test_sct_register_multimodal_with_labels(caplog, tmp_path, algo):
+def test_sct_register_multimodal_with_labels(capsys, tmp_path, algo):
     """
     Test registration with '-param type=label' set.
 
@@ -146,4 +146,4 @@ def test_sct_register_multimodal_with_labels(caplog, tmp_path, algo):
     for file in ['t2_dest_reg.nii.gz', 't2_src_reg.nii.gz', 'warp_t22t2.nii.gz']:
         assert os.path.isfile(tmp_path / file)
     if algo:
-        assert "has no effect for 'type=label' registration." in caplog.text
+        assert "has no effect for 'type=label' registration." in capsys.readouterr().out

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -124,7 +124,7 @@ def test_sct_register_multimodal_with_softmask(tmp_path):
 def test_sct_register_multimodal_with_labels(caplog, tmp_path, algo):
     """
     Test registration with '-param type=label' set.
-    
+
     NB: Label-based registration is a little different from normal registration.
     The path of execution goes from 'register()' onto 'register_step_label()'
     and then 'register_landmarks()', which is its own ITK-based landmarks
@@ -147,4 +147,3 @@ def test_sct_register_multimodal_with_labels(caplog, tmp_path, algo):
         assert os.path.isfile(tmp_path / file)
     if algo:
         assert "has no effect for 'type=label' registration." in caplog.text
-

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -128,12 +128,12 @@ def test_sct_register_multimodal_with_labels(capsys, tmp_path, algo):
     NB: Label-based registration is a little different from normal registration.
     The path of execution goes from 'register()' onto 'register_step_label()'
     and then 'register_landmarks()', which is its own ITK-based landmarks
-    registration function that entirely ignores the choice of 'algo'.
+    registration function separate from ANTs that entirely ignores the choice of 'algo'.
 
-    Because of this, we run registration with and without 'algo', and ensure
+    Because of this, we run registration with and without 'algo' set, and ensure
     that 'algo' really is ignored, but that registration doesn't actually fail.
 
-    See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3893.
+    See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3893 for bug context.
     """
     # NB: Registering the t2 image with itself is non-representative, but it's the only
     #     sct_testing_data image we have that has an associated vertebral label file.


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`sct_register_multimodal` performs multi-step registration. To be able to specify multiple parameters corresponding to each step, we use the `-param` argument, which takes a string formatted as `step=0,type=<>,algo=<>:step=1,type=<>,algo=<>` and can continue for as many steps the user wishes.

An ugly error occurs when the user erroneously specifies both `type='label'` and `algo=rigid` in a step:

```bash
# NB This isn't actually valid usage? See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3893#issuecomment-1265503675
sct_register_multimodal -param step=0,type=label,algo=rigid -i t2.nii.gz -d t2.nii.gz -ilabel labels.nii.gz -dlabel labels.nii.gz
```

* `type='label'` will output the transformation in the form of a `.txt` file.
* But, specifying `algo='rigid'` will cause the `.txt` file to incorrectly be renamed to a `.mat` file.
* The `.mat` file is incompatible with further transformation steps, hence the following error:

```
Description: itk::ERROR: TransformFileReaderTemplate(0x600002cf3a80): Transform IO: MatlabTransformIOTemplate
failed to read file: warp_forward_0.mat
```

To fix this, I've added a number of changes:

1. Prioritizing `type='label'`'s rename operation (`.txt`) over `algo='rigid'`'s rename operation (`.mat`)
2. Alternatively, rewriting the 'rename' block of code so that filename extensions are explicitly preserved. (Supersedes fix 1.)
3. Adding a warning when the user erroneously specifies `algo` alongside `type=label`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3893.
