### PR TITLE
Fix indentation for wrapped lines in argparse help

### DIFF
--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -322,13 +322,16 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         wrapped = []
         for i, li in enumerate(lines):
             if len(li) > 0:
-                o = offsets[i]
-                ol = len(o)
+                # Split the line into two parts: the first line, and wrapped lines
                 init_wrap = textwrap.fill(li, width).splitlines()
                 first = init_wrap[0]
                 rest = "\n".join(init_wrap[1:])
+                # Add an offset to the wrapped lines so that they're indented the same as the first line
+                o = offsets[i]
+                ol = len(o)
                 rest_wrap = textwrap.fill(rest, width - ol).splitlines()
                 offset_lines = [o + wl for wl in rest_wrap]
+                # Merge the first line and the wrapped lines
                 wrapped = wrapped + [first] + offset_lines
             else:
                 wrapped = wrapped + [li]

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -328,6 +328,8 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
                 rest = "\n".join(init_wrap[1:])
                 # Add an offset to the wrapped lines so that they're indented the same as the first line
                 o = offsets[i]
+                if re.match(r"^\s+[-*]\s\w.*$", li):  # List matching: " - Text" or " * Text"
+                    o += "  "  # If the line is a list item, add extra indentation to the wrapped lines (#2889)
                 ol = len(o)
                 rest_wrap = textwrap.fill(rest, width - ol).splitlines()
                 offset_lines = [o + wl for wl in rest_wrap]

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -289,9 +289,8 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         This method is what gets called for the parser's `description` field.
         """
         import textwrap
-        # NB: text.splitlines() is what's used by argparse.RawTextHelpFormatter
-        #     to preserve newline characters (`\n`) in text.
-        paragraphs = text.splitlines()
+        # NB: We use our overridden split_lines method to apply indentation to the help description
+        paragraphs = self._split_lines(text, width)
         # NB: The remaining code is fully custom
         rebroken = [textwrap.wrap(tpar, width) for tpar in paragraphs]
         rebrokenstr = []


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR fixes two visual formatting bugs in our argparse help for CLI scripts:

1. 9747707: Wrapped lines for list items (` - Text` or ` * Text`) would not get sufficient indentation. ([Before vs. after](https://www.diffchecker.com/REt4z27A/))
2. 1df5d6e: The "Description" part of each CLI script would get _no_ identation formatting. ([Before vs. after](https://www.diffchecker.com/RYbYVcZr/))

Additionally, the first commit (bb7b6fd356fc55cab4ad087de264cb00bcede0ce) is just a tiny reorganization to make the steps easier to understand.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2889.
