### PR TITLE
Use Miniconda instead of built-in Python for Windows installations

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -71,13 +71,6 @@ jobs:
       run:
         shell: bash
     steps:
-
-    # NB: For Windows installations, users must install Python beforehand
-    - uses: actions/setup-python@v4
-      if: matrix.os == 'windows-2019'
-      with:
-        python-version: '3.8'
-
     - name: Checkout spinalcordtoolbox
       uses: actions/checkout@v2
 

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -39,12 +39,6 @@ jobs:
       - name: Checkout SCT
         uses: actions/checkout@v2
 
-      # NB: For Windows installations, users must install Python beforehand
-      - uses: actions/setup-python@v4
-        if: matrix.os == 'windows-2019'
-        with:
-          python-version: '3.8'
-
       - name: Install SCT (Unix)
         if: matrix.os != 'windows-2019'
         run: ./install_sct -y

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,11 +384,6 @@ jobs:
         shell: cmd
     steps:
     - uses: actions/checkout@v3
-    # NB: For Windows installations, users must install Python beforehand
-    - uses: actions/setup-python@v4
-      if: matrix.os == 'windows-2019'
-      with:
-        python-version: '3.8'
     - name: Install SCT
       # NB: In real-world usage, it's assumed that the user would download the
       # install_sct.bat file from the Downloads page, and _not_ the full repo.

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -265,7 +265,7 @@ echo "Duration:        $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($
 echo "---"
 # The file `test_batch_processing.py` will output tested values when run as a script
 ./python/envs/venv_sct/bin/python testing/batch_processing/test_batch_processing.py ||
-./venv_sct/Scripts/python.exe testing/batch_processing/test_batch_processing.py
+./python/envs/venv_sct/python.exe testing/batch_processing/test_batch_processing.py
 echo "~~~"
 
 # Display syntax to open QC report on web browser

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -94,7 +94,7 @@ FOR %%D IN (PAM50 optic_models pmj_models deepseg_sc_models deepseg_gm_models de
 rem Copying SCT scripts to an isolated folder (so we can add scripts to the PATH without adding the entire venv_sct)
 echo:
 echo ### Copying SCT's CLI scripts to %CD%\bin\
-xcopy %CD%\venv_sct\Scripts\*sct*.* %CD%\bin\ /v /y /q /i || goto error
+xcopy %CD%\python\envs\venv_sct\Scripts\*sct*.* %CD%\bin\ /v /y /q /i || goto error
 
 rem Give further instructions that the user add the Scripts directory to their PATH
 echo:

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -121,6 +121,6 @@ echo Failed with error #%cached_errorlevel%.
 if "%cached_errorlevel%"=="" set cached_errorlevel=0
 popd
 where deactivate >nul 2>&1
-if %errorlevel% EQU 0 call deactivate
+if %errorlevel% EQU 0 call conda deactivate
 PAUSE
 exit /b %cached_errorlevel%

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -58,11 +58,19 @@ if exist .git\ (
   cd spinalcordtoolbox
 )
 
-rem Create and activate virtual environment to install SCT into
+rem Install portable miniconda instance. (Command source: https://github.com/conda/conda/issues/1977)
 echo:
-echo ### Using Python to create virtual environment...
-python -m venv venv_sct || goto error
-call venv_sct\Scripts\activate.bat || goto error
+echo ### Downloading Miniconda installer...
+curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
+echo:
+echo ### Installing portable copy of Miniconda...
+start /wait "" Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%cd%\python
+
+rem Create and activate miniconda environment to install SCT into
+echo:
+echo ### Using Conda to create virtual environment...
+python\Scripts\conda create -y -p python\envs\venv_sct python=3.8 || goto error
+CALL python\Scripts\activate.bat python\envs\venv_sct || goto error
 echo Virtual environment created and activated successfully!
 
 rem Install SCT and its requirements


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, our Windows install script (`install_sct.bat`) requires users to install Python 3.8 system-wide. `install_sct.bat` will then use the system Python to create a virtual environment that SCT will be installed into.

Relying on the system Python is fragile and error-prone, though. It makes upgrading Python versions difficult from SCT's end, and it requires users to juggle SCT's required Python version with any existing/future Python installations they may use on their computer.

So, this PR adds the same solution that we currently use in our Linux/macOS installations: Miniconda. This lets us automatically download and install an isolated, portable version of Python that we can update from our end whenever we like, solving the above issues and removing a prerequisite from the installation steps.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3942.
