### PR TITLE
Use milestone due date

### DIFF
--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Update '${{ github.event.inputs.fname_changelog }}' for '${{ github.event.repository.name }}'
       run: |
         cd ${{ github.event.repository.name }}
-        changelog spinalcordtoolbox/spinalcordtoolbox --update --name "${{ github.event.inputs.fname_changelog }}" --milestone ${{ github.event.inputs.milestone_title }}
+        changelog spinalcordtoolbox/spinalcordtoolbox --update --name "${{ github.event.inputs.fname_changelog }}" --milestone ${{ github.event.inputs.milestone_title }} --use-milestone-due-date
         rm -f "${{ github.event.inputs.fname_changelog }}.bak"
     - name: Create pull request for updated changelog
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
This is a follow-up to [changelog#33](https://github.com/neuropoly/changelog/pull/33), to use the new command-line flag `--use-milestone-due-date`, so that the changelog text refers to the planned release date, rather than whatever date the draft is created on.