### PR TITLE
Display vertebral levels when provided with `-perslice 1`

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -278,7 +278,6 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
 
     # aggregation based on levels
     vertgroups = None
-        
     if levels:
         # slicegroups = [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
         slicegroups = [tuple(get_slices_from_vertebral_levels(im_vert_level, level)) for level in levels]

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -153,7 +153,6 @@ def get_parser():
     optional.add_argument(
         '-vertfile',
         metavar=Metavar.str,
-        default=os.path.join('.', 'label', 'template', 'PAM50_levels.nii.gz'),
         help="Vertebral labeling file. Only use with flag -vert.\n"
         "The input and the vertebral labelling file must in the same voxel coordinate system "
         "and must match the dimensions between each other. "

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -154,6 +154,7 @@ def get_parser():
     optional.add_argument(
         '-vertfile',
         metavar=Metavar.str,
+        default=os.path.join('.', 'label', 'template', 'PAM50_levels.nii.gz'),
         help="Vertebral labeling file. Only use with flag -vert.\n"
         "The input and the vertebral labelling file must in the same voxel coordinate system "
         "and must match the dimensions between each other. "

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -372,7 +372,7 @@ def main(argv: Sequence[str]):
 
     file_out = os.path.abspath(arguments.o)
     append = bool(arguments.append)
-    if arguments.vert is not None:
+    if arguments.vertfile is not None:
         levels = arguments.vert
         fname_vert_level = arguments.vertfile
     else:

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -373,12 +373,8 @@ def main(argv: Sequence[str]):
 
     file_out = os.path.abspath(arguments.o)
     append = bool(arguments.append)
-    if arguments.vertfile is not None:
-        levels = arguments.vert
-        fname_vert_level = arguments.vertfile
-    else:
-        levels = []
-        fname_vert_level = None
+    levels = arguments.vert
+    fname_vert_level = arguments.vertfile
     perlevel = bool(arguments.perlevel)
     slices = arguments.z
     perslice = bool(arguments.perslice)

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -146,6 +146,7 @@ def get_parser():
         '-vert',
         metavar=Metavar.str,
         type=parse_num_list,
+        default='',
         help="Vertebral levels to compute the metrics across. Example: 2:9 for C2 to T2. If you also specify a range of "
              "slices with flag `-z`, the intersection between the specified slices and vertebral levels will be "
              "considered."

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -375,6 +375,13 @@ def main(argv: Sequence[str]):
     append = bool(arguments.append)
     levels = arguments.vert
     fname_vert_level = arguments.vertfile
+    if not os.path.isfile(fname_vert_level):
+        logger.warning(f"Vertebral level file {fname_vert_level} does not exist. Vert level information will "
+                       f"not be displayed. To use vertebral level information, you may need to run "
+                       f"`sct_warp_template` to generate the appropriate level file in your working directory.")
+        fname_vert_level = None  # Discard the default '-vertfile', so that we don't attempt to find vertebral levels
+        if levels:
+            raise FileNotFoundError("The vertebral level file must exist to use `-vert` to group by vertebral level.")
     perlevel = bool(arguments.perlevel)
     slices = arguments.z
     perslice = bool(arguments.perslice)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR adresses #3113. In `sct_process_segmentation` when specifying `-vertfile` and `-perslice 1`, it now specifies the vertebral levels (when they are provided). 

## Linked issues
Fixes #3113 (and also its duplication #3976)