### PR TITLE
Add `-qc-dataset` and `-qc-subject` flags to `sct_detect_pmj.py`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -93,6 +93,14 @@ def get_parser():
         help='The path where the quality control generated content will be saved.',
         default=None)
     optional.add_argument(
+        '-qc-dataset',
+        metavar=Metavar.str,
+        help='If provided, this string will be mentioned in the QC report as the dataset the process was run on.')
+    optional.add_argument(
+        '-qc-subject',
+        metavar=Metavar.str,
+        help='If provided, this string will be mentioned in the QC report as the subject the process was run on.')
+    optional.add_argument(
         "-igt",
         metavar=Metavar.str,
         help="File name of ground-truth PMJ (single voxel).",
@@ -344,7 +352,7 @@ def main(argv: Sequence[str]):
         if path_qc is not None:
             from spinalcordtoolbox.reports.qc import generate_qc
             generate_qc(fname_in, fname_seg=fname_out, args=argv, path_qc=os.path.abspath(path_qc),
-                        process='sct_detect_pmj')
+                        dataset=arguments.qc_dataset, subject=arguments.qc_subject, process='sct_detect_pmj')
 
         display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'], verbose=verbose)
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR adds `-qc-subject` and `-qc-dataset` flags to `sct_detect_pmj`. 

## Linked issues

This PR addresses the comment from https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4052#pullrequestreview-1315834600:

> I did a project-wide search for -qc, and found one other script that is missing -qc-subject and -qc-dataset: [sct_detect_pmj.py](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/33e134edf001670725d5fb36a06b8f37245d9580/spinalcordtoolbox/scripts/sct_detect_pmj.py#L90-L94). So, as a follow-up to this PR, we might want to open a separate PR to add those arguments, too.