### PR TITLE
Prevents centerline soft being used with non fitseg methods

### DIFF
--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -151,7 +151,7 @@ def main(argv: Sequence[str]):
     contrast_type = arguments.c
     if method == 'optic' and not contrast_type:
         # Contrast must be
-        error = "ERROR: -c is a mandatory argument when using 'optic' method."
+        error = "ERROR: -c is a mandatory argument when using '-method optic'."
         printv(error, type='error')
         return
 

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -150,9 +150,8 @@ def main(argv: Sequence[str]):
     # Contrast type
     contrast_type = arguments.c
     if method == 'optic' and not contrast_type:
-        # Contrast must be
-        error = "ERROR: -c is a mandatory argument when using '-method optic'."
-        printv(error, type='error')
+        # Contrast must be specified if method is optic
+        printv("ERROR: -c is a mandatory argument when using '-method optic'.", type='error')
         return
 
     # Soft centerline option can only be used with fitseg method

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -155,6 +155,12 @@ def main(argv: Sequence[str]):
         printv(error, type='error')
         return
 
+    # Soft centerline option can only be used with fitseg method
+    if arguments.centerline_soft == 1 and method != 'fitseg':
+        error = "ERROR: -centerline-soft can only be used with '-method fitseg'."
+        printv(error, type='error')
+        return
+
     # Gap between slices
     interslice_gap = arguments.gap
 

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -157,8 +157,7 @@ def main(argv: Sequence[str]):
 
     # Soft centerline option can only be used with fitseg method
     if arguments.centerline_soft == 1 and method != 'fitseg':
-        error = "ERROR: -centerline-soft can only be used with '-method fitseg'."
-        printv(error, type='error')
+        printv("ERROR: -centerline-soft can only be used with '-method fitseg'.", type='error')
         return
 
     # Gap between slices

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -149,8 +149,9 @@ def main(argv: Sequence[str]):
 
     # Contrast type
     contrast_type = arguments.c
+
+    # Contrast must be specified if method is optic
     if method == 'optic' and not contrast_type:
-        # Contrast must be specified if method is optic
         printv("ERROR: -c is a mandatory argument when using '-method optic'.", type='error')
 
     # Soft centerline option can only be used with fitseg method

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -152,12 +152,10 @@ def main(argv: Sequence[str]):
     if method == 'optic' and not contrast_type:
         # Contrast must be specified if method is optic
         printv("ERROR: -c is a mandatory argument when using '-method optic'.", type='error')
-        return
 
     # Soft centerline option can only be used with fitseg method
     if arguments.centerline_soft == 1 and method != 'fitseg':
         printv("ERROR: -centerline-soft can only be used with '-method fitseg'.", type='error')
-        return
 
     # Gap between slices
     interslice_gap = arguments.gap


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR prevents `-centerline-soft` from being used with non-fitseg methods.

## Linked issues

Fixes: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4062
