### PR TITLE
Minimize memory usage for `algo=dl` (and add a warning for potential OOM killer issues)

### DIFF
--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -449,8 +449,11 @@ def register_dl_multimodal_cascaded_reg(fname_src, fname_dest, fname_warp_forwar
     logger.info("\n Creating VxmDense models with arguments:")
     logger.info(f"\n{reg_args}")
 
-    moved, warp_data_first = register_dl_first_model(input_moving, input_fixed, reg_args, device)
-    moved_final, warp_data_second = register_dl_second_model(moved, input_fixed, reg_args, device)
+    logger.info("\n Predicting using first VxmDense model...")
+    moved, warp_data_first = register_dl_inference('pt_cascaded_first_model.pt', input_moving, input_fixed, reg_args, device)
+
+    logger.info("\n Predicting using second VxmDense model...")
+    moved_final, warp_data_second = register_dl_inference('pt_cascaded_second_model.pt', moved, input_fixed, reg_args, device)
 
     # ---- Warping fields ---- #
     # Modify the warp data so it can be used with sct_apply_transfo()
@@ -508,61 +511,32 @@ def register_dl_multimodal_cascaded_reg(fname_src, fname_dest, fname_warp_forwar
     save(warp_rev, fname_warp_reverse)
 
 
-def register_dl_first_model(input_moving, input_fixed, reg_args, device):
-    # ---- First Model ---- #
-    logger.info("\n Loading first VxmDense model...")
-    pt_first_model = vxm.networks.VxmDense(**reg_args)
-    model1_path = sct_dir_local_path('data', 'deepreg_models', 'pt_cascaded_first_model.pt')
-    trained_state_dict_first_model = torch.load(model1_path)
+def register_dl_inference(fname_model, input_moving, input_fixed, reg_args, device):
+    # Load the PyTorch model
+    pt_model = vxm.networks.VxmDense(**reg_args)
+    path_model = sct_dir_local_path('data', 'deepreg_models', fname_model)
+    trained_state_dict = torch.load(path_model)
+
     # Load the weights to the PyTorch model
-    weights_first_model = []
-    for k in trained_state_dict_first_model:
-        weights_first_model.append(trained_state_dict_first_model[k])
+    weights_model = []
+    for k in trained_state_dict:
+        weights_model.append(trained_state_dict[k])
     i = 0
-    i_max = len(list(pt_first_model.named_parameters()))
-    torchparam = pt_first_model.state_dict()
+    i_max = len(list(pt_model.named_parameters()))
+    torchparam = pt_model.state_dict()
     for k, v in torchparam.items():
         if i < i_max:
-            torchparam[k] = weights_first_model[i]
+            torchparam[k] = weights_model[i]
             i += 1
-    pt_first_model.load_state_dict(torchparam)
-    pt_first_model.to(device)
-    pt_first_model.eval()
+    pt_model.load_state_dict(torchparam)
+    pt_model.to(device)
+    pt_model.eval()
 
-    # ---- Registration ---- #
-    logger.info("\n Predicting using first VxmDense model...")
-    moved, warp_tensor_first = pt_first_model(input_moving, input_fixed, registration=True)
-    warp_data_first = warp_tensor_first[0].permute(1, 2, 3, 0).detach().numpy()
+    # Perform inference
+    im_warped, warp_tensor = pt_model(input_moving, input_fixed, registration=True)
+    warp_data = warp_tensor[0].permute(1, 2, 3, 0).detach().numpy()
 
-    return moved, warp_data_first
-
-
-def register_dl_second_model(moved, input_fixed, reg_args, device):
-    # ---- Second Model ---- #
-    logger.info("\n Loading second VxmDense model...")
-    pt_second_model = vxm.networks.VxmDense(**reg_args)
-    model2_path = sct_dir_local_path('data', 'deepreg_models', 'pt_cascaded_second_model.pt')
-    trained_state_dict_second_model = torch.load(model2_path)
-    # Load the weights to the PyTorch model
-    weights_second_model = []
-    for k in trained_state_dict_second_model:
-        weights_second_model.append(trained_state_dict_second_model[k])
-    i = 0
-    i_max = len(list(pt_second_model.named_parameters()))
-    torchparam = pt_second_model.state_dict()
-    for k, v in torchparam.items():
-        if i < i_max:
-            torchparam[k] = weights_second_model[i]
-            i += 1
-    pt_second_model.load_state_dict(torchparam)
-    pt_second_model.to(device)
-    pt_second_model.eval()
-
-    logger.info("\n Predicting using second VxmDense model...")
-    moved_final, warp_tensor_second = pt_second_model(moved, input_fixed, registration=True)
-    warp_data_second = warp_tensor_second[0].permute(1, 2, 3, 0).detach().numpy()
-
-    return moved_final, warp_data_second
+    return im_warped, warp_data
 
 
 def register_slicewise(fname_src, fname_dest, paramreg=None, fname_mask='', warp_forward_out='step0Warp.nii.gz',


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR amends the `algo='dl'` feature introduced in SCT v5.7 (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3807) by doing 2 things:

1. Minimize memory usage by factoring model inference into a function
    * `algo='dl'` runs inference using two successive PyTorch models.
    * When inference for both models is kept inside a single function, memory usage stacks.
    * However, when model inference is factored out into separate functions, memory usage resets between models.
    
2. Add a warning to preempt a possible OOM-killed process
    * By taking measurements, we can estimate how much memory will be used for images of a given size.
    * Then, if the estimated RAM usage will come close to (or exceed) the amount of free memory, we can emit a warning before the OOM killer kills the process.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3867.
