### PR TITLE
Limit `pyqt5` to >5.11 and <5.15 to avoid "Cannot load library libqxcb.so" error on Ubuntu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,10 @@ onnxruntime>=1.7.0
 pandas
 portalocker
 psutil
-pyqt5
+# pyqt5=5.11.X causes https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3916#discussion_r997435037
+# pyqt5=5.15.X causes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3925
+# So, we limit the range to 5.12-5.14.
+pyqt5>=5.12.0,<5.15.0
 pytest
 pytest-cov
 raven


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The range here is determined by the following issues:

- pyqt5=5.11.X causes an "ImportError: DLL load failed" error on native Windows (See [#3916 (comment)](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3916#discussion_r997435037)).
- pyqt5=5.15.X causes a "Cannot load library libqxcb.so" error on Ubuntu (See [#3925](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3925)).

So, we limit the range to 5.12-5.14. 

Note: There is probably a more elegant solution for addressing the issues with v5.15.X. But, given that this range solves things in the short-term, I think we can revisit the 5.15.X Ubuntu problems in the future, when 5.14 becomes outdated due to the [Python 3.8 EOL](https://endoflife.date/python) (14 Oct 2024).

## Testing this PR

This PR has been manually tested on two local machines (Ubuntu 22.04, Windows 10). But, I do not currently have access to macOS machines or VMs, so I'm not 100% certain that I've fully addressed the concerns from:

* https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3926

## Linked issues

Fixes #3925.
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
