### PR TITLE
Add `-qc-subject` and `-qc-dataset` flags to `sct_image`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -92,6 +92,18 @@ def get_parser():
              "(Note: QC reporting is only available for 'sct_image -stitch')."
     )
     image.add_argument(
+        '-qc-dataset',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the dataset the process was run on. "
+             "(Note: QC reporting is only available for 'sct_image -stitch')."
+    )
+    image.add_argument(
+        '-qc-subject',
+        metavar=Metavar.str,
+        help='If provided, this string will be mentioned in the QC report as the subject the process was run on. '
+             "(Note: QC reporting is only available for 'sct_image -stitch')."
+    )
+    image.add_argument(
         '-remove-vol',
         metavar=Metavar.list,
         help='Remove specific volumes from a 4d volume. Separate with ",". Example: "0,5,10"',
@@ -423,7 +435,8 @@ def main(argv: Sequence[str]):
             im_out_padded.save(fname_qc_out)
             # generate the QC report itself
             generate_qc(fname_in1=fname_qc_out, fname_in2=fname_qc_concat, args=sys.argv[1:],
-                        path_qc=os.path.abspath(arguments.qc), process='sct_image -stitch')
+                        path_qc=os.path.abspath(arguments.qc), dataset=arguments.qc_dataset,
+                        subject=arguments.qc_subject, process='sct_image -stitch')
         else:
             printv("WARNING: '-qc' is only supported for 'sct_image -stitch'. QC report will not be generated.",
                    type='warning')


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR adds `-qc-subject` and `-qc-dataset` flags to `sct_image`.

Note: QC reporting is only available for `sct_image -stitch`

## Linked issues

This PR addresses a comment from https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4051:

> Footnote question; sct_image supports only the -qc flag but not -qc-subject?

