### PR TITLE
Add more thorough check for `git` within the `PATH` for the Windows installer

### DIFF
--- a/install_sct.bat
+++ b/install_sct.bat
@@ -17,6 +17,7 @@ rem been installed somewhere else, but if this mitigates a user post on the foru
 PATH=%PATH%;C:\Program Files\Git
 git --version >nul 2>&1 || (
     echo ### git not found. Make sure that git is installed ^(and a fresh Command Prompt window has been opened^) before running the SCT installer.
+    goto error
 )
 
 if exist .git\ (

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -15,6 +15,9 @@ rem successfully and still getting an error. However, there are perhaps situatio
 rem hasn't refreshed their terminal. Manually modifying the PATH is a bit of a hacky workaround, especially if Git has
 rem been installed somewhere else, but if this mitigates a user post on the forum, this will save us some dev time.
 PATH=%PATH%;C:\Program Files\Git
+git -version >nul 2>&1 || (
+    echo ### git not found. Make sure that git is installed ^(and a fresh Command Prompt window has been opened^) before running the SCT installer.
+)
 
 if exist .git\ (
   rem If install_sct.bat is being run from a git repository, we assume that this is a git clone of SCT

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -8,6 +8,14 @@ rem This option is needed for expanding !git_ref!, which is set (*and expanded*!
 rem See also https://stackoverflow.com/q/9102422 for a further description of this behavior.
 setLocal EnableDelayedExpansion
 
+rem Try to ensure that Git is available on the PATH prior to invoking `git clone` to avoid 'command not found' errors
+rem   - See also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3912
+rem NB: This *should* be handled by the git installer, and we even have reports of people running git --version
+rem successfully and still getting an error. However, there are perhaps situations where someone has installed git but
+rem hasn't refreshed their terminal. Manually modifying the PATH is a bit of a hacky workaround, especially if Git has
+rem been installed somewhere else, but if this mitigates a user post on the forum, this will save us some dev time.
+PATH=%PATH%;C:\Program Files\Git
+
 if exist .git\ (
   rem If install_sct.bat is being run from a git repository, we assume that this is a git clone of SCT
   rem So, stay in this folder, skip git clone, and assume that we want to install SCT from the current state of the repository

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -15,7 +15,7 @@ rem successfully and still getting an error. However, there are perhaps situatio
 rem hasn't refreshed their terminal. Manually modifying the PATH is a bit of a hacky workaround, especially if Git has
 rem been installed somewhere else, but if this mitigates a user post on the forum, this will save us some dev time.
 PATH=%PATH%;C:\Program Files\Git
-git -version >nul 2>&1 || (
+git --version >nul 2>&1 || (
     echo ### git not found. Make sure that git is installed ^(and a fresh Command Prompt window has been opened^) before running the SCT installer.
 )
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #3912, we encountered some confusing behavior: `git` _appears_ to be on the PATH (`git --version` succeeds), but running `install_sct.bat` results in:

```
### Downloading SCT source code (@5.7) to \Users\tjchr\spinalcordtoolbox...
'git' is not recognized as an internal or external command,
operable program or batch file.
Failed with error #1.
Press any key to continue 
```

My hunch is that our users had opened multiple Command Prompt windows: one window prior to the installation of git, and a second window after the installation of git just to double-check the version. The second window displays `git --version` just fine, but the first window has outdated environment variables, and so `git` is not present on the `PATH` when `install_sct.bat` is run.

This PR attempts to weakly enforce the presence of git's directory on the `PATH`, while also providing a more useful error message in case `git` still isn't present. While this isn't a universal solution, I'm hoping it will help to mitigate time spent debugging with users on the forum.

I considered also trying to run some sort of command to refresh the environment variables ourselves (similar to `source .bashrc`). But, this doesn't seem to be an easily accessible feature in batch scripts outside of `chocolatey`, see: SO threads [1](https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w), [2](https://stackoverflow.com/questions/39856234/how-can-i-refresh-the-path-environment-variable-in-a-batch-script).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3912. (Maybe? At least until we get another report of this issue.)
