### PR TITLE
Refactor the `interpolate_metrics` function to simplify and shorten it

### DIFF
--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -61,7 +61,8 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
             if key != 'length':
                 metric_values_level = value.data[slices_im]
                 # Interpolate in the same number of slices
-                metrics_PAM50_space_dict[key][slices_PAM50] = np.interp(x_PAM50, x, metric_values_level)
+                metrics_inter = np.interp(x_PAM50, x, metric_values_level)
+                metrics_PAM50_space_dict[key][slices_PAM50] = metrics_inter
 
     # Loop through the slices in the first and last levels to scale only.
     for i, (slices_PAM50, slices_im) in enumerate(zip(level_slices_PAM50[::len(levels)-1],

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -46,22 +46,22 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     level_slices_PAM50 = [get_slices_from_vertebral_levels(im_seg_labeled_PAM50, level) for level in levels]
     level_slices_im = [get_slices_from_vertebral_levels(im_seg_labeled, level) for level in levels]
 
-    # Create empty list to keep the scaling between the image and PAM50
-    scales = []
+    # Find the mean scaling between the image and PAM50 (excluding first and last levels)
+    scales = [len(slices_PAM50)/len(slices_im) for slices_PAM50, slices_im
+              in zip(level_slices_PAM50[1:-1], level_slices_im[1:-1])]
+    scale_mean = np.mean(scales)
+
     # Loop through slices per-level (excluding first and last levels)
     for slices_PAM50, slices_im in zip(level_slices_PAM50[1:-1], level_slices_im[1:-1]):
         # Prepare vectors for the interpolation
         x_PAM50 = np.arange(0, len(slices_PAM50), 1)
         x = np.linspace(0, len(slices_PAM50) - 1, len(slices_im))
-        # Compute and keep the scaling factor for the currently processed level
-        scales.append(len(slices_PAM50)/len(slices_im))
         # Loop through metrics
         for key, value in metrics.items():
             if key != 'length':
                 metric_values_level = value.data[slices_im]
                 # Interpolate in the same number of slices
                 metrics_PAM50_space_dict[key][slices_PAM50] = np.interp(x_PAM50, x, metric_values_level)
-    scale_mean = np.mean(scales)
 
     # Loop through the slices in the first and last levels to scale only.
     for i, (slices_PAM50, slices_im) in enumerate(zip(level_slices_PAM50[::len(levels)-1],

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -50,14 +50,11 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     scales = []
     # Loop through slices per-level (excluding first and last levels)
     for slices_PAM50, slices_im in zip(level_slices_PAM50[1:-1], level_slices_im[1:-1]):
-        # Get number of slices for the currently processed level
-        nb_slices_PAM50 = len(slices_PAM50)
-        nb_slices_im = len(slices_im)
         # Prepare vectors for the interpolation
-        x_PAM50 = np.arange(0, nb_slices_PAM50, 1)
-        x = np.linspace(0, nb_slices_PAM50 - 1, nb_slices_im)
+        x_PAM50 = np.arange(0, len(slices_PAM50), 1)
+        x = np.linspace(0, len(slices_PAM50) - 1, len(slices_im))
         # Compute and keep the scaling factor for the currently processed level
-        scales.append(nb_slices_PAM50/nb_slices_im)
+        scales.append(len(slices_PAM50)/len(slices_im))
         # Loop through metrics
         for key, value in metrics.items():
             if key != 'length':
@@ -69,12 +66,10 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     # Loop through the slices in the first and last levels to scale only.
     for i, (slices_PAM50, slices_im) in enumerate(zip(level_slices_PAM50[::len(levels)-1],
                                                       level_slices_im[::len(levels)-1])):
-        # Get number of slices for the currently processed level
-        nb_slices_im = len(slices_im)
         # Prepare vectors for the interpolation
         # Note: since the first and the last level can be incomplete, we use the mean scaling factor from all other levels
-        x_PAM50 = np.linspace(0, scale_mean*nb_slices_im, int(scale_mean*nb_slices_im))
-        x = np.linspace(0, scale_mean*nb_slices_im, nb_slices_im)
+        x_PAM50 = np.linspace(0, scale_mean*len(slices_im), int(scale_mean*len(slices_im)))
+        x = np.linspace(0, scale_mean*len(slices_im), len(slices_im))
         # Loop through metrics
         for key, value in metrics.items():
             if key != 'length':

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -28,8 +28,7 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     # Create an metrics instance filled by NaN with number of rows equal to number of slices in PAM50 template
     metrics_PAM50_space_dict = {}
     for key in metrics.keys():
-        metrics_PAM50_space_dict[key] = np.empty(z, dtype=float)
-        metrics_PAM50_space_dict[key].fill(np.nan)
+        metrics_PAM50_space_dict[key] = np.full([z], np.nan)
 
     # Get unique vertebral levels
     levels = np.unique(im_seg_labeled.data)

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -22,12 +22,6 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     im_seg_labeled = Image(fname_vert_levels)
     im_seg_labeled.change_orientation('RPI')
 
-    # Get number of slices in PAM50
-    z = im_seg_labeled_PAM50.dim[2]
-
-    # Create an metrics instance filled by NaN with number of rows equal to number of slices in PAM50 template
-    metrics_PAM50_space_dict = {k: np.full([z], np.nan) for k in metrics.keys()}
-
     # Get unique integer vertebral levels (but exclude 0, 49, and 50, as these aren't vertebral levels)
     levels = sorted(int(level) for level in np.unique(im_seg_labeled.data) if 0 < int(level) < 49)
 
@@ -40,7 +34,10 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
               in zip(level_slices_PAM50[1:-1], level_slices_im[1:-1])]
     scale_mean = np.mean(scales)
 
-    # Loop through slices per-level (excluding first and last levels)
+    # Initialize a metrics dict filled by NaN with number of rows equal to number of slices in PAM50 template
+    z = im_seg_labeled_PAM50.dim[2]  # z == number of slices
+    metrics_PAM50_space_dict = {k: np.full([z], np.nan) for k in metrics.keys()}
+    # Loop through slices per-level (excluding first and last levels), populating the metrics dict
     for level, slices_PAM50, slices_im in zip(levels, level_slices_PAM50, level_slices_im):
         # Prepare vectors for the interpolation
         if level in [levels[0], levels[-1]]:

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -53,23 +53,20 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
                 metric_values_level = value.data[slices_im]
                 # Interpolate in the same number of slices
                 metrics_inter = np.interp(x_PAM50, x, metric_values_level)
-                # Scale interpolation of first and last levels
+                # Scale interpolation of first and last levels (to account for incomplete levels)
+                diff = len(metrics_inter) - len(slices_PAM50)
                 if level == levels[0]:
                     # If the first level, scale from level below
-                    if len(metrics_inter) > len(slices_PAM50):
-                        diff = len(metrics_inter) - len(slices_PAM50)
+                    if diff > 0:
                         metrics_inter = metrics_inter[:-diff]
-                    elif len(metrics_inter) < len(slices_PAM50):
-                        diff = len(slices_PAM50) - len(metrics_inter)
-                        slices_PAM50 = slices_PAM50[:-diff]
+                    elif diff < 0:
+                        slices_PAM50 = slices_PAM50[:-abs(diff)]
                 elif level == levels[-1]:
                     # If the last level, scale from level above
-                    if len(metrics_inter) > len(slices_PAM50):
-                        diff = len(metrics_inter) - len(slices_PAM50)
+                    if diff > 0:
                         metrics_inter = metrics_inter[diff:]
-                    elif len(metrics_inter) < len(slices_PAM50):
-                        diff = len(slices_PAM50) - len(metrics_inter)
-                        slices_PAM50 = slices_PAM50[diff:]
+                    elif diff < 0:
+                        slices_PAM50 = slices_PAM50[abs(diff):]
                 metrics_PAM50_space_dict[key][slices_PAM50] = metrics_inter
 
     # Convert dict of ndarrays to dict of Metric() objects

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -28,16 +28,8 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     # Create an metrics instance filled by NaN with number of rows equal to number of slices in PAM50 template
     metrics_PAM50_space_dict = {k: np.full([z], np.nan) for k in metrics.keys()}
 
-    # Get unique vertebral levels
-    levels = np.unique(im_seg_labeled.data)
-    # Remove zero and convert levels to int
-    levels = list(map(int, (levels[levels > 0])))
-
-    # Remove level 49 and 50 (not vertebral levels)
-    levels = [level for level in levels if level < 49]
-
-    # Sort levels (so min == levels[0] and max == levels[-1])
-    levels = sorted(levels)
+    # Get unique integer vertebral levels (but exclude 0, 49, and 50, as these aren't vertebral levels)
+    levels = sorted(int(level) for level in np.unique(im_seg_labeled.data) if 0 < int(level) < 49)
 
     # Get slices corresponding to each level
     level_slices_PAM50 = [get_slices_from_vertebral_levels(im_seg_labeled_PAM50, level) for level in levels]

--- a/spinalcordtoolbox/metrics_to_PAM50.py
+++ b/spinalcordtoolbox/metrics_to_PAM50.py
@@ -26,9 +26,7 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
     z = im_seg_labeled_PAM50.dim[2]
 
     # Create an metrics instance filled by NaN with number of rows equal to number of slices in PAM50 template
-    metrics_PAM50_space_dict = {}
-    for key in metrics.keys():
-        metrics_PAM50_space_dict[key] = np.full([z], np.nan)
+    metrics_PAM50_space_dict = {k: np.full([z], np.nan) for k in metrics.keys()}
 
     # Get unique vertebral levels
     levels = np.unique(im_seg_labeled.data)
@@ -85,11 +83,5 @@ def interpolate_metrics(metrics, fname_vert_levels_PAM50, fname_vert_levels):
                         slices_PAM50 = slices_PAM50[diff:]
                 metrics_PAM50_space_dict[key][slices_PAM50] = metrics_inter
 
-    # Create a dict of Metric() objects
-    metrics_PAM50_space = {}
-    # Loop through metrics
-    for key, value in metrics_PAM50_space_dict.items():
-        # Convert ndarray to Metric() object
-        metrics_PAM50_space[key] = Metric(data=np.array(value), label=key)
-
-    return metrics_PAM50_space
+    # Convert dict of ndarrays to dict of Metric() objects
+    return {k: Metric(data=np.array(v), label=k) for k, v in metrics_PAM50_space_dict.items()}

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -105,9 +105,9 @@ def test_sct_process_segmentation_check_normalize_PAM50(tmp_path):
     with open(filename, "r") as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         rows = list(reader)
-        row = rows[747]
+        row = rows[827]
         assert row['Slice (I->S)'] == '827'
-        assert row['MEAN(area)'] == pytest.approx('71.96880493869594')
+        assert float(row['MEAN(area)']) == pytest.approx(71.96880493869594)
         assert row['VertLevel'] == '5'
 
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR proposes some additional changes for @sandrinebedard's normalization PR, #3977. I'm using the "PR format" because the changes are a bit complex, and so it's easier for me to demonstrate each change using individual commits, as opposed to explaining them in review comments on #3977.

This PR contains purely refactoring; there are no functional changes here, just code reorganization. (I used the modified test to confirm that there are no changes; at each commit, the test passes.)

The goal of this refactoring is to simplify and shorten the `interpolate_metrics` function, so that it is easier to read and understand, thus paving the way for further reviews of the functionality.

## Reviewing this PR

I'd recommend using the "Commits" view, since each commit contains an extended commit description to explain the reasoning behind each commit. 

Feel free to discuss/ask questions/push back against my suggestions/etc. :smile: 

## Note

Since this is a PR into _another_ PR, I have not tagged this with milestones/labels, since it's a smaller part of a larger PR.
