### PR TITLE
`math.py`: Address `selem` deprecation by using `footprint`

### DIFF
--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -110,7 +110,7 @@ def dilate(data, size, shape, dim=None):
         im_out.data = dilate(data.data, size, shape, dim)
         return im_out
     else:
-        return dilation(data, selem=_get_selem(shape, size, dim), out=None)
+        return dilation(data, footprint=_get_selem(shape, size, dim), out=None)
 
 
 def erode(data, size, shape, dim=None):
@@ -130,7 +130,7 @@ def erode(data, size, shape, dim=None):
         im_out.data = erode(data.data, size, shape, dim)
         return im_out
     else:
-        return erosion(data, selem=_get_selem(shape, size, dim), out=None)
+        return erosion(data, footprint=_get_selem(shape, size, dim), out=None)
 
 
 def mutual_information(x, y, nbins=32, normalized=False):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR addresses the deprecation of the `selem` argument in `skimage` functions `dilation` and `erosion`.

This is just a 1:1 swap, as this is what `skimage` was already doing internally:

![image](https://user-images.githubusercontent.com/16181459/194347001-73913405-bf50-4bf1-afec-a318f0c889f4.png)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3736.