### PR TITLE
Pin `flake8<6.0.0` in our linting workflow

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
-      run: pip install flake8
+      run: pip install flake8<6.0.0
     # Note: flake8 picks up project-wide configuration options from 'setup.cfg' in SCT's root directory
     - name: Lint with flake8
       # NB: 'master...branch' is syntactic sugar for 'git diff `git merge-base master branch`..branch'

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
-      run: pip install flake8<6.0.0
+      run: pip install 'flake8<6.0.0'
     # Note: flake8 picks up project-wide configuration options from 'setup.cfg' in SCT's root directory
     - name: Lint with flake8
       # NB: 'master...branch' is syntactic sugar for 'git diff `git merge-base master branch`..branch'


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

v6.0.0 of `flake8` breaks our CI linting workflow by removing the `--diff` option. There is no officially-endorsed alternative for linting diffs. So, for now, preserve the old behavior until we work out a better solution. (--> https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3961#issuecomment-1325669386?)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3961.