### PR TITLE
Replace `-setorient-data` with `-flip` and `-transpose` options

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1059,7 +1059,7 @@ def change_shape(im_src, shape, im_dst=None):
     return im_dst
 
 
-def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_only=False):
+def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     """
 
     :param im_src: source image
@@ -1068,8 +1068,6 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_onl
                    operation, can be unset to generate one)
     :param inverse: if you think backwards, use this to specify that you actually
                     want to transform *from* the specified orientation, not *to* it.
-    :param data_only: If you want to only permute the data, not the header. Only use if you know there is a problem
-                      with the native orientation of the input data.
     :return: an image with changed orientation
 
     .. note::
@@ -1077,7 +1075,6 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_onl
         - if the source image is < 3D, it is reshaped to 3D and the destination is 3D
     """
 
-    # TODO: make sure to cover all cases for setorient-data
     if len(im_src.data.shape) < 3:
         pass  # Will reshape to 3D
     elif len(im_src.data.shape) == 3:
@@ -1136,10 +1133,9 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_onl
         im_src_data.shape)
     im_dst_aff = np.matmul(im_src_aff, aff)
 
-    if not data_only:
-        im_dst.header.set_qform(im_dst_aff)
-        im_dst.header.set_sform(im_dst_aff)
-        im_dst.header.set_data_shape(data.shape)
+    im_dst.header.set_qform(im_dst_aff)
+    im_dst.header.set_sform(im_dst_aff)
+    im_dst.header.set_data_shape(data.shape)
     im_dst.data = data
 
     return im_dst

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -29,6 +29,8 @@ from spinalcordtoolbox.utils.shell import (SCTArgumentParser, Metavar, display_v
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, rmtree
 
+DIM_LIST = ['x', 'y', 'z', 't']
+
 
 def get_parser():
     parser = SCTArgumentParser(
@@ -176,7 +178,7 @@ def get_parser():
              "string in the header. We recommend that you investigate and understand where the mismatch originated "
              "from in the first place before using this option.)\n"
              "Example: For an image with 'RPI' in its header, `-flip x` will flip the LR axis of the data array.",
-        choices=['x', 'y', 'z', 't'],
+        choices=DIM_LIST,
         required=False)
     orientation.add_argument(
         '-transpose',
@@ -248,7 +250,6 @@ def main(argv: Sequence[str]):
 
     # initializations
     output_type = None
-    dim_list = ['x', 'y', 'z', 't']
 
     fname_in = arguments.i
 
@@ -276,8 +277,8 @@ def main(argv: Sequence[str]):
     # Arguments are sorted alphabetically (not according to the usage order)
     if arguments.concat is not None:
         dim = arguments.concat
-        assert dim in dim_list
-        dim = dim_list.index(dim)
+        assert dim in DIM_LIST
+        dim = DIM_LIST.index(dim)
         im_out = [concat_data(im_in_list, dim)]
 
     elif arguments.copy_header is not None:
@@ -357,10 +358,10 @@ def main(argv: Sequence[str]):
         im_out = [change_orientation(im_in, arguments.setorient)]
 
     elif arguments.flip is not None:
-        if dim_list.index(arguments.flip) >= len(im_in.data.shape):
+        if DIM_LIST.index(arguments.flip) >= len(im_in.data.shape):
             parser.error(f"Cannot flip axis '{arguments.flip}' on an image with n_dim = {len(im_in.data.shape)}.")
         im_out = im_in.copy()
-        im_out.data = np.flip(im_out.data, axis=dim_list.index(arguments.flip))
+        im_out.data = np.flip(im_out.data, axis=DIM_LIST.index(arguments.flip))
         im_out = [im_out]
 
     elif arguments.transpose is not None:
@@ -368,7 +369,7 @@ def main(argv: Sequence[str]):
             parser.error(f"Transpose argument '{','.join(arguments.transpose)}' must match number of image dimensions "
                          f"in the input image ({len(im_in.data.shape)}).")
         im_out = im_in.copy()
-        transpose_numerical = [dim_list.index(axis)  # Convert [x, y, z, t] to [0, 1, 2, 3]
+        transpose_numerical = [DIM_LIST.index(axis)  # Convert [x, y, z, t] to [0, 1, 2, 3]
                                for axis in arguments.transpose]
         im_out.data = np.transpose(im_out.data, axes=transpose_numerical)
         im_out = [im_out]
@@ -384,8 +385,8 @@ def main(argv: Sequence[str]):
 
     elif arguments.split is not None:
         dim = arguments.split
-        assert dim in dim_list
-        dim = dim_list.index(dim)
+        assert dim in DIM_LIST
+        dim = DIM_LIST.index(dim)
         im_out = split_data(im_in, dim)
 
     elif arguments.stitch:
@@ -424,14 +425,14 @@ def main(argv: Sequence[str]):
             # use input file name and add _X, _Y _Z. Keep the same extension
             l_fname_out = []
             for i_dim in range(3):
-                l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + dim_list[i_dim].upper()))
+                l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + DIM_LIST[i_dim].upper()))
                 im_out[i_dim].save(l_fname_out[i_dim], verbose=verbose)
             display_viewer_syntax(l_fname_out, verbose=verbose)
         if arguments.split is not None:
             # use input file name and add _"DIM+NUMBER". Keep the same extension
             l_fname_out = []
             for i, im in enumerate(im_out):
