### PR TITLE
Add dataset `data_normalize_metric_pam50`

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -159,7 +159,13 @@ DATASET_DICT = {
             "https://github.com/ivadomed/multimodal-registration/releases/download/r20220512/models.zip"
         ],
         "default_location": os.path.join(__sct_dir__, "data", "deepreg_models"),
-    }
+    },
+    "data_normalize_metric_pam50": {
+        "mirrors": [
+            "https://github.com/spinalcordtoolbox/data_normalize_metric_pam50/archive/refs/tags/r20230221.zip"
+        ],
+        "default_location": os.path.join(__sct_dir__, "data", "data_normalize_metric_pam50"),
+    },
 }
 
 


### PR DESCRIPTION
Fixes #4044.

For testing, I successfully downloaded the data with:
```
sct_download_data -d data_normalize_metric_pam50
```

Question for the reviewer(s): is `data_normalize_metric_pam50` the name we want to use for this dataset?