### PR TITLE
Upgrade Ubuntu 18.04 -> 20.04/22.04 in test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -383,7 +383,7 @@ jobs:
       run:
         shell: cmd
     steps:
-    - uses: actions/checkout@v3ush
+    - uses: actions/checkout@v3
     - name: Install SCT
       # NB: In real-world usage, it's assumed that the user would download the
       # install_sct.bat file from the Downloads page, and _not_ the full repo.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: archlinux
     steps:
       - name: Dependencies
@@ -76,7 +76,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: debian:sid
     steps:
       - name: Dependencies
@@ -99,7 +99,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: debian:testing
     steps:
       - name: Dependencies
@@ -122,7 +122,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: debian:10
     steps:
       - name: Dependencies
@@ -145,7 +145,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04  # use an older ubuntu's kernel to closer emulate the older Debian
+    runs-on: ubuntu-20.04
     container: debian:9
     steps:
       - name: Dependencies
@@ -164,7 +164,7 @@ jobs:
 
   centos-8:
     name: CentOS Stream 8
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # Stream8 has a 2024 EOL, while CentOS 8 has a 2021 EOL
     # See: https://blog.centos.org/2020/12/future-is-centos-stream/
     container: quay.io/centos/centos:stream8
@@ -189,7 +189,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04  # use an older ubuntu's kernel to closer emulate the older Debian
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - name: Dependencies
@@ -221,13 +221,13 @@ jobs:
         run: |
           ./.ci.sh -t
 
-  ubuntu-18_04:
-    name: Ubuntu 18.04 (Bionic Beaver)
+  ubuntu-22_04:
+    name: Ubuntu 22.04 (Jammy Jellyfish)
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-
     steps:
       - name: Dependencies
         run: |
@@ -280,9 +280,9 @@ jobs:
         run: |
           ./.ci.sh -t
 
-  windows-wsl-ubuntu-18_04:
+  windows-wsl-ubuntu-22_04:
     # with the help of https://github.com/marketplace/actions/setup-wsl
-    name: WSL [Ubuntu 18.04]
+    name: WSL [Ubuntu 22.04]
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
@@ -295,7 +295,7 @@ jobs:
     - uses: Vampire/setup-wsl@v1
       with:
         # other WSL container choices at: https://github.com/marketplace/actions/setup-wsl#distribution
-        distribution: Ubuntu-18.04
+        distribution: Ubuntu-22.04
     - name: Use unix line endings
       shell: bash
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,7 +227,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-
+    runs-on: ubuntu-22.04
     steps:
       - name: Dependencies
         run: |
@@ -383,7 +383,7 @@ jobs:
       run:
         shell: cmd
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3ush
     - name: Install SCT
       # NB: In real-world usage, it's assumed that the user would download the
       # install_sct.bat file from the Downloads page, and _not_ the full repo.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: glu is needed for PyQT testing (https://stackoverflow.com/a/66486957/7584115)
           pacman -Syu --noconfirm gcc git curl glu
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -82,7 +82,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -105,7 +105,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -128,7 +128,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl libgl1-mesa-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -151,7 +151,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -172,7 +172,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: mesa-libGL is needed for PyQT testing (https://stackoverflow.com/a/65408967/7584115)
           yum install -y gcc git curl mesa-libGL
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -195,7 +195,7 @@ jobs:
       - name: Dependencies
         run: |  # NB: mesa-libGL is needed for PyQT testing (https://stackoverflow.com/a/65408967/7584115)
           yum install -y gcc git curl mesa-libGL
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -210,7 +210,7 @@ jobs:
     name: Ubuntu 20.04 (Focal Fossa)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -232,7 +232,7 @@ jobs:
       - name: Dependencies
         run: |
           # github runners come with dev-tools pre-installed
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -247,7 +247,7 @@ jobs:
    name: macOS 11.0 (Big Sur)
    runs-on: macos-11
    steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v3
      - name: Install SCT
        run: |
          ./.ci.sh -i
@@ -269,7 +269,7 @@ jobs:
       - name: Dependencies
         run: |
           # github runners come with dev-tools pre-installed
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SCT
         run: |
           ./.ci.sh -i
@@ -299,7 +299,7 @@ jobs:
     - name: Use unix line endings
       shell: bash
       run: |
-        # Github's actions/checkout@v2 when run on Windows mangles the line-endings to DOS-style
+        # Github's actions/checkout@v3 when run on Windows mangles the line-endings to DOS-style
         # but we're running Linux *on top* of Windows, so we need to not mangle them!
         # https://github.com/actions/checkout/issues/135#issuecomment-602171132
         # https://github.com/actions/virtual-environments/issues/50#issuecomment-663920265
@@ -310,7 +310,7 @@ jobs:
         # NB: this one needs sudo, so the global DEBIAN_FRONTEND doesn't get through.
         # NB: mesa-utils is needed for PyQT testing (https://github.com/Microsoft/WSL/issues/1246#issuecomment-356425862)
         sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y gcc git curl mesa-utils
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Copy SCT from $GITHUB_WORKSPACE to ~
       run: |
         cd ..
@@ -347,7 +347,7 @@ jobs:
     - name: Use unix line endings
       shell: bash
       run: |
-        # Github's actions/checkout@v2 when run on Windows mangles the line-endings to DOS-style
+        # Github's actions/checkout@v3 when run on Windows mangles the line-endings to DOS-style
         # but we're running Linux *on top* of Windows, so we need to not mangle them!
         # https://github.com/actions/checkout/issues/135#issuecomment-602171132
         # https://github.com/actions/virtual-environments/issues/50#issuecomment-663920265
@@ -358,7 +358,7 @@ jobs:
         # NB: this one needs sudo, so the global DEBIAN_FRONTEND doesn't get through.
         # NB: mesa-utils is needed for PyQT testing (https://github.com/Microsoft/WSL/issues/1246#issuecomment-356425862)
         sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y gcc git curl mesa-utils
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Copy SCT from $GITHUB_WORKSPACE to ~
       run: |
         cd ..
@@ -383,7 +383,7 @@ jobs:
       run:
         shell: cmd
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install SCT
       # NB: In real-world usage, it's assumed that the user would download the
       # install_sct.bat file from the Downloads page, and _not_ the full repo.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In our test suite, we have two kinds of jobs:

1. OSs natively supported by GitHub Actions
2. OSs that must be run via docker containers.

For this 2nd kind, we use `ubuntu-18.04` as the base runner, then run `docker` on top of that using the `container:` keyword. 

However:

* The CentOS Stream 8 CI job is having some troubles, and I want to test whether upgrading to `ubuntu-20.04` fixes this.
* Additionally, support for 18.04 will be removed on Dec 1, 2022. And, ArchLinux is already conducting a brownout for `ubuntu-18.04`:
   ```
   This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see 
   ```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3918.