### PR TITLE
Exclude original file extension (e.g. `.nii.gz`) from the output `.csv` filename

### DIFF
--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -178,7 +178,9 @@ def main(argv: Sequence[str]):
 
     # save centerline as nifti (discrete) and csv (continuous) files
     im_centerline.save(file_output)
-    np.savetxt(file_output + '.csv', arr_centerline.transpose(), delimiter=",")
+    # Replace `.nii.gz` extension with `.csv` extension
+    path_output, filename_output, _ = extract_fname(file_output)
+    np.savetxt(os.path.join(path_output, f"{filename_output}.csv"), arr_centerline.transpose(), delimiter=",")
 
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -19,7 +19,8 @@ def test_sct_get_centerline_output_file_exists(tmp_path):
        * https://github.com/neuropoly/spinalcordtoolbox/pull/2774/commits/5e6bd57abf6bcf825cd110e0d74b8e465d298409
        * https://github.com/neuropoly/spinalcordtoolbox/pull/2774#discussion_r450546434"""
     sct_get_centerline.main(argv=['-i', 't2s/t2s.nii.gz', '-c', 't2s', '-qc', str(tmp_path)])
-    assert os.path.exists(os.path.join('t2s', 't2s_centerline.nii.gz'))
+    for file in [os.path.join('t2s', 't2s_centerline.nii.gz'), os.path.join('t2s', 't2s_centerline.csv')]:
+        assert os.path.exists(file)
 
 
 @pytest.mark.sct_testing
@@ -30,4 +31,5 @@ def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, ext):
     ensure that the correct output file is created either way."""
     sct_get_centerline.main(argv=['-i', 't2s/t2s.nii.gz', '-c', 't2s', '-qc', str(tmp_path),
                                   '-o', os.path.join(tmp_path, 't2s_centerline'+ext)])
-    assert os.path.exists(os.path.join(tmp_path, 't2s_centerline.nii.gz'))
+    for file in [os.path.join('t2s', 't2s_centerline.nii.gz'), os.path.join('t2s', 't2s_centerline.csv')]:
+        assert os.path.exists(file)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The SCT CLI script `sct_get_centerline` outputs 2 files: An `.nii.gz` file and a `.csv` file. 

The filename for the `.csv` file is derived from the filename chosen for the `.nii.gz` file:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/d17e52f90a971cb778d93d88306b102254e9ba2f/spinalcordtoolbox/scripts/sct_get_centerline.py#L181

However, simply adding `.csv` to the filename results in outputs like `t2s_centerline.nii.gz.csv`, rather than the expected `t2s_centerline.csv`. 

So, this PR properly excludes the original file extension from the `.csv` filename.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3913.