### PR TITLE
Set `draft: true` in the release creation workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -173,3 +173,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         bodyFile: ".github/workflows/release-body.md"
         artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat"
+        draft: true


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Tiny change to enable draft releases by default, which would allow the release author to edit the description and etc. without feeling pressured for time.

From [ncipollo/release-action](https://github.com/ncipollo/release-action):

> Input name | Description | Required | Default Value
> -- | -- | -- | --
> draft | Optionally marks this release as a draft release. Set to true to enable. | false | ""

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3787.
