### PR TITLE
Clean up improper submodule access (via imported parent modules)

### DIFF
--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import multiprocessing
 
-import spinalcordtoolbox as sct
+from spinalcordtoolbox import __file__ as package_init_file
 
 
 def main():
@@ -26,7 +26,7 @@ def main():
     env['NEURITE_BACKEND'] = 'pytorch'
 
     command = os.path.basename(sys.argv[0])
-    pkg_dir = os.path.dirname(sct.__file__)
+    pkg_dir = os.path.dirname(package_init_file)
 
     script = os.path.join(pkg_dir, "scripts", "{}.py".format(command))
     assert os.path.exists(script)

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -11,7 +11,7 @@ import textwrap
 import shutil
 
 import spinalcordtoolbox as sct
-import spinalcordtoolbox.download
+from spinalcordtoolbox import download
 from spinalcordtoolbox.utils import stylize
 
 
@@ -256,7 +256,7 @@ def install_model(name_model):
     :return: None
     """
     logger.info("\nINSTALLING MODEL: {}".format(name_model))
-    sct.download.install_data(MODELS[name_model]['url'], folder(name_model))
+    download.install_data(MODELS[name_model]['url'], folder(name_model))
 
 
 def install_default_models():

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -12,7 +12,7 @@ import shutil
 
 import spinalcordtoolbox as sct
 from spinalcordtoolbox import download
-from spinalcordtoolbox.utils import stylize
+from spinalcordtoolbox.utils import stylize, __deepseg_dir__
 
 
 logger = logging.getLogger(__name__)
@@ -245,7 +245,7 @@ def folder(name_model):
     :param name: str: Name of model.
     :return: str: Folder to model
     """
-    return os.path.join(sct.__deepseg_dir__, name_model)
+    return os.path.join(__deepseg_dir__, name_model)
 
 
 def install_model(name_model):

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -10,7 +10,6 @@ import logging
 import textwrap
 import shutil
 
-import spinalcordtoolbox as sct
 from spinalcordtoolbox import download
 from spinalcordtoolbox.utils import stylize, __deepseg_dir__
 
@@ -292,21 +291,21 @@ def list_tasks():
 
 
 def display_list_tasks():
-    tasks = sct.deepseg.models.list_tasks()
+    tasks = list_tasks()
     # Display beautiful output
     color = {True: 'LightGreen', False: 'LightRed'}
     print("{:<30s}{:<50s}{:<15s}MODELS".format("TASK", "DESCRIPTION", "CONTRAST"))
     print("-" * 120)
     for name_task, value in tasks.items():
-        path_models = [sct.deepseg.models.folder(name_model) for name_model in value['models']]
-        are_models_valid = [sct.deepseg.models.is_valid(path_model) for path_model in path_models]
+        path_models = [folder(name_model) for name_model in value['models']]
+        are_models_valid = [is_valid(path_model) for path_model in path_models]
         task_status = stylize(name_task.ljust(30),
                               color[all(are_models_valid)])
         description_status = stylize(value['description'].ljust(50),
                                      color[all(are_models_valid)])
         models_status = ', '.join([stylize(model_name,
-                                           color[is_valid])
-                                   for model_name, is_valid in zip(value['models'], are_models_valid)])
+                                           color[validity])
+                                   for model_name, validity in zip(value['models'], are_models_valid)])
         input_contrasts = stylize(str(', '.join(model_name for model_name in
                                                 get_required_contrasts(name_task))).ljust(15),
                                   color[all(are_models_valid)])
@@ -326,7 +325,7 @@ def display_list_tasks():
 
 
 def display_list_tasks_long():
-    for name_task, value in sct.deepseg.models.list_tasks().items():
+    for name_task, value in list_tasks().items():
         indent_len = len("LONG_DESCRIPTION: ")
         print("{}{}".format("TASK:".ljust(indent_len), stylize(name_task, 'Bold')))
         print('\n'.join(textwrap.wrap(value['long_description'],
@@ -335,9 +334,9 @@ def display_list_tasks_long():
                         subsequent_indent=' '*indent_len)))
         print("{}{}".format("URL:".ljust(indent_len), stylize(value['url'], 'Cyan')))
 
