### PR TITLE
Add support for model ensembles to `sct_deepseg`, update `mp2rage_lesion` model

### DIFF
--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -1,0 +1,72 @@
+import logging
+from pathlib import Path
+
+from ivadomed import inference as imed_inference
+import nibabel as nib
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def segment_and_average_volumes(model_paths, input_filenames, options):
+    """
+        Run `ivadomed.inference.segment_volume()` once per model, then average the outputs.
+
+        :param model_paths: A list of folder paths. The folders must contain:
+            (1) the model ('folder_model/folder_model.pt') to use
+            (2) its configuration file ('folder_model/folder_model.json') used for the training,
+            see https://github.com/neuropoly/ivadomed/wiki/configuration-file
+        :param input_filenames: list of image filenames (e.g. .nii.gz) to segment. Multichannel models require multiple
+            images to segment, i.e.., len(fname_images) > 1.
+        :param options: A dictionary containing optional configuration settings, as specified by the
+            ivadomed.inference.segment_volume function.
+
+        :return: list, list: List of nibabel objects containing the soft segmentation(s), one per prediction class, \
+            List of target suffix associated with each prediction
+    """
+    if not isinstance(model_paths, list):
+        raise TypeError("'model_paths' must be a list of model path strings.")
+    if not len(model_paths) > 0:
+        raise ValueError("'model_paths' must contain one or more model path strings.")
+
+    # Fetch the name of the model (to be used in logging)
+    name_model = Path(model_paths[0]).parts[-1]
+    logger.info(f"\nRunning inference for model '{name_model}'...")
+
+    # Perform inference once per model
+    nii_lsts, target_lsts = [], []
+    for path_model in model_paths:
+        if len(model_paths) > 1:  # We have an ensemble, so output messages to distinguish between seeds
+            name_seed = Path(path_model).parts[-2]
+            logger.info(f"\nUsing '{name_seed}'...")
+        nii_lst, target_lst = imed_inference.segment_volume(path_model, input_filenames, options=options)
+        nii_lsts.append(nii_lst)
+        target_lsts.append(target_lst)
+
+    # If we have a single model, skip averaging
+    if len(model_paths) == 1:
+        nii_lst = nii_lsts[0]
+    # Otherwise, we have a model ensemble, so average the image data
+    else:
+        logger.info(f"\nAveraging outputs across the ensemble for '{name_model}'...")
+        nii_lst = []
+        # NB: `nii_lsts` is a list of lists, with each sublist being the *per-model* predictions. Example:
+        #         [
+        #             [m1_prediction_1.nii.gz, m1_prediction_2.nii.gz, ...],  # model 1 predictions
+        #             [m2_prediction_1.nii.gz, m2_prediction_2.nii.gz, ...]   # model 2 predictions
+        #         ]
+        # So, we want to take: the average of "prediction_1", the average of "prediction_2", etc.
+        # To do this, we unpack + zip `nii_lists`, so that "prediction_N" files are grouped as "predictions".
+        for predictions in zip(*nii_lsts):
+            # Average the data for each output in the ensemble
+            data_stack = np.stack([pred.get_fdata() for pred in predictions], axis=0)
+            data_mean = np.mean(data_stack, axis=0)
+            # Take the first image's header to reuse for the averaged image
+            nii_header = predictions[0].header
+            # Create a new Nifti1Image containing the averaged output
+            nii_lst.append(nib.Nifti1Image(data_mean, header=nii_header, affine=nii_header.get_best_affine()))
+
+    # The 'targets' should be identical for each model, so just take the first
+    target_lst = target_lsts[0]
+
+    return nii_lst, target_lst

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -184,7 +184,7 @@ TASKS = {
                              'cord and MS lesions. The dataset was preprocessed to crop around the spinal cord prior '
                              'to training. This dataset was provided by the University of Basel.',
          'url': 'https://github.com/ivadomed/model_seg_ms_mp2rage',
-         'models': ['model_seg_lesion_mp2rage']},
+         'models': ['model_seg_ms_lesion_mp2rage']},
     'seg_tumor-edema-cavity_t1-t2':
         {'description': 'Multiclass cord tumor/edema/cavity segmentation',
          'long_description': 'This segmentation model for T1w and T2w spinal tumor, edema, and cavity segmentation '

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -286,17 +286,22 @@ def install_default_models():
             install_model(name_model)
 
 
-def is_valid(path_model):
+def is_valid(path_models):
     """
-    Check if model has the necessary files and follow naming conventions:
+    Check if model paths have the necessary files and follow naming conventions:
     - Folder should have the same name as the enclosed files.
 
-    :param path_model: str: Absolute path to folder that encloses the model files.
+    :param path_models: str or list: Absolute path(s) to folder(s) that enclose the model files.
     """
-    name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
-    return (os.path.exists(os.path.join(path_model, name_model + '.pt')) or
-            os.path.exists(os.path.join(path_model, name_model + '.onnx'))) and os.path.exists(
-        os.path.join(path_model, name_model + '.json'))
+    def _is_valid(path_model):
+        name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
+        return (os.path.exists(os.path.join(path_model, name_model + '.pt')) or
+                os.path.exists(os.path.join(path_model, name_model + '.onnx'))) and os.path.exists(
+            os.path.join(path_model, name_model + '.json'))
+    # Adapt the function so that it can be used on single paths (str) or lists of paths
+    if not isinstance(path_models, list):
+        path_models = [path_models]
+    return all(_is_valid(path) for path in path_models)
 
 
 def list_tasks():

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 # List of models. The convention for model names is: (species)_(university)_(contrast)_region
 # Regions could be: sc, gm, lesion, tumor
+# NB: The 'url' field should either be:
+#     1) A <mirror URL list> containing different mirror URLs for the model
+#     2) A dict of <mirror URL lists>, where each list corresponds to a different seed (for model ensembling)
 MODELS = {
     "t2star_sc": {
         "url": [
@@ -256,7 +259,16 @@ def install_model(name_model):
     :return: None
     """
     logger.info("\nINSTALLING MODEL: {}".format(name_model))
-    download.install_data(MODELS[name_model]['url'], folder(name_model))
+    url_field = MODELS[name_model]['url']
+    # List of mirror URLs corresponding to a single model
+    if isinstance(url_field, list):
+        model_urls = url_field
+        download.install_data(model_urls, folder(name_model))
+    # Dict of lists, with each list corresponding to a different model seed for ensembling
+    elif isinstance(url_field, dict):
+        for seed_name, model_urls in url_field.items():
+            logger.info(f"\nInstalling '{seed_name}'...")
+            download.install_data(model_urls, folder(os.path.join(name_model, seed_name)), keep=True)
 
 
 def install_default_models():

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -101,7 +101,10 @@ MODELS = {
         },
         "description": "Segmentation of multiple sclerosis lesions on cropped MP2RAGE spinal cord data. To crop the "
                        "data you can first segment the spinal cord using the model 'model_seg_ms_sc_mp2rage' and "
-                       "then crop the MP2RAGE image using 'sct_crop_image -i IMAGE -m IMAGE_seg'",
+                       "then crop the MP2RAGE image using 'sct_crop_image -i IMAGE -m IMAGE_seg -dilate 32x0x32'."
+                       "Note: For the MS lesion segmentation model to perform well, it is important to respect "
+                       "the value 32. Also, the syntax assumes the image is sagittal. For another orientation, "
+                       "change the axes in '32x0x32'.",
         "contrasts": ["mp2rage"],
         "default": False,
     },

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -377,3 +377,19 @@ def get_metadata(folder_model):
     with open(fname_metadata, "r") as fhandle:
         metadata = json.load(fhandle)
     return metadata
+
+
+def find_ensemble_subfolders(path_model):
+    """
+    Search for the presence of model subfolders within the main model folder. If they exist,
+    then the model folder is actually an ensemble of models, so return a list of folders.
+
+    :param path_model: Absolute path to folder that encloses the model files.
+    :return: list or str: Either a list of ensemble subfolders, or the original model folder path.
+    """
+    name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
+    # Check to see if model folder contains subfolders with the model name (i.e. ensembling)
+    model_subfolders = [folder[0] for folder in os.walk(path_model)  # NB: `[0]` == folder name for os.walk
+                        if folder[0].endswith(name_model) and folder[0] != path_model]
+    # If it does, then these are the "true" model subfolders. Otherwise, return the original path.
+    return model_subfolders if model_subfolders else path_model

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 # Regions could be: sc, gm, lesion, tumor
 # NB: The 'url' field should either be:
 #     1) A <mirror URL list> containing different mirror URLs for the model
-#     2) A dict of <mirror URL lists>, where each list corresponds to a different seed (for model ensembling)
+#     2) A dict of <mirror URL lists>, where each list corresponds to a different seed (for model ensembling), and
+#        each dictionary key corresponds to the seed's name (seed names are used to create subfolders per-seed)
 MODELS = {
     "t2star_sc": {
         "url": [

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -322,7 +322,7 @@ def display_list_tasks():
     print("-" * 120)
     for name_task, value in tasks.items():
         path_models = [folder(name_model) for name_model in value['models']]
-        path_models = [find_ensemble_subfolders(path) for path in path_models]
+        path_models = [find_model_folder_paths(path) for path in path_models]
         are_models_valid = [is_valid(path_model) for path_model in path_models]
         task_status = stylize(name_task.ljust(30),
                               color[all(are_models_valid)])
@@ -361,7 +361,7 @@ def display_list_tasks_long():
 
         path_models = [folder(name_model)
                        for name_model in value['models']]
-        path_models = [find_ensemble_subfolders(path) for path in path_models]
+        path_models = [find_model_folder_paths(path) for path in path_models]
         if all([is_valid(path_model) for path_model in path_models]):
             installed = stylize("Yes", 'LightGreen')
         else:
@@ -383,17 +383,18 @@ def get_metadata(folder_model):
     return metadata
 
 
-def find_ensemble_subfolders(path_model):
+def find_model_folder_paths(path_model):
     """
     Search for the presence of model subfolders within the main model folder. If they exist,
     then the model folder is actually an ensemble of models, so return a list of folders.
+    If they don't exist, then return the original `path_model` (but as a list, to ensure code compatibility).
 
     :param path_model: Absolute path to folder that encloses the model files.
-    :return: list or str: Either a list of ensemble subfolders, or the original model folder path.
+    :return: list: Either a list of ensemble subfolders, or a list containing the original model folder path.
     """
     name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
     # Check to see if model folder contains subfolders with the model name (i.e. ensembling)
     model_subfolders = [folder[0] for folder in os.walk(path_model)  # NB: `[0]` == folder name for os.walk
                         if folder[0].endswith(name_model) and folder[0] != path_model]
-    # If it does, then these are the "true" model subfolders. Otherwise, return the original path.
-    return model_subfolders if model_subfolders else path_model
+    # If it does, then these are the "true" model subfolders. Otherwise, return the original path as a list.
+    return model_subfolders if model_subfolders else [path_model]

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -90,7 +90,7 @@ MODELS = {
         "contrasts": ["mp2rage"],
         "default": False,
     },
-    "model_seg_ms_lesion_mp2rage": {
+    "model_seg_lesion_mp2rage": {
         "url": {
             "seed7": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed7.zip"],
             "seed8": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed8.zip"],
@@ -183,7 +183,7 @@ TASKS = {
                              'cord and MS lesions. The dataset was preprocessed to crop around the spinal cord prior '
                              'to training. This dataset was provided by the University of Basel.',
          'url': 'https://github.com/ivadomed/model_seg_ms_mp2rage',
-         'models': ['model_seg_ms_lesion_mp2rage']},
+         'models': ['model_seg_lesion_mp2rage']},
     'seg_tumor-edema-cavity_t1-t2':
         {'description': 'Multiclass cord tumor/edema/cavity segmentation',
          'long_description': 'This segmentation model for T1w and T2w spinal tumor, edema, and cavity segmentation '

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -91,9 +91,13 @@ MODELS = {
         "default": False,
     },
     "model_seg_ms_lesion_mp2rage": {
-        "url": [
-            "https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20211223/model_seg_ms_lesion_mp2rage.zip"
-        ],
+        "url": {
+            "seed7": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed7.zip"],
+            "seed8": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed8.zip"],
+            "seed9": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed9.zip"],
+            "seed10": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed10.zip"],
+            "seed11": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed11.zip"],
+        },
         "description": "Segmentation of multiple sclerosis lesions on cropped MP2RAGE spinal cord data. To crop the "
                        "data you can first segment the spinal cord using the model 'model_seg_ms_sc_mp2rage' and "
                        "then crop the MP2RAGE image using 'sct_crop_image -i IMAGE -m IMAGE_seg'",

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -91,13 +91,13 @@ MODELS = {
         "contrasts": ["mp2rage"],
         "default": False,
     },
-    "model_seg_lesion_mp2rage": {
+    "model_seg_ms_lesion_mp2rage": {
         "url": {
-            "seed7": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed7.zip"],
-            "seed8": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed8.zip"],
-            "seed9": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed9.zip"],
-            "seed10": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed10.zip"],
-            "seed11": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210//model_seg_lesion_mp2rage_seed11.zip"],
+            "seed1": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210/model_seg_lesion_mp2rage_r20230210_dil32_seed01.zip"],
+            "seed2": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210/model_seg_lesion_mp2rage_r20230210_dil32_seed02.zip"],
+            "seed3": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210/model_seg_lesion_mp2rage_r20230210_dil32_seed03.zip"],
+            "seed4": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210/model_seg_lesion_mp2rage_r20230210_dil32_seed04.zip"],
+            "seed5": ["https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20230210/model_seg_lesion_mp2rage_r20230210_dil32_seed05.zip"],
         },
         "description": "Segmentation of multiple sclerosis lesions on cropped MP2RAGE spinal cord data. To crop the "
                        "data you can first segment the spinal cord using the model 'model_seg_ms_sc_mp2rage' and "

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -269,7 +269,8 @@ def install_model(name_model):
         model_urls = url_field
         download.install_data(model_urls, folder(name_model))
     # Dict of lists, with each list corresponding to a different model seed for ensembling
-    elif isinstance(url_field, dict):
+    else:
+        assert isinstance(url_field, dict), "Invalid url field in MODELS"
         for seed_name, model_urls in url_field.items():
             logger.info(f"\nInstalling '{seed_name}'...")
             download.install_data(model_urls, folder(os.path.join(name_model, seed_name)), keep=True)

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -320,6 +320,7 @@ def display_list_tasks():
     print("-" * 120)
     for name_task, value in tasks.items():
         path_models = [folder(name_model) for name_model in value['models']]
+        path_models = [find_ensemble_subfolders(path) for path in path_models]
         are_models_valid = [is_valid(path_model) for path_model in path_models]
         task_status = stylize(name_task.ljust(30),
                               color[all(are_models_valid)])
@@ -358,6 +359,7 @@ def display_list_tasks_long():
 
         path_models = [folder(name_model)
                        for name_model in value['models']]
+        path_models = [find_ensemble_subfolders(path) for path in path_models]
         if all([is_valid(path_model) for path_model in path_models]):
             installed = stylize("Yes", 'LightGreen')
         else:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -178,8 +178,8 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
         # To do this, we unpack + zip `nii_lists`, so that "prediction_N" files are grouped as "predictions".
         for predictions in zip(*nii_lsts):
             # Average the data for each output in the ensemble
-            data_stack = np.stack([pred.get_fdata() for pred in predictions], axis=-1)
-            data_mean = np.mean(data_stack, axis=-1)
+            data_stack = np.stack([pred.get_fdata() for pred in predictions], axis=0)
+            data_mean = np.mean(data_stack, axis=0)
             # Take the first image's header to reuse for the averaged image
             nii_header = predictions[0].header
             # Create a new Nifti1Image containing the averaged output

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -14,13 +14,10 @@ import os
 import sys
 import logging
 from typing import Sequence
-from pathlib import Path
 
-from ivadomed import inference as imed_inference
 import nibabel as nib
-import numpy as np
 
-from spinalcordtoolbox.deepseg import models
+from spinalcordtoolbox.deepseg import models, inference
 from spinalcordtoolbox.image import splitext
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -132,70 +129,6 @@ def get_parser():
     return parser
 
 
-def segment_and_average_volumes(model_paths, input_filenames, options):
-    """
-        Run `ivadomed.inference.segment_volume()` once per model, then average the outputs.
-
-        :param model_paths: A list of folder paths. The folders must contain:
-            (1) the model ('folder_model/folder_model.pt') to use
-            (2) its configuration file ('folder_model/folder_model.json') used for the training,
-            see https://github.com/neuropoly/ivadomed/wiki/configuration-file
-        :param input_filenames: list of image filenames (e.g. .nii.gz) to segment. Multichannel models require multiple
-            images to segment, i.e.., len(fname_images) > 1.
-        :param options: A dictionary containing optional configuration settings, as specified by the
-            ivadomed.inference.segment_volume function.
-
-        :return: list, list: List of nibabel objects containing the soft segmentation(s), one per prediction class, \
-            List of target suffix associated with each prediction
-    """
-    if not isinstance(model_paths, list):
-        raise TypeError("'model_paths' must be a list of model path strings.")
-    if not len(model_paths) > 0:
-        raise ValueError("'model_paths' must contain one or more model path strings.")
-
-    # Fetch the name of the model (to be used in logging)
-    name_model = Path(model_paths[0]).parts[-1]
-    logger.info(f"\nRunning inference for model '{name_model}'...")
-
-    # Perform inference once per model
-    nii_lsts, target_lsts = [], []
-    for path_model in model_paths:
-        if len(model_paths) > 1:  # We have an ensemble, so output messages to distinguish between seeds
-            name_seed = Path(path_model).parts[-2]
-            logger.info(f"\nUsing '{name_seed}'...")
-        nii_lst, target_lst = imed_inference.segment_volume(path_model, input_filenames, options=options)
-        nii_lsts.append(nii_lst)
-        target_lsts.append(target_lst)
-
-    # If we have a single model, skip averaging
-    if len(model_paths) == 1:
-        nii_lst = nii_lsts[0]
-    # Otherwise, we have a model ensemble, so average the image data
-    else:
-        logger.info(f"\nAveraging outputs across the ensemble for '{name_model}'...")
-        nii_lst = []
-        # NB: `nii_lsts` is a list of lists, with each sublist being the *per-model* predictions. Example:
-        #         [
-        #             [m1_prediction_1.nii.gz, m1_prediction_2.nii.gz, ...],  # model 1 predictions
-        #             [m2_prediction_1.nii.gz, m2_prediction_2.nii.gz, ...]   # model 2 predictions
-        #         ]
-        # So, we want to take: the average of "prediction_1", the average of "prediction_2", etc.
-        # To do this, we unpack + zip `nii_lists`, so that "prediction_N" files are grouped as "predictions".
-        for predictions in zip(*nii_lsts):
-            # Average the data for each output in the ensemble
-            data_stack = np.stack([pred.get_fdata() for pred in predictions], axis=0)
-            data_mean = np.mean(data_stack, axis=0)
-            # Take the first image's header to reuse for the averaged image
-            nii_header = predictions[0].header
-            # Create a new Nifti1Image containing the averaged output
-            nii_lst.append(nib.Nifti1Image(data_mean, header=nii_header, affine=nii_header.get_best_affine()))
-
-    # The 'targets' should be identical for each model, so just take the first
-    target_lst = target_lsts[0]
-
-    return nii_lst, target_lst
-
-
 def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
@@ -281,7 +214,7 @@ def main(argv: Sequence[str]):
         options = {**vars(arguments), "fname_prior": fname_prior}
         # NB: For single models, the averaging will have no effect.
         #     For model ensembles, this will average the output of the ensemble into a single set of outputs.
-        nii_lst, target_lst = segment_and_average_volumes(path_models, input_filenames, options=options)
+        nii_lst, target_lst = inference.segment_and_average_volumes(path_models, input_filenames, options=options)
 
         # Delete intermediate outputs
         if fname_prior and os.path.isfile(fname_prior) and arguments.r:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -148,6 +148,11 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
         :return: list, list: List of nibabel objects containing the soft segmentation(s), one per prediction class, \
             List of target suffix associated with each prediction
     """
+    if not isinstance(model_paths, list):
+        raise TypeError("'model_paths' must be a list of model path strings.")
+    if not len(model_paths) > 0:
+        raise ValueError("'model_paths' must contain one or more model path strings.")
+
     # Fetch the name of the model (to be used in logging)
     name_model = Path(model_paths[0]).parts[-1]
     logger.info(f"\nRunning inference for model '{name_model}'...")

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -262,7 +262,7 @@ def main(argv: Sequence[str]):
         elif isinstance(path_model, list):
             nii_lst, target_lst = segment_volume_with_ensemble(path_model, input_filenames, options=options)
         else:
-            raise ValueError(f"Invalid type for 'path_model': {type(path_model)}. Must be string or list of strings.")
+            raise TypeError(f"Invalid type for 'path_model': {type(path_model)}. Must be string or list of strings.")
 
         # Delete intermediate outputs
         if fname_prior and os.path.isfile(fname_prior) and arguments.r:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -178,7 +178,8 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
         # To do this, we unpack + zip `nii_lists`, so that "prediction_N" files are grouped as "predictions".
         for predictions in zip(*nii_lsts):
             # Average the data for each output in the ensemble
-            data_mean = np.mean([pred.get_fdata() for pred in predictions])
+            data_stack = np.stack([pred.get_fdata() for pred in predictions], axis=-1)
+            data_mean = np.mean(data_stack, axis=-1)
             # Take the first image's header to reuse for the averaged image
             nii_header = predictions[0].header
             # Create a new Nifti1Image containing the averaged output

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -254,6 +254,7 @@ def main(argv: Sequence[str]):
             if not models.is_valid(path_models):
                 printv("Model {} is not installed. Installing it now...".format(name_model))
                 models.install_model(name_model)
+                path_models = models.find_model_folder_paths(path_model)  # Re-parse to find newly downloaded folders
         # If it is not, check if this is a path to a valid model
         else:
             path_model = os.path.abspath(name_model)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR adds support for model ensembles by making the following changes:

1. Adds support for specifying "groups of model files" within the `'url'` field of [`MODELS`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/aef83eb1482ea9360065ac8d8913aaf18edd4ce8/spinalcordtoolbox/deepseg/models.py#L22):
   - Model ensembles are represented using dictionaries, with the keys being seed names, and the values being URL mirrors.
   - When installing an ensemble, multiple subfolders will be created (as per the [proposed spec](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4036#issue-1579823819)).
   - When running a task, the subfolders are parsed and `path_model` is updated accordingly.
   - This means that there won't always be a singular "model path" -- there may a list of model paths instead.
2. Adds support for "lists of model paths" in:
   - The `is_valid` function (which checks to see if models are installed) 
   - The call to `ivadomed.inference.segment_volume` (for model ensembles, we call `segment_volume` once per model, then average the results)

## Reviewing this PR

I've added detailed extended commit messages where I try to justify why I've made each change that I did. So, I would suggest using the "Commits" view to review this PR.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4036.