### PR TITLE
`sct_image`: Clarify descriptions for `-setorient` commands

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -146,12 +146,18 @@ def get_parser():
         required=False)
     orientation.add_argument(
         '-setorient',
-        help='Set orientation of the input image (only modifies the header).',
+        help='Set orientation of the input image (modifies BOTH the header and data array, similar to `fslswapdim`).',
         choices='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split(),
         required=False)
     orientation.add_argument(
         '-setorient-data',
-        help='Set orientation of the input image\'s data (does NOT modify the header, but the data). Use with care !',
+        help='Set orientation of the input image\'s data (modifies ONLY the data array, and leaves the header alone).\n'
+             'Example usage: If `-getorient` returns "RPI", then:\n'
+             '  - Calling `-setorient-data LPI` will flip the LR axis of the data array.\n'
+             '  - Calling `-setorient-data IPR` will rearrange the first and last axes of the data array.\n'
+             '  - In both cases, the header of the image will still return "RPI".\n'
+             'WARNING: Use with care, as improper usage may introduce a mismatch between orientation of the header, '
+             'and the orientation of the data array.\n',
         choices='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split(),
         required=False)
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -155,7 +155,8 @@ def get_parser():
              'Example usage: If `-getorient` returns "RPI", then:\n'
              '  - Calling `-setorient-data LPI` will flip the LR axis of the data array.\n'
              '  - Calling `-setorient-data IPR` will rearrange the first and last axes of the data array.\n'
-             '  - In both cases, the header of the image will still return "RPI".\n'
+             '  - In both cases, calling `-getorient` afterwards will still return "RPI", because the header is '
+             'not modified.\n'
              'WARNING: Use with care, as improper usage may introduce a mismatch between orientation of the header, '
              'and the orientation of the data array.\n',
         choices='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split(),


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR is a direct response to the user confusion from https://forum.spinalcordmri.org/t/how-to-use-sct-image-to-fix-the-orientation-of-the-header-and-data-array-setorient-data-vs-setorient/848/1.

My main goals were to:

- Clarify that `-setorient` modifies the header _and_ array in tandem.
- Clarify the usage of `-setorient-data`, since I had to explain its usage multiple times to the user.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3741.