-        path_models = [sct.deepseg.models.folder(name_model)
+        path_models = [folder(name_model)
                        for name_model in value['models']]
-        if all([sct.deepseg.models.is_valid(path_model) for path_model in path_models]):
+        if all([is_valid(path_model) for path_model in path_models]):
             installed = stylize("Yes", 'LightGreen')
         else:
             installed = stylize("No", 'LightRed')

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -10,8 +10,9 @@ import logging
 import textwrap
 import shutil
 
+import spinalcordtoolbox as sct
 from spinalcordtoolbox import download
-from spinalcordtoolbox.utils import stylize, __deepseg_dir__
+from spinalcordtoolbox.utils import stylize
 
 
 logger = logging.getLogger(__name__)
@@ -244,7 +245,7 @@ def folder(name_model):
     :param name: str: Name of model.
     :return: str: Folder to model
     """
-    return os.path.join(__deepseg_dir__, name_model)
+    return os.path.join(sct.__deepseg_dir__, name_model)
 
 
 def install_model(name_model):

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -18,9 +18,8 @@ from typing import Sequence
 from ivadomed import inference as imed_inference
 import nibabel as nib
 
-import spinalcordtoolbox as sct
 from spinalcordtoolbox.deepseg import models
-
+from spinalcordtoolbox.image import splitext
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
@@ -230,7 +229,7 @@ def main(argv: Sequence[str]):
                     fname_seg = options['o'].replace(extension, target + extension) if len(target_lst) > 1 \
                         else options['o']
             else:
-                fname_seg = ''.join([sct.image.splitext(input_filenames[0])[0], target + '.nii.gz'])
+                fname_seg = ''.join([splitext(input_filenames[0])[0], target + '.nii.gz'])
 
             # If output folder does not exist, create it
             path_out = os.path.dirname(fname_seg)

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -19,8 +19,7 @@ from ivadomed import inference as imed_inference
 import nibabel as nib
 
 import spinalcordtoolbox as sct
-import spinalcordtoolbox.deepseg as deepseg
-import spinalcordtoolbox.deepseg.models
+from spinalcordtoolbox.deepseg import models
 
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -74,7 +73,7 @@ def get_parser():
     seg.add_argument(
         "-install-task",
         help="Install models that are required for specified task.",
-        choices=list(deepseg.models.TASKS.keys()))
+        choices=list(models.TASKS.keys()))
 
     misc = parser.add_argument_group('\nPARAMETERS')
     misc.add_argument(
@@ -146,14 +145,14 @@ def main(argv: Sequence[str]):
 
     # Deal with task
     if arguments.list_tasks:
-        deepseg.models.display_list_tasks()
+        models.display_list_tasks()
     # Deal with task long description
     if arguments.list_tasks_long:
-        deepseg.models.display_list_tasks_long()
+        models.display_list_tasks_long()
 
     if arguments.install_task is not None:
-        for name_model in deepseg.models.TASKS[arguments.install_task]['models']:
-            deepseg.models.install_model(name_model)
+        for name_model in models.TASKS[arguments.install_task]['models']:
+            models.install_model(name_model)
         exit(0)
 
     # Deal with input/output
@@ -162,12 +161,12 @@ def main(argv: Sequence[str]):
             parser.error("This file does not exist: {}".format(file))
 
     # Verify if the task is part of the "official" tasks, or if it is pointing to paths containing custom models
-    if len(arguments.task) == 1 and arguments.task[0] in deepseg.models.TASKS:
+    if len(arguments.task) == 1 and arguments.task[0] in models.TASKS:
         # Check if all input images are provided
-        required_contrasts = deepseg.models.get_required_contrasts(arguments.task[0])
+        required_contrasts = models.get_required_contrasts(arguments.task[0])
         n_contrasts = len(required_contrasts)
         # Get pipeline model names
-        name_models = deepseg.models.TASKS[arguments.task[0]]['models']
+        name_models = models.TASKS[arguments.task[0]]['models']
     else:
         n_contrasts = len(arguments.i)
         name_models = arguments.task
@@ -188,22 +187,22 @@ def main(argv: Sequence[str]):
     output_filenames = None
     for name_model in name_models:
         # Check if this is an official model
-        if name_model in list(deepseg.models.MODELS.keys()):
+        if name_model in list(models.MODELS.keys()):
             # If it is, check if it is installed
-            path_model = deepseg.models.folder(name_model)
-            if not deepseg.models.is_valid(path_model):
+            path_model = models.folder(name_model)
+            if not models.is_valid(path_model):
                 printv("Model {} is not installed. Installing it now...".format(name_model))
-                deepseg.models.install_model(name_model)
+                models.install_model(name_model)
         # If it is not, check if this is a path to a valid model
         else:
             path_model = os.path.abspath(name_model)
-            if not deepseg.models.is_valid(path_model):
+            if not models.is_valid(path_model):
                 parser.error("The input model is invalid: {}".format(path_model))
 
         # Order input images
         if arguments.c is not None:
             input_filenames = []
-            for required_contrast in deepseg.models.MODELS[name_model]['contrasts']:
+            for required_contrast in models.MODELS[name_model]['contrasts']:
                 for provided_contrast, input_filename in zip(arguments.c, arguments.i):
                     if required_contrast == provided_contrast:
                         input_filenames.append(input_filename)

--- a/spinalcordtoolbox/scripts/sct_version.py
+++ b/spinalcordtoolbox/scripts/sct_version.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import spinalcordtoolbox as sct
+from spinalcordtoolbox import __version__
 
 
 def main():
-    print(sct.__version__)
+    print(__version__)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

SCT has several levels of nested modules. For example:

* **2 levels:** `spinalcordtoolbox` -> `image.py`
* **3 levels:** `spinalcordtoolbox` -> `deepseg` -> `models.py`

<details>
<summary> Snapshot </summary>

![image](https://user-images.githubusercontent.com/16181459/205771050-9672e027-548e-4a69-bc4f-88ada2d7cce7.png)

</details>

There is a dangerous pattern that can arise as a result of nested modules:

```python
# 1. Import only the top-level module (`spinalcordtoolbox`)
import spinalcordtoolbox as sct
# 2. Try to access the submodule (`image`) using dot notation
result = sct.image.function(input)

# 1. Import only the top-level module (`deepseg`)
import spinalcordtoolbox.deepseg as deepseg
# 2. Try to access the submodule (`models`) using dot notation
result = deepseg.models.function(input)
```

Typically, this should cause an error, because the submodule itself (`image`, `models`) wasn't actually imported. However, if the submodule _was_ imported elsewhere, this pattern will work! [Until it doesn't,](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3972#issuecomment-1338128371) and causes a bug...

So, it's a bit of a footgun to import a top-level module by itself _when that module also has submodules_, because accessing those submodules can be unreliable. And, IMO, this pattern should be avoided. 

For the purposes of this PR, this means:

* Don't import the entire `spinalcordtoolbox` package -- import the specific function you need (e.g. `image.splitext`).
* Don't import the entire `deepseg` module -- import the specific submodule you need (i.e. `models.py`)
* etc.

> _Aside: There are other instances of `import spinalcordtoolbox as sct` that could also be cleaned up. Should that be done in this PR?_ :thinking: 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3972,