### PR TITLE
Allow `path_output` parameter to start with `~`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -479,7 +479,7 @@ def main(argv: Sequence[str]):
     else:
         try:
             # Copy the script and record the new location
-            script_copy = os.path.abspath(shutil.copy(script, arguments.path_output))
+            script_copy = os.path.abspath(shutil.copy(script, path_output))
             print("{} -> {}".format(script, script_copy))
             script = script_copy
         except shutil.SameFileError:


### PR DESCRIPTION
The `path_output` variable is defined so that it correctly handles paths which start with `~`, via `os.path.expanduser`:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/c57b43f715cb85dad87a33623c7caf0ed47543ca/spinalcordtoolbox/scripts/sct_run_batch.py#L407-L418

But the raw value of `arguments.path_output` is used once later on, causing problems:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/c57b43f715cb85dad87a33623c7caf0ed47543ca/spinalcordtoolbox/scripts/sct_run_batch.py#L482

(A quick search didn't turn up any other bad uses of `arguments.path_*` parameters.)

## Linked issues
Fixes #3957.