### PR TITLE
Fix small typo in `-uthr` help description (`below` -> `above`)

### DIFF
--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -190,7 +190,7 @@ def get_parser():
     thresholding.add_argument(
         "-uthr",
         type=float,
-        help='Upper threshold limit (zero below number).',
+        help='Upper threshold limit (zero above number).',
         metavar=Metavar.float,
         required=False)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The help description was the same for both `-thr` and `-uthr`. So, this PR fixes the `-uthr` description so that it properly reflects the meaning of upper thresholding.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3921.