-                l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + dim_list[dim].upper() + str(i).zfill(4)))
+                l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + DIM_LIST[dim].upper() + str(i).zfill(4)))
                 im.save(l_fname_out[i])
             display_viewer_syntax(l_fname_out, verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -168,25 +168,6 @@ def get_parser():
             'ILA', 'ILP', 'IRA', 'IRP', 'IAL', 'IAR', 'IPL', 'IPR',
         ],
         required=False)
-    orientation.add_argument(
-        '-setorient-data',
-        help='Set orientation of the input image\'s data (modifies ONLY the data array, and leaves the header alone).\n'
-             'Example usage: If `-getorient` returns "RPI", then:\n'
-             '  - Calling `-setorient-data LPI` will flip the LR axis of the data array.\n'
-             '  - Calling `-setorient-data IPR` will rearrange the first and last axes of the data array.\n'
-             '  - In both cases, calling `-getorient` afterwards will still return "RPI", because the header is '
-             'not modified.\n'
-             'WARNING: Use with care, as improper usage may introduce a mismatch between orientation of the header, '
-             'and the orientation of the data array.\n',
-        choices=[
-            'LAS', 'LAI', 'LPS', 'LPI', 'LSA', 'LSP', 'LIA', 'LIP',
-            'RAS', 'RAI', 'RPS', 'RPI', 'RSA', 'RSP', 'RIA', 'RIP',
-            'ALS', 'ALI', 'ARS', 'ARI', 'ASL', 'ASR', 'AIL', 'AIR',
-            'PLS', 'PLI', 'PRS', 'PRI', 'PSL', 'PSR', 'PIL', 'PIR',
-            'SLA', 'SLP', 'SRA', 'SRP', 'SAL', 'SAR', 'SPL', 'SPR',
-            'ILA', 'ILP', 'IRA', 'IRP', 'IAL', 'IAR', 'IPL', 'IPR',
-        ],
-        required=False)
 
     multi = parser.add_argument_group('MULTI-COMPONENT OPERATIONS ON ITK COMPOSITE WARPING FIELDS')
     multi.add_argument(
@@ -354,9 +335,6 @@ def main(argv: Sequence[str]):
     elif arguments.setorient is not None:
         printv(im_in.absolutepath)
         im_out = [change_orientation(im_in, arguments.setorient)]
-
-    elif arguments.setorient_data is not None:
-        im_out = [change_orientation(im_in, arguments.setorient_data, data_only=True)]
 
     elif arguments.header is not None:
         header = im_in.header

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -182,7 +182,9 @@ def get_parser():
         required=False)
     orientation.add_argument(
         '-transpose',
-        help="Transpose the axes of the image's data array. (This will not change the header orientation string.)\n "
+        metavar="ax1,ax2,ax3",
+        help="Transpose the axes (x,y,z) of the image's data array. (This will not change the header orientation "
+             "string.)\n "
              "(WARNING: This option should only be used to fix the data array when it does not match the orientation "
              "string in the header. We recommend that you investigate and understand where the mismatch originated "
              "from in the first place before using this option.)\n"

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -174,22 +174,22 @@ def get_parser():
     orientation.add_argument(
         '-flip',
         help="Flip an axis of the image's data array. (This will not change the header orientation string.)\n"
-             "(WARNING: This option should only be used to fix the data array when it does not match the orientation "
+             " - WARNING: This option should only be used to fix the data array when it does not match the orientation "
              "string in the header. We recommend that you investigate and understand where the mismatch originated "
-             "from in the first place before using this option.)\n"
-             "Example: For an image with 'RPI' in its header, `-flip x` will flip the LR axis of the data array.",
+             "from in the first place before using this option.\n"
+             " - Example: For an image with 'RPI' in its header, `-flip x` will flip the LR axis of the data array.",
         choices=DIM_LIST,
         required=False)
     orientation.add_argument(
         '-transpose',
         metavar="ax1,ax2,ax3",
         help="Transpose the axes (x,y,z) of the image's data array. (This will not change the header orientation "
-             "string.)\n "
-             "(WARNING: This option should only be used to fix the data array when it does not match the orientation "
+             "string.)\n"
+             " - WARNING: This option should only be used to fix the data array when it does not match the orientation "
              "string in the header. We recommend that you investigate and understand where the mismatch originated "
-             "from in the first place before using this option.)\n"
-             "Example: For a 3D image with 'RPI' in its header, `-transpose z,y,x` will swap the LR and SI axes of "
-             "the data array.'",
+             "from in the first place before using this option.\n"
+             " - Example: For a 3D image with 'RPI' in its header, `-transpose z,y,x` will swap the LR and SI axes of "
+             "the data array.",
         type=list_type(',', str),
         required=False)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`-setorient-data` is essentially a way to perform flips and transposes on an image's data array. However, its usage requires the
user to specify an orientation string *relative to the orientation string already in the header*, which has historically been [confusing
to our users](https://forum.spinalcordmri.org/t/how-to-use-sct-image-to-fix-the-orientation-of-the-header-and-data-array-setorient-data-vs-setorient/848/1).

To make things clearer, we can instead provide flip and transpose functionality directly to our users, so that they explicitly know
what operations they are applying to their data.

> **Note**: I considered writing a test for these new options, however they are dead simple, as they call `numpy` functions directly in one-liners. The corresponding test would just be... calling those same `numpy` functions again, and seeing if things match? And that seems like a pretty useless test to me. But, maybe there's a smarter way to write a useful test. Please, share your thoughts!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4038.
