### PR TITLE
Ensure bundled GLIBC is up-to-date in order to resolve `MESA-LOADER` errors

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -620,6 +620,9 @@ if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
   exit 1
 fi
 
+# Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
+conda install -y -c conda-forge libstdcxx-ng
+
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
 python -m pip install -U "pip!=21.2.*"
 

--- a/install_sct
+++ b/install_sct
@@ -621,7 +621,9 @@ if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
 fi
 
 # Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
-conda install -y -c conda-forge libstdcxx-ng
+if [[ $OS == linux* ]]; then
+  conda install -y -c conda-forge libstdcxx-ng
+fi
 
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
 python -m pip install -U "pip!=21.2.*"

--- a/install_sct
+++ b/install_sct
@@ -574,7 +574,7 @@ run mkdir -p "$SCT_DIR/$PYTHON_DIR"
 # Download miniconda
 print info "Downloading Miniconda..."
 case $OS in
-linux*)
+linux)
   download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   ;;
 osx)
@@ -621,7 +621,7 @@ if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
 fi
 
 # Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
-if [[ $OS == linux* ]]; then
+if [[ $OS == linux ]]; then
   conda install -y -c conda-forge libstdcxx-ng
 fi
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

For Ubuntu 22.04 (and possibly other OSs), in `sct_check_dependencies`, the matplotlib/pyqt5 checks will throw a non-fatal error about missing `.so` files that should be in `/usr/lib/dri`. 

```
libGL error: MESA-LOADER: failed to open iris: /usr/lib/dri/iris_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/x86_64-linux-gnu/dri:\$${ORIGIN}/dri:/usr/lib/dri, suffix _dri)
libGL error: failed to load driver: iris
libGL error: MESA-LOADER: failed to open swrast: /usr/lib/dri/swrast_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/x86_64-linux-gnu/dri:\$${ORIGIN}/dri:/usr/lib/dri, suffix _dri)
libGL error: failed to load driver: swrast
```

However (on my machine) these files do exist! They're just in `/usr/lib/x86_64-gnu-linux/dri/` instead of `/usr/lib/dri`.

Separately, there is another file in SCT's venv called `libstdc++.so`, which is [tied to the loading of the above `.so` driver files](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927#issuecomment-1298613727). By default, the version installed is `6.0.29`. But, when this file is updated to `6.0.30`, suddenly `MESA-LOADER` can successfully locate the needed `.so` files, thus eliminating the errors.

So, this PR introduces a conda command to update the GLIBC version before installing SCT's dependencies.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3927.
