### PR TITLE
Faithfully display `sct_qc` arguments, rather than making a fake command

### DIFF
--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -81,16 +81,10 @@ def main(argv: Sequence[str]):
     set_loglevel(verbose=verbose)
 
     from spinalcordtoolbox.reports.qc import generate_qc
-    # Build args list (for display)
-    args_disp = '-i ' + arguments.i
-    if arguments.d:
-        args_disp += ' -d ' + arguments.d
-    if arguments.s:
-        args_disp += ' -s ' + arguments.s
     generate_qc(fname_in1=arguments.i,
                 fname_in2=arguments.d,
                 fname_seg=arguments.s,
-                args=args_disp,
+                args=f'("sct_qc {" ".join(argv)}")',
                 path_qc=arguments.qc,
                 dataset=arguments.qc_dataset,
                 subject=arguments.qc_subject,

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -11,7 +11,7 @@ import os
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser
+from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser, list2cmdline
 
 
 def get_parser():
@@ -84,7 +84,7 @@ def main(argv: Sequence[str]):
     generate_qc(fname_in1=arguments.i,
                 fname_in2=arguments.d,
                 fname_seg=arguments.s,
-                args=f'("sct_qc {" ".join(argv)}")',
+                args=f'("sct_qc {list2cmdline(argv)}")',
                 path_qc=arguments.qc,
                 dataset=arguments.qc_dataset,
                 subject=arguments.qc_subject,


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Rather than generating a fake, incorrect set of arguments that mimic the original command, such as:

```
sct_dmri_moco -i dmri_crop.nii.gz -d dmri_crop_moco.nii.gz
              -s dmri_crop_moco_dwi_mean_seg.nii.gz
```

We instead try to faithfully display the arguments that were passed to sct_qc itself:

```
sct_dmri_moco ("sct_qc -i dmri_crop.nii.gz -d dmri_crop_moco.nii.gz
                       -s dmri_crop_moco_dwi_mean_seg.nii.gz
                       -p sct_dmri_moco -qc .")
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3356.
