### PR TITLE
Tidy up PEP8 warnings and other small style issues

### DIFF
--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -145,10 +145,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
     data = np.zeros([nii_dest.dim[0], nii_dest.dim[1], nii_dest.dim[2], len(list_fname_src)])
     partial_volume = np.zeros([nii_dest.dim[0], nii_dest.dim[1], nii_dest.dim[2], len(list_fname_src)])
 
-    # loop across files
-    i_file = 0
-    for fname_src in list_fname_src:
-
+    for i_file, fname_src in enumerate(list_fname_src):
         # apply transformation src --> dest
         sct_apply_transfo.main(argv=[
             '-i', fname_src,
@@ -176,7 +173,6 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
         # open data
         data[:, :, :, i_file] = Image('src_' + str(i_file) + '_template.nii.gz').data
         partial_volume[:, :, :, i_file] = Image('src_' + str(i_file) + '_template_partialVolume.nii.gz').data
-        i_file += 1
 
     # merge files using partial volume information (and convert nan resulting from division by zero to zeros)
     data_merge = np.divide(np.sum(data * partial_volume, axis=3), np.sum(partial_volume, axis=3))

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree
 from spinalcordtoolbox.math import binarize
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -147,7 +147,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
 
     for i_file, fname_src in enumerate(list_fname_src):
         # apply transformation src --> dest
-        fname_src_warped = os.path.join(path_tmp, f"src_{i_file}_template.nii.gz")
+        fname_src_warped = os.path.join(path_tmp, f"src{i_file}_template.nii.gz")
         sct_apply_transfo.main(argv=[
             '-i', fname_src,
             '-d', fname_dest,
@@ -164,7 +164,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
         out.save(path=fname_src_bin)
 
         # apply transformation to binary mask to compute partial volume
-        fname_src_pv = os.path.join(path_tmp, f"src_{i_file}_template_partialVolume.nii.gz")
+        fname_src_pv = os.path.join(path_tmp, f"src{i_file}_template_partialVolume.nii.gz")
         sct_apply_transfo.main(argv=[
             '-i', fname_src_bin,
             '-d', fname_dest,

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -147,7 +147,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
 
     for i_file, fname_src in enumerate(list_fname_src):
         # apply transformation src --> dest
-        fname_src_warped = os.path.join(path_tmp, 'src_' + str(i_file) + '_template.nii.gz')
+        fname_src_warped = os.path.join(path_tmp, f"src_{i_file}_template.nii.gz")
         sct_apply_transfo.main(argv=[
             '-i', fname_src,
             '-d', fname_dest,
@@ -164,7 +164,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
         out.save(path=fname_src_bin)
 
         # apply transformation to binary mask to compute partial volume
-        fname_src_pv = os.path.join(path_tmp, 'src_' + str(i_file) + '_template_partialVolume.nii.gz')
+        fname_src_pv = os.path.join(path_tmp, f"src_{i_file}_template_partialVolume.nii.gz")
         sct_apply_transfo.main(argv=[
             '-i', fname_src_bin,
             '-d', fname_dest,

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -204,9 +204,6 @@ def main(argv: Sequence[str]):
     fname_dest = arguments.d
     list_fname_warp = arguments.w
     fname_out = arguments.o
-
-    # if arguments.ofolder is not None
-    #     path_results = arguments.ofolder
     interp = arguments.x
     rm_tmp = arguments.r
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -167,11 +167,11 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
         img = Image(fname_src)
         out = img.copy()
         out.data = binarize(out.data, param.almost_zero)
-        out.save(path=f"src_{i_file}native_bin.nii.gz")
+        out.save(path=f"src{i_file}_native_bin.nii.gz")
 
         # apply transformation to binary mask to compute partial volume
         sct_apply_transfo.main(argv=[
-            '-i', 'src_' + str(i_file) + 'native_bin.nii.gz',
+            '-i',  f"src{i_file}_native_bin.nii.gz",
             '-d', fname_dest,
             '-w', list_fname_warp[i_file],
             '-x', param.interp,

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -148,7 +148,6 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
     # initialize variables
     data = np.zeros([nii_dest.dim[0], nii_dest.dim[1], nii_dest.dim[2], len(list_fname_src)])
     partial_volume = np.zeros([nii_dest.dim[0], nii_dest.dim[1], nii_dest.dim[2], len(list_fname_src)])
-    data_merge = np.zeros([nii_dest.dim[0], nii_dest.dim[1], nii_dest.dim[2]])
 
     # loop across files
     i_file = 0


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR started with issue #3920, a very simple suggestion for `sct_merge_images` to change the position of a `_` character in an output filename. This was fixed in f72f1bb394ba94811c1aaba18a5e260f106ed45b.

However, while looking at the `sct_merge_images` script, I noticed that there were quite a few PEP8 issues to clean up, as well as some other small style improvements. So, I thought I'd tidy things up while I was here.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3920.