### PR TITLE
Update `version.txt` on master branch during release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       milestone_title:
-        description: 'Milestone title'
+        description: 'Milestone title (this release)'
         required: true
       future_milestone_title:
-        description: 'Milestone title (future release)'
+        description: 'Milestone title (next release)'
         required: true
   push:
     branches:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -149,16 +149,16 @@ jobs:
           git commit -m "Update version.txt for ${{ github.event.inputs.future_milestone_title }} development"
           git push
 
-    - name: Download requirements-freeze.txt
+    - name: Download requirements-freeze.txt (for release)
       uses: actions/download-artifact@v3
       with:
         name: requirements-freeze
 
-    - name: Update version.txt (using milestone title)
+    - name: Update version.txt (for release)
       run: |
         echo "${{ github.event.inputs.milestone_title }}" > spinalcordtoolbox/version.txt
 
-    - name: Commit and push
+    - name: Commit and push release changes
       run: |
         git checkout -b bot/${{ github.event.inputs.milestone_title }}
         git add requirements-freeze.txt

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -128,6 +128,11 @@ jobs:
     # Only create the release if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
     if: github.event_name == 'workflow_dispatch'
     steps:
+    # The GitHub Actions bot email was taken from: https://github.community/t/github-actions-bot-email-address/17204/6
+    - name: Set bot user data for commits
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "GitHub Actions Bot"
 
     - name: Checkout spinalcordtoolbox (main branch)
       uses: actions/checkout@v2
@@ -143,12 +148,6 @@ jobs:
     - name: Update version.txt (using milestone title)
       run: |
         echo "${{ github.event.inputs.milestone_title }}" > spinalcordtoolbox/version.txt
-
-    # The GitHub Actions bot email was taken from: https://github.community/t/github-actions-bot-email-address/17204/6
-    - name: Set bot user data for commits
-      run: |
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "GitHub Actions Bot"
 
     - name: Commit and push
       run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,9 @@ on:
       milestone_title:
         description: 'Milestone title'
         required: true
+      future_milestone_title:
+        description: 'Milestone title (future release)'
+        required: true
   push:
     branches:
       - master
@@ -139,6 +142,12 @@ jobs:
       with:
         ref: ${{ env.MAIN_BRANCH }}
         fetch-depth: 0
+
+    - name: Update version.txt (main branch)
+      run: | 
+          echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
+          git commit -m "Update version.txt for ${{ github.event.inputs.future_milestone_title }} development"
+          git push
 
     - name: Download requirements-freeze.txt
       uses: actions/download-artifact@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -143,6 +143,11 @@ jobs:
         ref: ${{ env.MAIN_BRANCH }}
         fetch-depth: 0
 
+    # Branch off before adding commits to the main branch
+    - name: Create release branch
+      run: |
+        git branch bot/${{ github.event.inputs.milestone_title }}
+
     - name: Update version.txt (main branch)
       run: |
         echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
@@ -161,7 +166,7 @@ jobs:
 
     - name: Commit and push release changes
       run: |
-        git checkout -b bot/${{ github.event.inputs.milestone_title }}
+        git checkout bot/${{ github.event.inputs.milestone_title }}
         git add requirements-freeze.txt
         git commit -m "Update requirements-freeze.txt for ${{ github.event.inputs.milestone_title }}"
         git add spinalcordtoolbox/version.txt

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -160,17 +160,19 @@ jobs:
       with:
         name: requirements-freeze
 
-    - name: Update version.txt (for release)
-      run: |
-        echo "${{ github.event.inputs.milestone_title }}" > spinalcordtoolbox/version.txt
-
-    - name: Commit and push release changes
-      run: |
+    - name: Commit requirements-freeze.txt (for release)
         git checkout bot/${{ github.event.inputs.milestone_title }}
         git add requirements-freeze.txt
         git commit -m "Update requirements-freeze.txt for ${{ github.event.inputs.milestone_title }}"
+
+    - name: Update version.txt (for release)
+      run: |
+        echo "${{ github.event.inputs.milestone_title }}" > spinalcordtoolbox/version.txt
         git add spinalcordtoolbox/version.txt
         git commit -m "Update version.txt for ${{ github.event.inputs.milestone_title }}"
+
+    - name: Push release changes
+      run: |
         git tag ${{ github.event.inputs.milestone_title }}
         git push --tags
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -144,11 +144,11 @@ jobs:
         fetch-depth: 0
 
     - name: Update version.txt (main branch)
-      run: | 
-          echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
-          git add spinalcordtoolbox/version.txt
-          git commit -m "Update version.txt for ${{ github.event.inputs.future_milestone_title }} development"
-          git push
+      run: |
+        echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
+        git add spinalcordtoolbox/version.txt
+        git commit -m "Update version.txt for ${{ github.event.inputs.future_milestone_title }} development"
+        git push
 
     - name: Download requirements-freeze.txt (for release)
       uses: actions/download-artifact@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -161,6 +161,7 @@ jobs:
         name: requirements-freeze
 
     - name: Commit requirements-freeze.txt (for release)
+      run: |
         git checkout bot/${{ github.event.inputs.milestone_title }}
         git add requirements-freeze.txt
         git commit -m "Update requirements-freeze.txt for ${{ github.event.inputs.milestone_title }}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -146,6 +146,7 @@ jobs:
     - name: Update version.txt (main branch)
       run: | 
           echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
+          git add spinalcordtoolbox/version.txt
           git commit -m "Update version.txt for ${{ github.event.inputs.future_milestone_title }} development"
           git push
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR is a follow-up to https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3999. It makes sure that our `version.txt` on `master` is updated when a new release is created, to reflect the version currently in development.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3998.