### PR TITLE
Catch errors from outdated `wxpython` versions bundled with FSL, then suggest a solution

### DIFF
--- a/contrib/fsl_integration/sct_plugin.py
+++ b/contrib/fsl_integration/sct_plugin.py
@@ -808,11 +808,35 @@ def run_main():
     panel_vlb = TabPanelVertLB(parent=notebook)
     panel_reg = TabPanelRegisterToTemplate(parent=notebook)
 
-    notebook.AddPage(page=panel_propseg, caption="sct_propseg", select=True)
-    notebook.AddPage(page=panel_sc, caption="sct_deepseg_sc", select=False)
-    notebook.AddPage(page=panel_gm, caption="sct_deepseg_gm", select=False)
-    notebook.AddPage(page=panel_vlb, caption="sct_label_vertebrae", select=False)
-    notebook.AddPage(page=panel_reg, caption="sct_register_to_template", select=False)
+    try:
+        notebook.AddPage(page=panel_propseg, caption="sct_propseg", select=True)
+        notebook.AddPage(page=panel_sc, caption="sct_deepseg_sc", select=False)
+        notebook.AddPage(page=panel_gm, caption="sct_deepseg_gm", select=False)
+        notebook.AddPage(page=panel_vlb, caption="sct_label_vertebrae", select=False)
+        notebook.AddPage(page=panel_reg, caption="sct_register_to_template", select=False)
+    except TypeError as e:
+        # Partially addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988
+        if "unexpected type 'float'" in str(e):
+            sct_view_panel.removeFromFrame()
+            raise EnvironmentError(
+                "The FSL installation contains an out of date package: 'wxpython' (4.1.1). "
+                "\n"
+                "\nPlease update 'wxpython' by running one of the following commands in your terminal (depending on "
+                "your FSL version):"
+                "\n"
+                "\nFSL 6.0.6 or newer:"
+                "\n"
+                "\n    $FSLDIR/bin/conda update -n base wxpython"
+                "\n"
+                "\nFSL 6.0.2 to 6.0.5.2:"
+                "\n"
+                "\n    $FSLDIR/fslpython/bin/conda update -n fslpython -c conda-forge --update-all wxpython"
+                "\n"
+                "\nMore information here: "
+                "https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661"
+            )
+        else:
+            raise e
 
     aui_manager.AddPane(notebook, aui.AuiPaneInfo().Name("notebook_content").CenterPane().PaneBorder(False))
     aui_manager.Update()

--- a/contrib/fsl_integration/sct_plugin.py
+++ b/contrib/fsl_integration/sct_plugin.py
@@ -819,7 +819,7 @@ def run_main():
         if "unexpected type 'float'" in str(e):
             sct_view_panel.removeFromFrame()
             raise EnvironmentError(
-                "The FSL installation contains an out of date package: 'wxpython' (4.1.1). "
+                "The FSL installation contains an out of date package: 'wxpython'. "
                 "\n"
                 "\nPlease update 'wxpython' by running one of the following commands in your terminal (depending on "
                 "your FSL version):"

--- a/documentation/source/user_section/fsleyes.rst
+++ b/documentation/source/user_section/fsleyes.rst
@@ -13,7 +13,7 @@ Previously, SCT provided instructions on how to install FSLeyes into the SCT env
 
 .. warning::
 
-   If you choose to install FSLeyes via a complete FSL installation, you will need to update 'wxpython' (an internal packaged used by FSLeyes). This is because the version of 'wxpython' that comes with FSL is out of date (`more info here <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661>`_).
+   If you choose to install FSLeyes via a complete FSL installation, you will need to update 'wxpython' (an internal package used by FSLeyes). This is because the version of 'wxpython' that comes with FSL is out of date (`more info here <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661>`_).
 
    To update, please run one of the the following commands (`depending on your FSL version <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_):
 

--- a/documentation/source/user_section/fsleyes.rst
+++ b/documentation/source/user_section/fsleyes.rst
@@ -11,6 +11,28 @@ be installed as either part of the ``FSL`` package, or as a standalone app.
 
 Previously, SCT provided instructions on how to install FSLeyes into the SCT environment. However, we now request that you install FSLeyes separately and manage the installation on your own. You can find installation instructions for FSLeyes at `this link <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_.
 
+.. warning::
+
+   If you choose to install FSLeyes via a complete FSL installation, you will need to update 'wxpython' (an internal packaged used by FSLeyes). This is because the version of 'wxpython' that comes with FSL is out of date (`more info here <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661>`_).
+
+   To update, please run one of the the following commands (`depending on your FSL version <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_):
+
+   .. note:: The terminal commands in these instructions may require administrative privileges, depending on where you have installed FSL.
+
+   **FSL 6.0.6 or newer:**
+
+   .. code:: sh
+
+      $FSLDIR/bin/conda update -n base wxpython
+
+   **FSL 6.0.2 to 6.0.5.2:**
+
+   .. code:: sh
+
+      $FSLDIR/fslpython/bin/conda update -n fslpython -c conda-forge --update-all wxpython
+
+   Then, restart FSLeyes.
+
 
 SCT + FSLeyes
 =============


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR more gracefully handles an error thrown by FSLeyes when WxPython is out of date (buggy: `4.1.1`, fixed: `4.2.0`). 

Before:

![image](https://user-images.githubusercontent.com/16181459/220677784-360d2f29-e9f1-4754-8b10-e945e7dc39f7.png)

After:

![image](https://user-images.githubusercontent.com/16181459/220679213-de884390-1ec8-41d3-9808-682a76989f76.png)

This out of date WxPython is installed when using the "FSL installation method" for FSLeyes. So, we provide FSL-specific instructions for updating WxPython within the FSL conda environment. 

(If FSLeyes is installed via a dedicated conda environment, then an up-to-date WxPython will be installed, and thus will be unaffected by this bug.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3988
