### PR TITLE
Add `im_type` argument in `display_viewer_syntax` to facilitate colormap selection

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -557,14 +557,14 @@ def main(argv: Sequence[str]):
     if fname_ref is not None:
         display_viewer_syntax(
             files=[fname_mask, os.path.join(path_results, lesion_obj.fname_label)],
-            colormaps=['gray', 'red-yellow'],
+            im_types=['anat', 'softseg'],
             opacities=['1.0', '0.7'],
             verbose=verbose
         )
     else:
         display_viewer_syntax(
             files=[os.path.join(path_results, lesion_obj.fname_label)],
-            colormaps=['red-yellow'],
+            im_types=['softseg'],
             opacities=['0.7'],
             verbose=verbose
         )

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -349,7 +349,7 @@ def main(argv: Sequence[str]):
 
     display_viewer_syntax(
         files=[arguments.i] + fname_out_lst,
-        colormaps=['gray'] + ['red-yellow'] * len(fname_out_lst),
+        im_types=['anat'] + ['softseg'] * len(fname_out_lst),
         opacities=['1.0'] + ['0.7'] * len(fname_out_lst),
         verbose=verbose
     )

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -201,7 +201,6 @@ def main(argv: Sequence[str]):
 
     display_viewer_syntax(
         [arguments.omtsat, arguments.ot1map],
-        colormaps=['gray', 'gray'],
         minmax=['-10,10', '0, 3'],
         opacities=['1', '1'],
         verbose=verbose,

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -151,7 +151,7 @@ def main(argv: Sequence[str]):
     # run main program
     create_mask(param)
 
-    display_viewer_syntax([param.fname_data, param.fname_out], colormaps=['gray', 'red'], opacities=['', '0.5'], verbose=verbose)
+    display_viewer_syntax([param.fname_data, param.fname_out], im_types=['anat', 'seg'], opacities=['', '0.5'], verbose=verbose)
 
 
 def create_mask(param):

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -243,7 +243,7 @@ def main(argv: Sequence[str]):
         fname_prior = fname_seg
 
     for output_filename in output_filenames:
-        display_viewer_syntax([arguments.i[0], output_filename], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
+        display_viewer_syntax([arguments.i[0], output_filename], im_types=['anat', 'seg'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -127,7 +127,7 @@ def main(argv: Sequence[str]):
 
     display_viewer_syntax(
         [input_filename, format(out_fname)],
-        colormaps=['gray', 'red'],
+        im_types=['anat', 'seg'],
         opacities=['1', '0.7'],
         verbose=verbose,
     )

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -165,7 +165,7 @@ def main(argv: Sequence[str]):
                                                  extract_fname(fname_image)[2]))
         im_ctr.save(fname_ctr)
 
-    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
+    display_viewer_syntax([fname_image, fname_seg], im_types=['anat', 'seg'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -206,7 +206,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_image, fname_seg=fname_seg, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_deepseg_sc')
-    display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
+    display_viewer_syntax([fname_image, fname_seg], im_types=['anat', 'seg'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -346,7 +346,7 @@ def main(argv: Sequence[str]):
             generate_qc(fname_in, fname_seg=fname_out, args=argv, path_qc=os.path.abspath(path_qc),
                         process='sct_detect_pmj')
 
-        display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'], verbose=verbose)
+        display_viewer_syntax([fname_in, fname_out], im_types=['anat', 'seg'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -200,7 +200,7 @@ def main(argv: Sequence[str]):
         generate_qc(fname_input_data, fname_seg=file_output, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_get_centerline')
 
-    display_viewer_syntax([fname_input_data, file_output], colormaps=['gray', 'red'], opacities=['', '0.7'], verbose=verbose)
+    display_viewer_syntax([fname_input_data, file_output], im_types=['anat', 'seg'], opacities=['', '0.7'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -490,7 +490,8 @@ def main(argv: Sequence[str]):
         generate_qc(fname_in, fname_seg=labeled_seg_file, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
-    display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'labels'], opacities=['1', '0.5'], verbose=verbose)
+    display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],
+                          verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -490,7 +490,7 @@ def main(argv: Sequence[str]):
         generate_qc(fname_in, fname_seg=labeled_seg_file, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
-    display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'subcortical'], opacities=['1', '0.5'], verbose=verbose)
+    display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'labels'], opacities=['1', '0.5'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -692,7 +692,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_in1=fname_input_data, fname_seg=fname_seg, args=argv,
                     path_qc=os.path.abspath(path_qc), dataset=qc_dataset, subject=qc_subject, process='sct_propseg')
-    display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '1'], verbose=verbose)
+    display_viewer_syntax([fname_input_data, fname_seg], im_types=['anat', 'seg'], opacities=['', '1'], verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -278,7 +278,7 @@ def main(argv: Sequence[str]):
              spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
              spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
              spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
-            colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
+            im_types=['anat', 'anat', 'softseg', 'softseg-alt'],
             opacities=['1', '1', '0.5', '0.5'],
             minmax=['', '0,4000', '0.4,1', '0.4,1'],
             verbose=verbose)

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -159,11 +159,8 @@ def _construct_itksnap_syntax(viewer, files, im_types):
     #    or else itksnap will throw this error:
     #        "Error: Option -s must be used together with option -g"
     # NB: `-g` really should be a grayscale image, but if there are no gray images, we fall back to using a seg image.
-    cmd = f"{viewer} -g "
-    if len(gray_images) > 0:
-        cmd += f"{gray_images.pop(0)}"
-    else:
-        cmd += f"{seg_images.pop(0)}"
+    main_image = (gray_images or seg_images).pop(0)
+    cmd = f"{viewer} -g {main_image}"
     # 2. '-o' is used for any remaining grayscale images not used as the main image (`-g`)
     if gray_images:
         cmd += f" -o {' '.join(gray_images)}"

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -42,6 +42,7 @@ SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'it
 IMTYPES_COLORMAP = {'anat': {'fsleyes': 'greyscale', 'fslview': 'Greyscale'},
                     'seg': {'fsleyes': 'red', 'fslview': 'Red'},
                     'softseg': {'fsleyes': 'red-yellow', 'fslview': 'Red-Yellow'},
+                    'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue'},
                     'labels': {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
                     }
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -140,7 +140,7 @@ def _construct_fsleyes_syntax(viewer, files, colormaps, im_types, minmax, opacit
                 cmd += ' -cm ' + dict_fsleyes[colormaps[i]]
         elif im_types:
             if im_types[i]:
-                cmd += ' -l ' + imtypes_colormap[im_types[i]]['fsleyes']
+                cmd += ' -cm ' + imtypes_colormap[im_types[i]]['fsleyes']
         if minmax:
             if minmax[i]:
                 cmd += ' -dr ' + ' '.join(minmax[i].split(','))  # a b

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -1,4 +1,4 @@
-# Convenience/shell related utilites
+# Convenience/shell related utilities
 
 import os
 import sys
@@ -59,7 +59,7 @@ def display_viewer_syntax(files, verbose, colormaps=[], im_types=[], minmax=[], 
     -------
     display_viewer_syntax([file1, file2, file3])
     display_viewer_syntax([file1, file2], colormaps=['gray', 'red'], minmax=['', '0,1'], opacities=['', '0.7'])
-    display_viewer_syntax([file1, file2], im_types=['seg', 'softseg'], minmax=['', '0,1'], opacities=['', '0.7'])
+    display_viewer_syntax([file1, file2], im_types=['anat', 'softseg'], minmax=['', '0,1'], opacities=['', '0.7'])
     """
     available_viewers = [viewer for viewer in SUPPORTED_VIEWERS if check_exe(viewer)]
 
@@ -92,12 +92,6 @@ def display_viewer_syntax(files, verbose, colormaps=[], im_types=[], minmax=[], 
 def _construct_fslview_syntax(viewer, files, colormaps, im_types, minmax, opacities, mode):
     dict_fslview = {'gray': 'Greyscale', 'red-yellow': 'Red-Yellow', 'blue-lightblue': 'Blue-Lightblue', 'red': 'Red',
                     'green': 'Green', 'random': 'Random-Rainbow', 'hsv': 'hsv', 'subcortical': 'MGH-Subcortical'}
-    imtypes_colormap = {
-    'anat':    {'fsleyes': 'greyscale' ,  'fslview': 'Greyscale'},
-    'seg':     {'fsleyes': 'red',         'fslview': 'Red'},
-    'softseg': {'fsleyes': 'red-yellow',  'fslview': 'Red-Yellow'},
-    'labels':  {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
-    }
 
     cmd = viewer
     # add mode (only supported by fslview for the moment)
@@ -125,12 +119,6 @@ def _construct_fslview_syntax(viewer, files, colormaps, im_types, minmax, opacit
 def _construct_fsleyes_syntax(viewer, files, colormaps, im_types, minmax, opacities):
     dict_fsleyes = {'gray': 'greyscale', 'red-yellow': 'red-yellow', 'blue-lightblue': 'blue-lightblue', 'red': 'red',
                     'green': 'green', 'random': 'random', 'hsv': 'hsv', 'subcortical': 'subcortical'}
-    imtypes_colormap = {
-    'anat':    {'fsleyes': 'greyscale' ,  'fslview': 'Greyscale'},
-    'seg':     {'fsleyes': 'red',         'fslview': 'Red'},
-    'softseg': {'fsleyes': 'red-yellow',  'fslview': 'Red-Yellow'},
-    'labels':  {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
-    }
 
     cmd = viewer
     for i in range(len(files)):

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -42,9 +42,9 @@ SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'it
 IMTYPES_COLORMAP = {
     'anat':        {'fsleyes': 'greyscale',      'fslview': 'Greyscale',       'itksnap': 'gray'},
     'seg':         {'fsleyes': 'red',            'fslview': 'Red',             'itksnap': 'seg'},
+    'seg-labeled': {'fsleyes': 'subcortical',    'fslview': 'MGH-Subcortical', 'itksnap': 'seg'},
     'softseg':     {'fsleyes': 'red-yellow',     'fslview': 'Red-Yellow',      'itksnap': 'gray'},
     'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue',  'itksnap': 'gray'},
-    'labels':      {'fsleyes': 'subcortical',    'fslview': 'MGH-Subcortical', 'itksnap': 'seg'},
 }
 
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -40,11 +40,11 @@ def display_open(file, message="Done! To view results"):
 SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'itksnap']
 
 IMTYPES_COLORMAP = {
-    'anat':        {'fsleyes': 'greyscale',      'fslview': 'Greyscale'},
-    'seg':         {'fsleyes': 'red',            'fslview': 'Red'},
-    'softseg':     {'fsleyes': 'red-yellow',     'fslview': 'Red-Yellow'},
-    'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue'},
-    'labels':      {'fsleyes': 'subcortical',    'fslview': 'MGH-Subcortical'},
+    'anat':        {'fsleyes': 'greyscale',      'fslview': 'Greyscale',       'itksnap': 'gray'},
+    'seg':         {'fsleyes': 'red',            'fslview': 'Red',             'itksnap': 'seg'},
+    'softseg':     {'fsleyes': 'red-yellow',     'fslview': 'Red-Yellow',      'itksnap': 'gray'},
+    'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue',  'itksnap': 'gray'},
+    'labels':      {'fsleyes': 'subcortical',    'fslview': 'MGH-Subcortical', 'itksnap': 'seg'},
 }
 
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -39,12 +39,13 @@ def display_open(file, message="Done! To view results"):
 
 SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'itksnap']
 
-IMTYPES_COLORMAP = {'anat': {'fsleyes': 'greyscale', 'fslview': 'Greyscale'},
-                    'seg': {'fsleyes': 'red', 'fslview': 'Red'},
-                    'softseg': {'fsleyes': 'red-yellow', 'fslview': 'Red-Yellow'},
-                    'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue'},
-                    'labels': {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
-                    }
+IMTYPES_COLORMAP = {
+    'anat':        {'fsleyes': 'greyscale',      'fslview': 'Greyscale'},
+    'seg':         {'fsleyes': 'red',            'fslview': 'Red'},
+    'softseg':     {'fsleyes': 'red-yellow',     'fslview': 'Red-Yellow'},
+    'softseg-alt': {'fsleyes': 'blue-lightblue', 'fslview': 'Blue-Lightblue'},
+    'labels':      {'fsleyes': 'subcortical',    'fslview': 'MGH-Subcortical'},
+}
 
 
 def display_viewer_syntax(files, verbose, im_types=[], minmax=[], opacities=[], mode=''):

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -38,7 +38,11 @@ def display_open(file, message="Done! To view results"):
 
 
 SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'itksnap']
-
+# - The 'fsleyes' colormaps are used for 'fsleyes'.
+# - The 'fslview' colormaps are used for 'fslview' and 'fslview_deprecated'.
+# - For 'itksnap', there are no colormaps. Instead, color behavior is dictated using CLI options '-g', '-o', and '-s'.
+#   How imtypes are mapped to CLI options is a bit convoluted, but tl;dr: only 2 image types (gray, seg) are supported.
+#   Surprisingly, softseg images can only be properly displayed as grayscale images, hence the use of 'gray' for them.
 IMTYPES_COLORMAP = {
     'anat':        {'fsleyes': 'greyscale',      'fslview': 'Greyscale',       'itksnap': 'gray'},
     'seg':         {'fsleyes': 'red',            'fslview': 'Red',             'itksnap': 'seg'},

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -39,6 +39,12 @@ def display_open(file, message="Done! To view results"):
 
 SUPPORTED_VIEWERS = ['fsleyes', 'fslview_deprecated', 'fslview', 'itk-snap', 'itksnap']
 
+IMTYPES_COLORMAP = {'anat': {'fsleyes': 'greyscale', 'fslview': 'Greyscale'},
+                    'seg': {'fsleyes': 'red', 'fslview': 'Red'},
+                    'softseg': {'fsleyes': 'red-yellow', 'fslview': 'Red-Yellow'},
+                    'labels': {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
+                    }
+
 
 def display_viewer_syntax(files, verbose, colormaps=[], im_types=[], minmax=[], opacities=[], mode=''):
     """
@@ -104,7 +110,7 @@ def _construct_fslview_syntax(viewer, files, colormaps, im_types, minmax, opacit
                 cmd += ' -l ' + dict_fslview[colormaps[i]]
         elif im_types:
             if im_types[i]:
-                cmd += ' -l ' + imtypes_colormap[im_types[i]]['fslview']
+                cmd += ' -l ' + IMTYPES_COLORMAP[im_types[i]]['fslview']
         if minmax:
             if minmax[i]:
                 cmd += ' -b ' + minmax[i]  # a,b
@@ -128,7 +134,7 @@ def _construct_fsleyes_syntax(viewer, files, colormaps, im_types, minmax, opacit
                 cmd += ' -cm ' + dict_fsleyes[colormaps[i]]
         elif im_types:
             if im_types[i]:
-                cmd += ' -cm ' + imtypes_colormap[im_types[i]]['fsleyes']
+                cmd += ' -cm ' + IMTYPES_COLORMAP[im_types[i]]['fsleyes']
         if minmax:
             if minmax[i]:
                 cmd += ' -dr ' + ' '.join(minmax[i].split(','))  # a b

--- a/testing/api/test_utils.py
+++ b/testing/api/test_utils.py
@@ -63,7 +63,7 @@ def test_display_viewer_syntax(temporary_viewers):
     """Test that sample input produces the required syntax string output."""
     syntax_strings = utils.display_viewer_syntax(
         files=["test_img.nii.gz", "test_img_2.nii.gz", "test_seg.nii.gz", "test_img_3.nii.gz"],
-        colormaps=['gray', 'gray', 'red', 'gray'],
+        im_types=['anat', 'anat', 'seg', 'anat'],
         minmax=['', '0,1', '0.25,0.75', ''],
         opacities=['', '0.7', '1.0', ''],
         mode="test",

--- a/testing/api/test_utils.py
+++ b/testing/api/test_utils.py
@@ -86,5 +86,5 @@ def test_display_viewer_syntax(temporary_viewers):
                                 "test_img_3.nii.gz -l Greyscale &")
         elif viewer.startswith("itk"):
             assert cmd_opts == ("-g test_img.nii.gz "
-                                "-s test_seg.nii.gz "
-                                "-o test_img_2.nii.gz test_img_3.nii.gz")
+                                "-o test_img_2.nii.gz test_img_3.nii.gz "
+                                "-s test_seg.nii.gz")


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR enables to select image types (`im_type`) in the function `display_viewer_syntax` to simplify the colormap selection process. Indeed, it is now possible to use specifically predefined mapping between image types and colormap names instead of colormaps directly.

This mapping was proposed in this issue https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4030,
```python
imtypes_colormap = {
    'anat':    {'fsleyes': 'greyscale' ,  'fslview': 'Greyscale'},
    'seg':     {'fsleyes': 'red',         'fslview': 'Red'},
    'softseg': {'fsleyes': 'red-yellow',  'fslview': 'Red-Yellow'},
    'labels':  {'fsleyes': 'subcortical', 'fslview': 'MGH-Subcortical'},
}
```

Concerning the colormap selection process, it is still possible to select a specific colormap. However, if both arguments are specified (`im_type` and `colormaps`), the script will prioritize the colormap choice.

Use examples
```python
display_viewer_syntax([file1, file2], colormaps=['gray', 'red'], minmax=['', '0,1'], opacities=['', '0.7'])
display_viewer_syntax([file1, file2], im_types=['anat', 'softseg'], minmax=['', '0,1'], opacities=['', '0.7'])
```

## Linked issues
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4030

----

Question:

- Should we store the mapping between image types and colormaps in an other place to avoid repeating the variable in `_construct_fslview_syntax` and `_construct_fsleyes_syntax` ?