### PR TITLE
Update `binaries_linux` to include a rebuilt version of `stitching` that targets `centos7`

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -73,7 +73,7 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20221018/spinalcordtoolbox-binaries_linux.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F5%2Fmerge-3430482189/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -73,7 +73,7 @@ DATASET_DICT = {
     },
     "binaries_linux": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/refs%2Fpull%2F5%2Fmerge-3430482189/spinalcordtoolbox-binaries_linux.tar.gz",
+            "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20221109/spinalcordtoolbox-binaries_linux.tar.gz",
         ],
         "default_location": __bin_dir__,
     },


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3865, the new `-stitch` feature was tested against a subset of our most common OSs. 

However, once the PR was merged, it was then tested against a larger suite of OSs. At that point, it became apparent that the `stitching` binary (built against GHA's `ubuntu-2018` runner) required a version of `GLIBC` too new for `centos-7` and `debian-9`.

So, this PR updates the link to the binaries to include the work from:

* https://github.com/spinalcordtoolbox/build_biomedia_stitching/pull/1
* https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/pull/5

Which together, rebuilt and packaged the `stitching` binary to target `centos-7`. 

When running the full test suite against commit https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/bacd3e96db624ab3c668f5214272b2bfb2ed3049 (the head of this branch), [everything passes](https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/3431579360).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3937.
