### PR TITLE
Add references to Bédard and Cohen-Adad

### DIFF
--- a/documentation/source/user_section/citing_sct.rst
+++ b/documentation/source/user_section/citing_sct.rst
@@ -68,6 +68,8 @@ The table below provides individual references for novel methods used in SCT's :
      - `Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018 <https://www.sciencedirect.com/science/article/pii/S136184151730186X>`__
    * - ``sct_label_vertebrae``
      - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <http://downloads.hindawi.com/journals/ijbi/2014/719520.pdf>`__
+   * - ``sct_process_segmentation -pmj``
+     - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
    * - ``sct_propseg``
      - `De Leener et al. Robust, accurate and fast automatic segmentation of the spinal cord. Neuroimage 2014 <https://www.ncbi.nlm.nih.gov/pubmed/24780696>`__
    * - ``sct_propseg -CSF``

--- a/documentation/source/user_section/citing_sct.rst
+++ b/documentation/source/user_section/citing_sct.rst
@@ -68,7 +68,7 @@ The table below provides individual references for novel methods used in SCT's :
      - `Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018 <https://www.sciencedirect.com/science/article/pii/S136184151730186X>`__
    * - ``sct_label_vertebrae``
      - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <http://downloads.hindawi.com/journals/ijbi/2014/719520.pdf>`__
-   * - ``sct_process_segmentation -pmj``
+   * - ``sct_process_segmentation`` with ``-pmj`` or ``-normalize``
      - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
    * - ``sct_propseg``
      - `De Leener et al. Robust, accurate and fast automatic segmentation of the spinal cord. Neuroimage 2014 <https://www.ncbi.nlm.nih.gov/pubmed/24780696>`__

--- a/documentation/source/user_section/citing_sct.rst
+++ b/documentation/source/user_section/citing_sct.rst
@@ -68,7 +68,9 @@ The table below provides individual references for novel methods used in SCT's :
      - `Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018 <https://www.sciencedirect.com/science/article/pii/S136184151730186X>`__
    * - ``sct_label_vertebrae``
      - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <http://downloads.hindawi.com/journals/ijbi/2014/719520.pdf>`__
-   * - ``sct_process_segmentation`` with ``-pmj`` or ``-normalize``
+   * - ``sct_process_segmentation -pmj``
+     - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
+   * - ``sct_process_segmentation -normalize``
      - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
    * - ``sct_propseg``
      - `De Leener et al. Robust, accurate and fast automatic segmentation of the spinal cord. Neuroimage 2014 <https://www.ncbi.nlm.nih.gov/pubmed/24780696>`__

--- a/documentation/source/user_section/tutorials/registration-to-template/shape-metric-computation/csa-pmj.rst
+++ b/documentation/source/user_section/tutorials/registration-to-template/shape-metric-computation/csa-pmj.rst
@@ -7,7 +7,7 @@ Although using vertebral levels as a reference to :ref:`compute CSA <csa-perleve
 
 To overcome this limitation, the CSA can instead be computed as a function of the distance to a neuroanatomical reference point. Here, we use the pontomedullary junction (PMJ) as a reference for computing CSA, since the distance from the PMJ along the spinal cord will vary depending on the position of the neck.
 
-Computing the PMJ-based CSA involves a 4-step process `(Bedard & Cohen-Adad, 2021) <https://www.biorxiv.org/content/10.1101/2021.09.30.462636v1>`_: 
+Computing the PMJ-based CSA involves a 4-step process `(Bedard & Cohen-Adad, 2022) <https://doi.org/10.3389/fnimg.2022.1031253>`_: 
 
 1. The PMJ is detected using ``sct_detect_pmj``.
 2. The spinal cord centerline is extracted using a segmentation of the spinal cord, then the centerline is extended to the position of the PMJ label using linear interpolation and smoothing. 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -88,8 +88,9 @@ def get_parser():
             "      (For option 3, you can also add '-perlevel' to compute metrics for each vertebral level, rather "
             "than averaging.)\n"
             "\n"
