### PR TITLE
Pin `numpy<1.24` to mitigate incompatibility with `pystrum==0.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,10 @@ matplotlib
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
-numpy
+# This pin is due to an incompatibility with pystrum==0.2, which is installed via voxelmorph -> neurite -> pystrum
+# See also: https://github.com/adalca/pystrum/issues/9
+# If pystrum is updated to 0.3, then we should replace this version pinning with `pystrum>=0.3`
+numpy<1.24
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 onnxruntime>=1.7.0


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Numpy 1.24 was released recently, bringing with it the removal of the `np.bool` alias. 

One of our upstream dependencies, `voxelmorph`, depends on `neurite`, which in turn depends on `pystrum`. Pystrum's most recent PyPI version still uses `np.bool`. (See https://github.com/adalca/pystrum/issues/9.)

Until `pystrum` fixes this issue, we can pin `numpy<1.24` to keep our test suite from failing.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3980.