### PR TITLE
Attach `install_sct` as an asset during release creation CI workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -190,5 +190,7 @@ jobs:
         tag: ${{ github.event.inputs.milestone_title }}
         token: ${{ secrets.GITHUB_TOKEN }}
         bodyFile: ".github/workflows/release-body.md"
-        artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat,install_sct-${{ github.event.inputs.milestone_title }}_linux.sh,install_sct-${{ github.event.inputs.milestone_title }}_macos.sh"
+        artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat,\
+                    install_sct-${{ github.event.inputs.milestone_title }}_linux.sh,\
+                    install_sct-${{ github.event.inputs.milestone_title }}_macos.sh"
         draft: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -175,6 +175,14 @@ jobs:
         cp install_sct.bat install_sct-${{ github.event.inputs.milestone_title }}_win.bat
         perl -pi -e 's/set git_ref=master/set git_ref=${{ github.event.inputs.milestone_title }}/' install_sct-${{ github.event.inputs.milestone_title }}_win.bat
 
+    - name: Create ${{ github.event.inputs.milestone_title }} Linux/macOS install scripts
+      # NB: `install_sct` works for both Linux and macOS platforms. So, here, we simply duplicate the script for both
+      # platforms (which will allow us to collect some rudimentary statistics + make our installation steps clearer).
+      run: |
+        cp install_sct install_sct-${{ github.event.inputs.milestone_title }}_linux.sh
+        perl -pi -e 's/SCT_GIT_REF="master"/SCT_GIT_REF="${{ github.event.inputs.milestone_title }}"/' install_sct-${{ github.event.inputs.milestone_title }}_linux.sh
+        cp install_sct-${{ github.event.inputs.milestone_title }}_linux.sh install_sct-${{ github.event.inputs.milestone_title }}_macos.sh
+
     - uses: ncipollo/release-action@v1
       name: Create release
       id: create_release
@@ -182,5 +190,5 @@ jobs:
         tag: ${{ github.event.inputs.milestone_title }}
         token: ${{ secrets.GITHUB_TOKEN }}
         bodyFile: ".github/workflows/release-body.md"
-        artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat"
+        artifacts: "install_sct-${{ github.event.inputs.milestone_title }}_win.bat,install_sct-${{ github.event.inputs.milestone_title }}_linux.sh,install_sct-${{ github.event.inputs.milestone_title }}_macos.sh"
         draft: true


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Since `install_sct` can now be run standalone (#4049), the next step is to adopt what we currently do for our Native Windows installer:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/2850ac8aca9d8d199165caac5e84bc1d904c7bd8/.github/workflows/create-release.yml#L173-L185

(i.e. Update the install script to specify the stable release version, then attach the install script as a release asset, so that users don't have to download the "Source code"  archive, and so we can collect download statistics.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3545. 
