### PR TITLE
Add Google Sheets summary graphs to `studies.rst`

### DIFF
--- a/documentation/source/overview/studies.rst
+++ b/documentation/source/overview/studies.rst
@@ -3,6 +3,21 @@
 Studies using SCT
 #################
 
+Summary graphs
+--------------
+
+The graphs below summarize the pathologies, tools, species, and count per year of SCT citations:
+
+.. raw:: html
+
+       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=1220039972&amp;format=interactive"></iframe>
+
+       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=366269532&amp;format=interactive"></iframe>
+
+       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=819409616&amp;format=interactive"></iframe>
+
+       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=1302662251&amp;format=interactive"></iframe>
+
 The following studies have used SCT:
 
 2022

--- a/documentation/source/overview/studies.rst
+++ b/documentation/source/overview/studies.rst
@@ -4,7 +4,7 @@ Studies using SCT
 #################
 
 Summary graphs
---------------
+==============
 
 The graphs below summarize the pathologies, tools, species, and count per year of SCT citations:
 
@@ -17,6 +17,9 @@ The graphs below summarize the pathologies, tools, species, and count per year o
        <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=819409616&amp;format=interactive"></iframe>
 
        <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=1302662251&amp;format=interactive"></iframe>
+
+Citation list
+=============
 
 The following studies have used SCT:
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

SCT tracks citations in two ways: 

1. The public-facing [`studies.rst`](https://spinalcordtoolbox.com/overview/studies.html) page in our Sphinx documentation.
2. An internal, semi-private Google Sheets spreadsheet that tracks some additional information not in the Sphinx page.

The internal spreadsheet also contains some graphs that aggregate and summarize statistics for SCT's citations (such as pathologies treated, tools used, and type of subject). These graphs can be published and shared via Google Sheets' "publish" feature. 

This PR adds some HTML snippets to display the published graphs on the Sphinx page, alongside the list of citations. You can view the rendered graphs on this page: https://spinalcordtoolbox--3896.org.readthedocs.build/overview/studies.html

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3857.
