### PR TITLE
Switch to higher-quality "Tools used" graph on the studies page

### DIFF
--- a/documentation/source/overview/studies.rst
+++ b/documentation/source/overview/studies.rst
@@ -12,7 +12,7 @@ The graphs below summarize the pathologies, tools, species, and count per year o
 
        <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=1220039972&amp;format=interactive"></iframe>
 
-       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=366269532&amp;format=interactive"></iframe>
+       <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=1409188329&amp;format=interactive"></iframe>
 
        <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSwyEvoiTOMflrJveD277xWYSb_1QSwkpxWsZoMSucgHBS7BHcgfvzGG21--1bLRFO_DIV4EhL9lBl2/pubchart?oid=819409616&amp;format=interactive"></iframe>
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, we display a pie chart of "Tools used" from the [studies_citing_SCT](https://docs.google.com/spreadsheets/d/1Utmf-btG7uXmu7RCBBx7fIKobm6yvXstX2Psc-UR2HA/edit?usp=sharing) spreadsheet. However, this pie chart has two main problems:

1. It contains a mix of both descriptors (e.g. Segmentation, Registration) and literal tool names (e.g. sct_deepseg, sct_register_to_template)
2. It contains comma-delimited entries (e.g. "labeling, moco") that are treated as their own entry, rather than parsed as individual parts.

To fix these problems, I created a new column in the spreadsheet, copied the existing data, and applied the following changes:

1. Replaced tool names (e.g. sct_deepseg) with their broader purpose (e.g. Segmentation)
2. In a separate postprocessing sheet, I concatenated the cells, then split them based on `','`, so that each individual part is counted as a unique entry.

The result is a pie graph with no redundant entries:

![image](https://user-images.githubusercontent.com/16181459/195109455-9d46d7e0-8f7f-4ca9-85d1-7c7db427bcff.png)

This PR simply updates the link to this new graph.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3897. (NB: I also did a find and replace for HC -> Healthy Control, which fixes the "Pathology" column, too.)
