### PR TITLE
Set a more permissive `quaternion_threshold` inside `Image` constructor

### DIFF
--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -50,10 +50,6 @@ class ImageCropper(object):
             logger.info("Cropping the image...")
             data_crop = self.img_in.data[bbox.xmin:bbox.xmax+1, bbox.ymin:bbox.ymax+1, bbox.zmin:bbox.zmax+1]
             img_out = Image(param=data_crop, hdr=self.img_in.hdr)
-
-            # set a more permissive threshold for reading the qform
-            # (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703 for details)
-            img_out.hdr.quaternion_threshold = -1e-6
             # adapt the origin in the qform matrix
             new_origin = np.dot(img_out.hdr.get_qform(), [bbox.xmin, bbox.ymin, bbox.zmin, 1])
             img_out.hdr.structarr['qoffset_x'] = new_origin[0]

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -303,6 +303,10 @@ class Image(object):
         else:
             raise TypeError('Image constructor takes at least one argument.')
 
+        # set a more permissive threshold for reading the qform
+        # (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703 for details)
+        self.hdr.quaternion_threshold = -1e-6
+
         # Make sure sform and qform are the same.
         # Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/2429
         if check_sform and not check_affines_match(self):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When `hdr.get_qform()` is called on an image with a slightly negative (~0) qform quaternion values, depending on the magnitude, `nibabel` will sometimes throw an exception, even if the header is still acceptable by SCT's standards. 

```
  File "/home/mguaypaq/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.7/site-packages/nibabel/nifti1.py", line 1831, in get_qform
    return self._header.get_qform(coded)
  File "/home/mguaypaq/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.7/site-packages/nibabel/nifti1.py", line 915, in get_qform
    quat = self.get_qform_quaternion()
  File "/home/mguaypaq/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.7/site-packages/nibabel/nifti1.py", line 890, in get_qform_quaternion
    return fillpositive(bcd, self.quaternion_threshold)
  File "/home/mguaypaq/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.7/site-packages/nibabel/quaternions.py", line 99, in fillpositive
    raise ValueError(f'w2 should be positive, but is {w2:e}')
```

The threshold for which "slightly negative" values are considered acceptable is controlled by the `quaternion_threshold` header property. And, in #3771, we chose to tweak this threshold a little to accommodate for a user's data files.

However, #3771 only set the threshold in the context of a single call to `.get_qform`, when in reality, there are 7 total places we call that method. As a result, the error popped up once more, just in a different location.

So, rather than set the threshold on a per-usage basis, this PR sets the threshold in the image constructor itself, so that the modification is present in all cases.

## Alternative solutions

I considered also potentially creating a method inside `Image` call `get_qform`, which sets the threshold and then calls `hdr.get_qform`. (Then, replacing each call to `Image.hdr.get_qform` with `Image.get_qform`.) That way, the change truly only effects the 7 instances of `hdr.get_qform`, rather than making a universal change.

But, as far as I understand, `quaternion_threshold` is only ever used in a single place in `Nifti1Header` objects (the `get_qform_quaternion()` function). So, I think setting the threshold universally shouldn't have any far-reaching effects outside of `get_qform` calls.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3703.