-            "Reference for '-pmj': Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord "
-            "cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022.\n"
+            "Reference for '-pmj' and for '-normalize':\n"
+            "Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using "
+            "the pontomedullary junction. Frontiers in Neuroimaging 2022.\n"
             "doi.org/10.3389/fnimg.2022.1031253"
         )
     )

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -86,7 +86,11 @@ def get_parser():
             "than averaging.)\n"
             "   3. '-vert' + '-vertfile': Select a region based on vertebral labels instead of individual slices.\n"
             "      (For option 3, you can also add '-perlevel' to compute metrics for each vertebral level, rather "
-            "than averaging.)"
+            "than averaging.)\n"
+            "\n"
+            "Reference for '-pmj': Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord "
+            "cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022.\n"
+            "doi.org/10.3389/fnimg.2022.1031253"
         )
     )
 


### PR DESCRIPTION
As discussed during the 2022-11-03 SCT dev meeting:
* The reference is updated in the [PMJ tutorial](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/shape-metric-computation/csa-pmj.html).
* A reference is added in the [Citing SCT](https://spinalcordtoolbox.com/user_section/citing_sct.html#command-line-tools) documentation page.
* A reference is added in the `sct_process_segmentation` page for the `-pmj` option:

  ```
  --
  Spinal Cord Toolbox (git-mgp/pmj-citation-1fd6354fea25917eee5c82cd034f3e4e30560a00)
  
  sct_process_segmentation -h
  --
  
  usage: sct_process_segmentation -i <file> [-h] [-o <file>] [-append <int>] [-z <str>]
                                  [-perslice <int>] [-vert <str>] [-vertfile <str>]
                                  [-perlevel <int>] [-angle-corr <int>]
                                  [-centerline-algo {polyfit,bspline,linear,nurbs}]
                                  [-centerline-smooth <int>] [-pmj <file>]
                                  [-pmj-distance <float>] [-pmj-extent <float>]
                                  [-normalize <list> [<list> ...]] [-qc <folder>]
                                  [-qc-image <str>] [-qc-dataset <str>]
                                  [-qc-subject <str>] [-v <int>]
  
  Compute the following morphometric measures based on the spinal cord segmentation:
    - area [mm^2]: Cross-sectional area, measured by counting pixels in each slice.
  Partial volume can be accounted for by inputing a mask comprising values within
  [0,1]. Can be normalized when specifying the flag -normalize
    - angle_AP, angle_RL: Estimated angle between the cord centerline and the axial
  slice. This angle is used to correct for morphometric information.
    - diameter_AP, diameter_RL: Finds the major and minor axes of the cord and measure
  their length.
    - eccentricity: Eccentricity of the ellipse that has the same second-moments as the
  spinal cord. The eccentricity is the ratio of the focal distance (distance between
  focal points) over the major axis length. The value is in the interval [0, 1). When
  it is 0, the ellipse becomes a circle.
    - orientation: angle (in degrees) between the AP axis of the spinal cord and the AP
  axis of the image
    - solidity: CSA(spinal_cord) / CSA_convex(spinal_cord). If perfect ellipse, it
  should be one. This metric is interesting for detecting non-convex shape (e.g., in
  case of strong compression)
    - length: Length of the segmentation, computed by summing the slice thickness
  (corrected for the centerline angle at each slice) across the specified superior-
  inferior region.
  
  To select the region to compute metrics over, choose one of the following arguments:
     1. '-z': Select axial slices based on slice index.
     2. '-pmj' + '-pmj-distance' + '-pmj-extent': Select axial slices based on distance
  from pontomedullary junction.
        (For options 1 and 2, you can also add '-perslice' to compute metrics for each
  axial slice, rather than averaging.)
     3. '-vert' + '-vertfile': Select a region based on vertebral labels instead of
  individual slices.
        (For option 3, you can also add '-perlevel' to compute metrics for each
  vertebral level, rather than averaging.)
  
  Reference for '-pmj' and for '-normalize':
  Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-
  sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022.
  doi.org/10.3389/fnimg.2022.1031253
  
  MANDATORY ARGUMENTS:
    -i <file>             Mask to compute morphometrics from. Could be binary or
                          weighted. E.g., spinal cord segmentation.Example: seg.nii.gz
  
  OPTIONAL ARGUMENTS:
    -h, --help            Show this help message and exit.
    -o <file>             Output file name (add extension). (default: csa.csv)
    -append <int>         Append results as a new line in the output csv file instead
                          of overwriting it. (default: 0)
    -z <str>              Slice range to compute the metrics across. Example: 5:23
    -perslice <int>       Set to 1 to output one metric per slice instead of a single
                          output metric. Please note that when methods ml or map is
                          used, outputing a single metric per slice and then averaging
                          them all is not the same as outputting a single metric at
                          once across all slices. (default: 0)
    -vert <str>           Vertebral levels to compute the metrics across. Example: 2:9
                          for C2 to T2. If you also specify a range of slices with flag
                          `-z`, the intersection between the specified slices and
                          vertebral levels will be considered.
    -vertfile <str>       Vertebral labeling file. Only use with flag -vert.
                          The input and the vertebral labelling file must in the same
                          voxel coordinate system and must match the dimensions between
                          each other.  (default: ./label/template/PAM50_levels.nii.gz)
    -perlevel <int>       Set to 1 to output one metric per vertebral level instead of
                          a single output metric. This flag needs to be used with flag
                          -vert. (default: 0)
    -angle-corr <int>     Angle correction for computing morphometric measures. When
                          angle correction is used, the cord within the slice is
                          stretched/expanded by a factor corresponding to the cosine of
                          the angle between the centerline and the axial plane. If the
                          cord is already quasi-orthogonal to the slab, you can set
                          -angle-corr to 0. (default: 1)
    -centerline-algo {polyfit,bspline,linear,nurbs}
                          Algorithm for centerline fitting. Only relevant with -angle-
                          corr 1. (default: bspline)
    -centerline-smooth <int>
                          Degree of smoothing for centerline fitting. Only use with
                          -centerline-algo {bspline, linear}. (default: 30)
    -pmj <file>           Ponto-Medullary Junction (PMJ) label file. Example:
                          pmj.nii.gz
    -pmj-distance <float>
                          Distance (mm) from Ponto-Medullary Junction (PMJ) to the
                          center of the mask used to compute morphometric measures. (To
                          be used with flag '-pmj'.)
    -pmj-extent <float>   Extent (in mm) for the mask used to compute morphometric
                          measures. Each slice covered by the mask is included in the
                          calculation. (To be used with flag '-pmj' and '-pmj-
                          distance'.) (default: 20.0)
    -normalize <list> [<list> ...]
                          Normalize CSA values ('MEAN(area)').
                          Two models are available:
                              1. sex, brain-volume, thalamus-volume.
                              2. sex, brain-volume.
                          Specify each value for the subject after the corresponding
                          predictor.
                          Example:
                              -normalize sex 0 brain-volume 960606.0 thalamus-volume
                              13942.0
                          *brain-volume and thalamus-volume are in mm^3. For sex,
                          female: 0, male: 1.
                          
                          The models were generated using T1w brain images from 804
                          healthy (non-pathological) participants ranging from 48 to 80
                          years old, taken from the UK Biobank dataset.
                          For more details on the subjects and methods used to create
                          the models, go to: https://github.com/sct-pipeline/ukbiobank-
                          spinalcord-csa#readme
                          Given the risks and lack of consensus surrounding CSA
                          normalization, we recommend thoroughly reviewing the
                          literature on this topic before applying this feature to your
                          data.
    -qc <folder>          The path where the quality control generated content will be
                          saved. The QC report is only available for PMJ-based CSA
                          (with flag '-pmj').
    -qc-image <str>       Input image to display in QC report. Typically, it would be
                          the source anatomical image used to generate the spinal cord
                          segmentation. This flag is mandatory if using flag '-qc'.
    -qc-dataset <str>     If provided, this string will be mentioned in the QC report
                          as the dataset the process was run on.
    -qc-subject <str>     If provided, this string will be mentioned in the QC report
                          as the subject the process was run on.
    -v <int>              Verbosity. 0: Display only errors/warnings, 1:
                          Errors/warnings + info messages, 2: Debug mode (default: 1)
  ```