### PR TITLE
Use `filters.rank` instead of `dilate`/`erode` for `uint8`/`uint16` images

### DIFF
--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 from skimage.morphology import erosion, dilation, disk, ball, square, cube
-from skimage.filters import threshold_local, threshold_otsu
+from skimage.filters import threshold_local, threshold_otsu, rank
 from scipy.ndimage.filters import gaussian_filter, gaussian_laplace
 from scipy.stats import pearsonr, spearmanr
 from dipy.denoise.noise_estimate import estimate_sigma
@@ -110,7 +110,11 @@ def dilate(data, size, shape, dim=None):
         im_out.data = dilate(data.data, size, shape, dim)
         return im_out
     else:
-        return dilation(data, footprint=_get_footprint(shape, size, dim), out=None)
+        footprint = _get_footprint(shape, size, dim)
+        if data.dtype in ['uint8', 'uint16']:
+            return rank.maximum(data, footprint=footprint)
+        else:
+            return dilation(data, footprint=footprint, out=None)
 
 
 def erode(data, size, shape, dim=None):
@@ -130,7 +134,11 @@ def erode(data, size, shape, dim=None):
         im_out.data = erode(data.data, size, shape, dim)
         return im_out
     else:
-        return erosion(data, footprint=_get_footprint(shape, size, dim), out=None)
+        footprint = _get_footprint(shape, size, dim)
+        if data.dtype in ['uint8', 'uint16']:
+            return rank.minimum(data, footprint=footprint)
+        else:
+            return erosion(data, footprint=footprint, out=None)
 
 
 def mutual_information(x, y, nbins=32, normalized=False):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When images are `uint8` or `uint16`, using `filters.rank.{maximum,mininum}` is *much* faster than using `dilation` or `erosion`, especially in our use-case (large 3D images).

Source: [`skimage.morphology.dilation`](https://scikit-image.org/docs/stable/api/skimage.morphology.html#dilation)

> For uint8 (and uint16 up to a certain bit-depth) data, the lower algorithm complexity makes the [skimage.filters.rank.maximum](https://scikit-image.org/docs/stable/api/skimage.filters.rank.html#skimage.filters.rank.maximum) function more efficient for larger images and footprints.

Anecdotally, on my personal laptop, testing on a `sct_example_data/t2` segmentation using `-dilate 32` caused the processing time to reduce from ~260s to ~6s. (And my CPU kind of sucks, so I imagine this would be even faster on better computers.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Related to #4020.
