### PR TITLE
Enforce use of `display_viewer_syntax` in four scripts using hardcoded `fsleyes` commands

### DIFF
--- a/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
+++ b/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
@@ -23,6 +23,7 @@ import numpy as np
 from spinalcordtoolbox.image import Image, generate_output_file, convert
 from spinalcordtoolbox.utils.sys import init_sct, __data_dir__, printv
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, rmtree, extract_fname
+from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 from spinalcordtoolbox.scripts import sct_resample, sct_smooth_spinalcord
 
@@ -160,8 +161,7 @@ def main():
     printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's')
 
     # to view results
-    printv('\nTo view results, type:')
-    printv('fslview ' + file_data + ' ' + file_data + suffix + ' &\n')
+    display_viewer_syntax([fname_data, fname_out], verbose=verbose)
 
 
 # printv(usage)

--- a/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
+++ b/spinalcordtoolbox/scripts/isct_convert_binary_to_trilinear.py
@@ -136,10 +136,10 @@ def main():
     # downsample data
     printv('\nDownsample data...', verbose)
     sct_resample.main([
-        "-i", "data_up_smooth.nii",
+        "-i", "data_up_smooth.nii.gz",
         "-x", "linear",
         "-vox", str(nx) + 'x' + str(ny) + 'x' + str(nz),
-        "-o", "data_up_smooth_down.nii",
+        "-o", "data_up_smooth_down.nii.gz",
         "-v", "0",
     ])
 
@@ -148,7 +148,7 @@ def main():
 
     # Generate output files
     printv('\nGenerate output files...')
-    fname_out = generate_output_file(os.path.join(path_tmp, "data_up_smooth_down.nii"), '' + file_data + suffix + ext_data)
+    fname_out = generate_output_file(os.path.join(path_tmp, "data_up_smooth_down.nii.gz"), '' + file_data + suffix + ext_data)
 
     # Delete temporary files
     if remove_temp_files == 1:

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -19,7 +19,7 @@ from skimage.measure import label
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
-from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
@@ -554,11 +554,20 @@ def main(argv: Sequence[str]):
     if rm_tmp:
         rmtree(lesion_obj.tmp_dir)
 
-    printv('\nDone! To view the labeled lesion file (one value per lesion), type:', verbose)
     if fname_ref is not None:
-        printv('fsleyes ' + fname_mask + ' ' + os.path.join(path_results, lesion_obj.fname_label) + ' -cm red-yellow -a 70.0 & \n', verbose, 'info')
+        display_viewer_syntax(
+            files=[fname_mask, os.path.join(path_results, lesion_obj.fname_label)],
+            colormaps=['gray', 'red-yellow'],
+            opacities=['1.0', '0.7'],
+            verbose=verbose
+        )
     else:
-        printv('fsleyes ' + os.path.join(path_results, lesion_obj.fname_label) + ' -cm red-yellow -a 70.0 & \n', verbose, 'info')
+        display_viewer_syntax(
+            files=[os.path.join(path_results, lesion_obj.fname_label)],
+            colormaps=['red-yellow'],
+            opacities=['0.7'],
+            verbose=verbose
+        )
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -17,7 +17,7 @@ import numpy as np
 from skimage.feature import greycomatrix, greycoprops
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like, concat_data
-from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
@@ -347,8 +347,12 @@ def main(argv: Sequence[str]):
     if param.rm_tmp:
         rmtree(glcm.tmp_dir)
 
-    printv('\nDone! To view results, type:', param.verbose)
-    printv('fsleyes ' + arguments.i + ' ' + ' -cm red-yellow -a 70.0 '.join(fname_out_lst) + ' -cm Red-Yellow -a 70.0 & \n', param.verbose, 'info')
+    display_viewer_syntax(
+        files=[arguments.i] + fname_out_lst,
+        colormaps=['gray'] + ['red-yellow'] * len(fname_out_lst),
+        opacities=['1.0'] + ['0.7'] * len(fname_out_lst),
+        verbose=verbose
+    )
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -8,7 +8,8 @@ import numpy as np
 import nibabel as nib
 from dipy.denoise.nlmeans import nlmeans
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel
+from spinalcordtoolbox.utils import (SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel,
+                                     display_viewer_syntax)
 
 
 # DEFAULT PARAMETERS
@@ -186,8 +187,7 @@ def main(argv: Sequence[str]):
     nib.save(img_denoise, output_file_name)
     nib.save(img_diff, file + '_difference' + ext)
 
-    printv('\nDone! To view results, type:', param.verbose)
-    printv('fsleyes ' + file_to_denoise + ' ' + output_file_name + ' & \n', param.verbose, 'info')
+    display_viewer_syntax(files=[file_to_denoise, output_file_name], verbose=verbose)
 
 
 # =======================================================================================================================


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Most SCT scripts use a function called `display_viewer_syntax` at the end of processing. This function searches for the presence of image viewing software like `fsleyes` or `itksnap`, then outputs commands that let the user open output files in those viewers.

However, some scripts still hardcode a command for `fsleyes`/`fslview`. So, this PR replaces those commands with `display_viewer_syntax`.

> ((NB: The `isct_convert_binary_to_trilinear` script is looking a bit neglected. I've made sure it works, because it's listed in our `setup.py`, and thus is available to our users. That said, the script doesn't use argparse, and its main function isn't properly exposed, so we don't currently test it. 
> 
> We might want to reflect on whether or not these `isct_` scripts are worth maintaining. If they are, we should fix them up and turn them into a properly formatted + tested `sct_` scripts. If they aren't, then we should move them to `dev/`.))

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3883.