### PR TITLE
Allow `install_sct` to be run standalone (without downloading "Source code" archive)

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -22,6 +22,7 @@
 #  -d   Prevent the (re)-installation of the data/ directory
 #  -b   Prevent the (re)-installation of the SCT binaries files
 #  -c   Prevent checks from being run to validate the installation
+#  -g   Specify git ref (branch, tag, commit SHA) to clone when 'install_sct' is run by itself
 #  -v   Full verbose
 #
 #
@@ -57,6 +58,9 @@ NONINTERACTIVE=""
 NO_DATA_INSTALL=""
 NO_SCT_BIN_INSTALL=""
 NO_INSTALL_VALIDATION=""
+# CLI option -g: The git ref to use during the git clone (if `install_sct` is run by itself without source files)
+# (Default value: 'master', however this value is updated on stable release branches.)
+SCT_GIT_REF="master"
 
 # ======================================================================================================================
 # FUNCTIONS
@@ -348,7 +352,7 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":iydbcvh" opt; do
+while getopts ":iydbcgvh" opt; do
   case $opt in
   i)
     SCT_INSTALL_TYPE="in-place"
@@ -368,6 +372,10 @@ while getopts ":iydbcvh" opt; do
   c)
     echo " no checks will be run (installation will not be validated)"
     NO_INSTALL_VALIDATION="yes"
+    ;;
+    g)
+    echo " if script has been run by itself, git clone will use ref ${OPTARG}"
+    SCT_GIT_REF=${OPTARG}
     ;;
   v)
     echo " Full verbose!"

--- a/install_sct
+++ b/install_sct
@@ -352,7 +352,7 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":iydbcgvh" opt; do
+while getopts ":iydbcg:vh" opt; do
   case $opt in
   i)
     SCT_INSTALL_TYPE="in-place"
@@ -373,7 +373,7 @@ while getopts ":iydbcgvh" opt; do
     echo " no checks will be run (installation will not be validated)"
     NO_INSTALL_VALIDATION="yes"
     ;;
-    g)
+  g)
     echo " if script has been run by itself, git clone will use ref ${OPTARG}"
     SCT_GIT_REF=${OPTARG}
     ;;

--- a/install_sct
+++ b/install_sct
@@ -411,11 +411,15 @@ print info "
 fetch_os_type
 check_requirements
 
-# Catch SCT version
+# Check to see if the PWD contains the project source files (using `version.txt` as a proxy for the entire source dir)
 if [[ -e "spinalcordtoolbox/version.txt" ]]; then
   SCT_VERSION="$(cat spinalcordtoolbox/version.txt)"
+# If version.txt isn't present, then the installation script is being run without source files, so clone SCT
 else
-  die "ERROR: version.txt not found."
+  SCT_SOURCE="$TMP_DIR/spinalcordtoolbox"
+  echo "Source files not present. Cloning source files to $SCT_SOURCE."
+  git clone -b "$SCT_GIT_REF" --single-branch --depth 1 https://github.com/spinalcordtoolbox/spinalcordtoolbox.git "$SCT_SOURCE"
+  SCT_VERSION=$(cat "$SCT_SOURCE/spinalcordtoolbox/version.txt")
 fi
 
 # Get installation type (from git or from package) if not already specified

--- a/install_sct
+++ b/install_sct
@@ -412,25 +412,28 @@ fetch_os_type
 check_requirements
 
 # Check to see if the PWD contains the project source files (using `version.txt` as a proxy for the entire source dir)
+# If it exists, then we can reliably access source files (`version.txt`, `requirements-freeze.txt) from the PWD.
 if [[ -e "spinalcordtoolbox/version.txt" ]]; then
   SCT_VERSION="$(cat spinalcordtoolbox/version.txt)"
-# If version.txt isn't present, then the installation script is being run without source files, so clone SCT
+  # Get installation type if not already specified
+  if [[ -z "$SCT_INSTALL_TYPE" ]]; then
+    # The file 'requirements-freeze.txt` only exists for stable releases
+    if [[ -e "requirements-freeze.txt" ]]; then
+      SCT_INSTALL_TYPE="package"
+    # If it doesn't exist, then we can assume that a dev is performing an in-place installation from master
+    else
+      SCT_INSTALL_TYPE="in-place"
+    fi
+  fi
+# If version.txt isn't present, then the installation script is being run by itself (i.e. without source files).
+# So, we need to clone SCT to a TMPDIR to access the source files, and update SCT_SOURCE accordingly.
 else
   SCT_SOURCE="$TMP_DIR/spinalcordtoolbox"
   echo "Source files not present. Cloning source files to $SCT_SOURCE."
   git clone -b "$SCT_GIT_REF" --single-branch --depth 1 https://github.com/spinalcordtoolbox/spinalcordtoolbox.git "$SCT_SOURCE"
   SCT_VERSION=$(cat "$SCT_SOURCE/spinalcordtoolbox/version.txt")
-fi
-
-# Get installation type (from git or from package) if not already specified
-if [[ -z "$SCT_INSTALL_TYPE" ]]; then
-  # The file 'requirements-freeze.txt` only exists on the `release` branch
-  # or in stable release "Source Code" .zips (which point at tags `release`)
-  if [[ -e "requirements-freeze.txt" ]]; then
-    SCT_INSTALL_TYPE="package"   # i.e. release installations
-  else
-    SCT_INSTALL_TYPE="in-place"  # i.e. dev installations
-  fi
+  # Since we're git cloning into a TMPDIR, this can never be an "in-place" installation, so we force "package" instead.
+  SCT_INSTALL_TYPE="package"
 fi
 
 # Define sh files


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, for Linux/macOS installations of SCT, users must navigate to the Release page, then download a "Source code (.zip)" archive. They must then `cd` into the folder and run `install_sct`. 

This is a bit unwieldy, and has also [prevented us from collecting download statistics](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3545) for the past several years. Without download statistics, it's more difficult to demonstrate the use and impact of SCT (for the purposes of e.g. grant proposals).

As a test, the Windows installer (`install_sct.bat`) was designed to be run standalone. This allowed us to upload the install script to the release as an asset, which [_does_ grant us download statistics](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3545#issuecomment-1334195311).

As a followup, then, this PR updates `install_sct` so that the Linux/macOS installers so that they can be run standalone, and thus uploaded to releases to benefit from the same statistics gathering.

## Future work

- [ ] Add steps to our CI to upload `install_sct` as a release asset (changing the default `git_ref` value from `master` to `<release milestone name>`)
  - We could potentially even upload `install_sct` twice as two separate release artifacts, Linux and macOS, to collect better data on who uses which OS. 
    (This would also make the installation process for each OS a bit more unified, since `install_sct.bat` gets renamed to `install_sct-5.8_win.bat`. Similarly, `install_sct` could become `install_sct-5.8_linux.sh` and `install_sct-5.8_macos.sh`.)
    (This could also lead us down a path where we remove all of the OS-specific if/else blocks that pollute `install_sct`, since we would maintain dedicated installers for Linux vs. macOS.)
  - This could be possibly be done as part of this PR, too?
- [ ] Update the documentation to describe the new installation process (and clarify that `git` is now a dependency).
- [ ] Better unify the installation process for Linux/macOS and Windows
   - [ ] Windows: Using a more sensible installation directory by default (`~/sct_<version>` instead of `~/spinalcordtoolbox`)
   - [ ] Windows: Allowing users to choose a custom installation directory.
   - [ ] Windows: Git cloning into a temporary directory first, then copying the files over to the target installation directory.
   - [ ] etc.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3545.