### PR TITLE
Fix broken `-v 2` case by making sure `fname_res_ctr` exists prior to resampling

### DIFF
--- a/spinalcordtoolbox/deepseg_/lesion.py
+++ b/spinalcordtoolbox/deepseg_/lesion.py
@@ -165,6 +165,10 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
         im_ctl = \
             resampling.resample_nib(im_ctl, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm', interpolation='linear')
 
+    # Save the centerline image file
+    fname_res_ctr = add_suffix(fname_orient, '_ctr')
+    im_ctl.save(fname_res_ctr)
+
     # crop image around the spinal cord centerline
     logger.info("\nCropping the image around the spinal cord...")
     crop_size = 48
@@ -231,7 +235,6 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
         im_viewer = None
 
     if verbose == 2:
-        fname_res_ctr = add_suffix(fname_orient, '_ctr')
         resampling.resample_file(fname_res_ctr, fname_res_ctr, initial_resolution,
                                  'mm', 'linear', verbose=0)
         im_image_res_ctr_downsamp = Image(fname_res_ctr).change_orientation(original_orientation)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When `sct_deepseg_lesion` is called with `-v 2`, an error is thrown, because `resample_file` is called on the `fname_res_ctr` filename, but that file that doesn't exist.

I tried to infer where exactly this file was supposed to have been created:

- `fname_res_ctr` is the result of `fname_orient` combined with a `_ctr` (centerline) suffix.
   https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/6ee19076472c7e42da1e15b4483ff0720772df27/spinalcordtoolbox/deepseg_/lesion.py#L234
- Because the filename implies a centerline file created from `fname_orient`, this clearly seems to me to be:
   https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/6ee19076472c7e42da1e15b4483ff0720772df27/spinalcordtoolbox/deepseg_/lesion.py#L157-L163
- So, I've saved `im_ctl` using the filename expected later on in the function.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3970.
