### PR TITLE
Improve the readability of temporary directory names throughout SCT

### DIFF
--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -240,7 +240,7 @@ def get_centerline(im_seg, param=ParamCenterline(), verbose=1, remove_temp_files
 
     # Save centerline image to tmp_folder (but only if user hasn't opted to `remove_temp_files`)
     if not remove_temp_files:
-        tmp_folder = tmp_create("centerline")
+        tmp_folder = tmp_create(basename="get-centerline")
         im_centerline.save(os.path.join(tmp_folder, add_suffix(im_seg.absolutepath, "_ctr")), mutable=True)
 
     return (im_centerline,

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -78,7 +78,7 @@ def detect_centerline(img, contrast, remove_temp_files=1):
     logger.debug('Detecting the spinal cord using OptiC')
     img_orientation = img.orientation
 
-    temp_folder = TempFolder()
+    temp_folder = TempFolder(basename="optic-detect-centerline")
     temp_folder.chdir()
 
     # convert image data type to int16, as required by opencv (backend in OptiC)

--- a/spinalcordtoolbox/deepseg_/lesion.py
+++ b/spinalcordtoolbox/deepseg_/lesion.py
@@ -126,7 +126,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     """
 
     # create temporary folder with intermediate results
-    tmp_folder = TempFolder(verbose=verbose)
+    tmp_folder = TempFolder(basename="deepseg-lesion", verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
     if ctr_algo == 'file':  # if the ctr_file is provided
         tmp_folder.copy_from(ctr_file)

--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -416,7 +416,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     logger.info("  Threshold: {}".format(threshold_seg))
 
     # create temporary folder with intermediate results
-    tmp_folder = TempFolder(verbose=verbose)
+    tmp_folder = TempFolder(basename="deepseg-sc", verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
     if ctr_algo == 'file':  # if the ctr_file is provided
         tmp_folder.copy_from(ctr_file)

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -291,7 +291,7 @@ def install_data(url, dest_folder, keep=False):
 
     tmp_file = download_data(url)
 
-    extraction_folder = tmp_create()
+    extraction_folder = tmp_create(basename="install-data")
 
     unzip(tmp_file, extraction_folder)
 

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1751,7 +1751,7 @@ def stitch_images(im_list: Sequence[Image], fname_out: str = 'stitched.nii.gz', 
     orig_ornt = im_list[0].orientation
 
     # reorient input files and save them to a temp directory
-    path_tmp = tmp_create(basename="image-stitching")
+    path_tmp = tmp_create(basename="stitch-images")
     fnames_in = []
     for im_in in im_list:
         temp_file_path = os.path.join(path_tmp, os.path.basename(im_in.absolutepath))

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -148,7 +148,7 @@ def moco_wrapper(param):
     printv('  Input file ............ ' + param.fname_data, param.verbose)
     printv('  Group size ............ {}'.format(param.group_size), param.verbose)
 
-    path_tmp = tmp_create(basename="moco")
+    path_tmp = tmp_create(basename="moco-wrapper")
 
     # Copying input data to tmp folder
     printv('\nCopying input data to tmp folder and convert to nii...', param.verbose)

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -569,7 +569,7 @@ def register_slicewise(fname_src, fname_dest, paramreg=None, fname_mask='', warp
     """
 
     # create temporary folder
-    path_tmp = tmp_create(basename="register")
+    path_tmp = tmp_create(basename="register-slicewise")
 
     # copy data to temp folder
     logger.info("\nCopy input data to temp folder...")

--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -80,7 +80,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         file_out_inv = file_out + '_inv'
 
     # create temporary folder
-    path_tmp = tmp_create(basename="register")
+    path_tmp = tmp_create(basename="register-wrapper")
 
     printv('\nCopying input data to tmp folder and convert to nii...', param.verbose)
     Image(fname_src).save(os.path.join(path_tmp, "src.nii"))

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -117,7 +117,7 @@ class AnalyzeLeion:
                 printv("ERROR input file %s is not binary file with 0 and 1 values" % fname_mask, 1, 'error')
 
         # create tmp directory
-        self.tmp_dir = tmp_create()  # path to tmp directory
+        self.tmp_dir = tmp_create(basename="analyze-lesion")  # path to tmp directory
 
         # lesion file where each lesion has a different value
         self.fname_label = extract_fname(self.fname_mask)[1] + '_label' + extract_fname(self.fname_mask)[2]

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -114,7 +114,7 @@ class ExtractGLCM:
         self.param_glcm = param_glcm if param_glcm is not None else ParamGLCM()
 
         # create tmp directory
-        self.tmp_dir = tmp_create()  # path to tmp directory
+        self.tmp_dir = tmp_create(basename="analyze-texture")  # path to tmp directory
 
         if self.param.dim == 'ax':
             self.orientation_extraction = 'RPI'

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -210,7 +210,7 @@ class Transform:
             # if labels, dilate before resampling
             if islabel:
                 printv("\nDilate labels before warping...")
-                path_tmp = tmp_create(basename="apply_transfo")
+                path_tmp = tmp_create(basename="apply-transfo-3d-label")
                 fname_dilated_labels = os.path.join(path_tmp, "dilated_data.nii")
                 # dilate points
                 dilate(Image(fname_src), 4, 'ball').save(fname_dilated_labels)
@@ -230,7 +230,7 @@ class Transform:
                 raise NotImplementedError
 
             dim = '4'
-            path_tmp = tmp_create(basename="apply_transfo")
+            path_tmp = tmp_create(basename="apply-transfo-4d")
 
             # convert to nifti into temp folder
             printv('\nCopying input data to tmp folder and convert to nii...', verbose)

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -525,7 +525,7 @@ def main(argv: Sequence[str]):
             output_fname = arguments.o
         param.verbose = verbose
 
-        tmp_dir = tmp_create()
+        tmp_dir = tmp_create(basename="compute-hausdorff-distance")
         im1_name = "im1.nii.gz"
         copy(input_fname, os.path.join(tmp_dir, im1_name))
         if input_second_fname != '':

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -172,7 +172,7 @@ def create_mask(param):
     if param.fname_out == '':
         param.fname_out = os.path.abspath(param.file_prefix + file_data + ext_data)
 
-    path_tmp = tmp_create(basename="create_mask")
+    path_tmp = tmp_create(basename="create-mask")
 
     printv('\nOrientation:', param.verbose)
     orientation_input = Image(param.fname_data).orientation

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -128,7 +128,7 @@ class DetectPMJ:
 
         self.verbose = verbose
 
-        self.tmp_dir = tmp_create()  # path to tmp directory
+        self.tmp_dir = tmp_create(basename="detect-pmj")  # path to tmp directory
 
         self.orientation_im = Image(self.fname_im).orientation  # to re-orient the data at the end
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -111,7 +111,7 @@ def main(argv: Sequence[str]):
     fname_input1 = arguments.i
     fname_input2 = arguments.d
 
-    tmp_dir = tmp_create()  # create tmp directory
+    tmp_dir = tmp_create(basename="dice-coefficient")  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)
 
     # copy input files to tmp directory

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -149,7 +149,7 @@ def main(argv: Sequence[str]):
     path_data, file_data, ext_data = extract_fname(fname_data)
 
     # create temporary folder
-    path_tmp = tmp_create(basename="dmri_separate")
+    path_tmp = tmp_create(basename="dmri-separate-b0-and-dwi")
 
     # copy files into tmp folder and convert to nifti
     printv('\nCopy files into temporary folder...', verbose)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -576,7 +576,7 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
     if im_grid:
         fname_grid = im_grid.absolutepath
     else:
-        tmp_dir = tmp_create()
+        tmp_dir = tmp_create(basename="visualize-warp")
         nx, ny, nz = im_warp.data.shape[0:3]
         curdir = os.getcwd()
         os.chdir(tmp_dir)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -399,7 +399,7 @@ def main(argv: Sequence[str]):
         if arguments.stitch is not None:
             printv("Generating QC Report...", verbose=verbose)
             # specify filenames to use in QC report
-            path_tmp = tmp_create("stitching-QC")
+            path_tmp = tmp_create(basename="stitching-qc")
             fname_qc_concat = os.path.join(path_tmp, "concatenated_input_images.nii.gz")
             fname_qc_out = os.path.join(path_tmp, os.path.basename(fname_out))
             # generate 2 images to compare in QC report

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -295,7 +295,7 @@ def main(argv: Sequence[str]):
     remove_temp_files = arguments.r
     clean_labels = arguments.clean_labels
 
-    path_tmp = tmp_create(basename="label_vertebrae")
+    path_tmp = tmp_create(basename="label-vertebrae")
 
     # Copying input data to tmp folder
     printv('\nCopying input data to tmp folder...', verbose)

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -136,7 +136,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp,
 
     """
     # create temporary folder
-    path_tmp = tmp_create()
+    path_tmp = tmp_create(basename="merge-images")
 
     # get dimensions of destination file
     nii_dest = Image(fname_dest)

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -460,7 +460,7 @@ def main(argv: Sequence[str]):
                 fname_ctl_smooth = add_suffix(fname_ctl, '_smooth')
                 if verbose != 2:
                     from spinalcordtoolbox.utils.fs import tmp_create
-                    path_tmp = tmp_create()
+                    path_tmp = tmp_create(basename="pmj-qc")
                     fname_mask_out = os.path.join(path_tmp, fname_mask_out)
                     fname_ctl = os.path.join(path_tmp, fname_ctl)
                     fname_ctl_smooth = os.path.join(path_tmp, fname_ctl_smooth)

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -50,7 +50,7 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_
     """
     printv('\nCheck consistency of segmentation...', verbose)
     # creating a temporary folder in which all temporary files will be placed and deleted afterwards
-    path_tmp = tmp_create(basename="propseg")
+    path_tmp = tmp_create(basename="propseg-check-segmentation")
     im_seg = convert(Image(fname_segmentation))
     im_seg.save(os.path.join(path_tmp, "tmp.segmentation.nii.gz"), mutable=True, verbose=0)
     im_centerline = convert(Image(fname_centerline))
@@ -421,7 +421,7 @@ def func_rescale_header(fname_data, rescale_factor, verbose=0):
     header_rescaled.set_qform(qform)
     # the data are the same-- only the header changes
     img_rescaled = nib.nifti1.Nifti1Image(img.get_data(), None, header=header_rescaled)
-    path_tmp = tmp_create(basename="propseg")
+    path_tmp = tmp_create(basename="propseg-rescale-header")
     fname_data_rescaled = os.path.join(path_tmp, os.path.basename(add_suffix(fname_data, "_rescaled")))
     nib.save(img_rescaled, fname_data_rescaled)
     return fname_data_rescaled

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -563,7 +563,6 @@ def propseg(img_input, options_dict):
         printv('ERROR: your input image needs to be 3D in order to be segmented.', 1, 'error')
 
     path_data, file_data, ext_data = extract_fname(fname_data)
-    path_tmp = tmp_create(basename="label_vertebrae")
 
     # rescale header (see issue #1406)
     if rescale_header != 1.0:
@@ -611,6 +610,7 @@ def propseg(img_input, options_dict):
     # If using OptiC
     elif use_optic:
         image_centerline = optic.detect_centerline(image_input, contrast_type, remove_temp_files)
+        path_tmp = tmp_create(basename="propseg-centerline-optic")
         fname_centerline_optic = os.path.join(path_tmp, 'centerline_optic.nii.gz')
         image_centerline.save(fname_centerline_optic)
         cmd += ["-init-centerline", fname_centerline_optic]

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -401,7 +401,7 @@ def main(argv: Sequence[str]):
     if len(labels) > 2 and label_type in ['disc', 'spinal']:
         level_alignment = True
 
-    path_tmp = tmp_create(basename="register_to_template")
+    path_tmp = tmp_create(basename="register-to-template")
 
     # set temporary file names
     ftmp_data = 'data.nii'

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -167,7 +167,7 @@ def main(argv: Sequence[str]):
     path_anat, file_anat, ext_anat = extract_fname(fname_anat)
     path_centerline, file_centerline, ext_centerline = extract_fname(fname_centerline)
 
-    path_tmp = tmp_create(basename="smooth_spinalcord")
+    path_tmp = tmp_create(basename="smooth-spinalcord")
 
     # Copying input data to tmp folder
     printv('\nCopying input data to tmp folder and convert to nii...', verbose)

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -99,7 +99,7 @@ class SpinalCordStraightener(object):
         # Extract path/file/extension
         path_anat, file_anat, ext_anat = extract_fname(fname_anat)
 
-        path_tmp = tmp_create(basename="straighten_spinalcord")
+        path_tmp = tmp_create(basename="straighten-spinalcord")
 
         # Copying input data to tmp folder
         logger.info('Copy files to tmp folder...')

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -13,12 +13,11 @@ from .sys import printv
 logger = logging.getLogger(__name__)
 
 
-def tmp_create(basename=None):
+def tmp_create(basename):
     """Create temporary folder and return its path
     """
     prefix = "sct-%s-" % datetime.datetime.now().strftime("%Y%m%d%H%M%S.%f")
-    if basename:
-        prefix += "%s-" % basename
+    prefix += "%s-" % basename
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info("Creating temporary folder (%s)" % tmpdir)
     return tmpdir
@@ -120,8 +119,8 @@ def check_file_exist(fname, verbose=1):
 class TempFolder(object):
     """This class will create a temporary folder."""
 
-    def __init__(self, verbose=0):
-        self.path_tmp = tmp_create()
+    def __init__(self, basename, verbose=0):
+        self.path_tmp = tmp_create(basename)
         self.previous_path = None
 
     def chdir(self):

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def tmp_create(basename):
     """Create temporary folder and return its path
     """
-    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S.%f')}_{basename}_"
+    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S')}_{basename}_"
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info(f"Creating temporary folder ({tmpdir})")
     return tmpdir

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def tmp_create(basename):
     """Create temporary folder and return its path
     """
-    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H.%M.%S')}_{basename}_"
+    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_{basename}_"
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info(f"Creating temporary folder ({tmpdir})")
     return tmpdir

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -16,10 +16,9 @@ logger = logging.getLogger(__name__)
 def tmp_create(basename):
     """Create temporary folder and return its path
     """
-    prefix = "sct-%s-" % datetime.datetime.now().strftime("%Y%m%d%H%M%S.%f")
-    prefix += "%s-" % basename
+    prefix = f"sct-{datetime.datetime.now().strftime('%Y%m%d%H%M%S.%f')}-{basename}-"
     tmpdir = tempfile.mkdtemp(prefix=prefix)
-    logger.info("Creating temporary folder (%s)" % tmpdir)
+    logger.info(f"Creating temporary folder ({tmpdir})")
     return tmpdir
 
 

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def tmp_create(basename):
     """Create temporary folder and return its path
     """
-    prefix = f"sct-{datetime.datetime.now().strftime('%Y%m%d%H%M%S.%f')}-{basename}-"
+    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S.%f')}_{basename}_"
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info(f"Creating temporary folder ({tmpdir})")
     return tmpdir

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def tmp_create(basename):
     """Create temporary folder and return its path
     """
-    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H:%M:%S')}_{basename}_"
+    prefix = f"sct_{datetime.datetime.now().strftime('%Y-%m-%d_%H.%M.%S')}_{basename}_"
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info(f"Creating temporary folder ({tmpdir})")
     return tmpdir

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -59,7 +59,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
 
     # create temporary folder with intermediate results
     logger.info("Creating temporary folder...")
-    tmp_folder = TempFolder()
+    tmp_folder = TempFolder(basename="detect-c2c3")
     tmp_folder.chdir()
 
     # Extract mid-slice

--- a/testing/api/test_image.py
+++ b/testing/api/test_image.py
@@ -569,7 +569,7 @@ def test_more_change_orientation(tmp_path, fake_3dimage_sct, fake_3dimage_sct_vi
 
 def test_change_nd_orientation(fake_4dimage_sct):
     im_src = fake_4dimage_sct.copy()
-    path_tmp = tmp_create(basename="test_reorient")
+    path_tmp = tmp_create(basename="test-reorient")
     im_src.save(os.path.join(path_tmp, "src.nii"), mutable=True)
 
     print(im_src.orientation, im_src.data.shape)
@@ -621,7 +621,7 @@ def test_change_shape(fake_3dimage_sct):
     im_src = fake_3dimage_sct
     shape = tuple(list(im_src.data.shape) + [1])
     im_dst = msct_image.change_shape(im_src, shape)
-    path_tmp = tmp_create(basename="test_reshape")
+    path_tmp = tmp_create(basename="test-reshape")
     src_path = os.path.join(path_tmp, "src.nii")
     dst_path = os.path.join(path_tmp, "dst.nii")
     im_src.save(src_path)
@@ -647,7 +647,7 @@ def test_sequences(fake_3dimage_sct):
 
     img = fake_3dimage_sct.copy()
 
-    path_tmp = tmp_create(basename="test_sequences")
+    path_tmp = tmp_create(basename="test-sequences")
 
     path_a = os.path.join(path_tmp, 'a.nii')
     path_b = os.path.join(path_tmp, 'b.nii')

--- a/testing/dependencies/test_ants.py
+++ b/testing/dependencies/test_ants.py
@@ -26,7 +26,7 @@ def test_ants_registration():
     dice_acceptable = 0.39  # computed DICE should be 0.931034
     verbose = 1
 
-    path_tmp = tmp_create(basename="test_ants")
+    path_tmp = tmp_create(basename="test-ants")
 
     # go to tmp folder
     curdir = os.getcwd()


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR originated in issue #3978, when @valosekj noticed that `sct_propseg`'s centerline folder name was erroneously called "label_vertebrae".

Separately, however, I've held the opinion that tempdir names in SCT [aren't as clear as they could be](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3978#issuecomment-1342822951). I've been wanting to update _every_ tempdir name; issue #3978 is just the straw that broke the camel's back.

So, this PR aims to improve the quality of tempdir names in SCT. This PR contains two main parts:

1. Updating the `tmp_create` function in `fs.py`, to improve the general structure of tmpdir names.
2. Updating the `basename` parameters in each _call_ to `tmp_create`, so that they all follow a standard.

The "naming standardization" is explained in commit 0c3abd0310b51d21682342ea77d041033d6a9654:

1. Only lowercase names
2. Words are delimited with `-`, not `_` (due to the fact that `_` is already in use to delimit other parts of the temporary directory name e.g. date, time, etc.)
3. Basenames should roughly match the name of the CLI script or API function that the temporary directory belongs to
   (minus `sct_` for CLI scripts).
4. If the function name itself doesn't provide enough context, then another identifier can be added (e.g. adding `propseg-` to the propseg-specific `rescale-header` function.)

Lastly, #3978 itself is fixed by 80b62205c698eb10cca74afac5130a07023a217a.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3978.
