### PR TITLE
List resampled labels in order

### DIFF
--- a/spinalcordtoolbox/registration/labeling.py
+++ b/spinalcordtoolbox/registration/labeling.py
@@ -117,7 +117,7 @@ def resample_labels(fname_labels, fname_dest, fname_output):
     nxd, nyd, nzd, _, _, _, _, _ = Image(fname_dest).dim
     sampling_factor = [float(nx) / nxd, float(ny) / nyd, float(nz) / nzd]
 
-    og_labels = Image(fname_labels).getNonZeroCoordinates()
+    og_labels = Image(fname_labels).getNonZeroCoordinates(sorting='value')
     new_labels = [Coordinate([int(np.round(int(x) / sampling_factor[0])),
                               int(np.round(int(y) / sampling_factor[1])),
                               int(np.round(int(z) / sampling_factor[2])),


### PR DESCRIPTION
This would be nicer.

Fixes #4087.

## Reproduction / testing

### Steps

1. Use the files `t2.nii.gz` and `t2_seg.nii.gz` from [the registration tutorial](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/template-registration/before-starting.html).
2. Generate labels so that we have more than just 2 labels, with:

   ```sh
   sct_label_vertebrae -i t2.nii.gz -s t2_seg.nii.gz -c t2 -qc qc
   ```
3. Run the registration command, with verbose output, and look for `Label #` in the output:

   ```sh
   sct_register_to_template -i t2.nii.gz -s t2_seg.nii.gz -l t2_seg_labeled_discs.nii.gz -c t2 -qc qc -v 2 |& grep 'Label #'
   ```

### Before this PR

Labels are in a random order:
```
Label #0: 24, 75, 7 --> 11
Label #1: 24, 80, 26 --> 10
Label #2: 25, 86, 47 --> 9
Label #3: 25, 106, 150 --> 3
Label #4: 26, 103, 132 --> 4
Label #5: 26, 107, 165 --> 2
Label #6: 26, 108, 177 --> 1
Label #7: 26, 91, 67 --> 8
Label #8: 26, 94, 82 --> 7
Label #9: 26, 96, 98 --> 6
Label #10: 26, 99, 114 --> 5
```

### After this PR

Labels are sorted by value:
```
Label #0: 26, 108, 177 --> 1
Label #1: 26, 107, 165 --> 2
Label #2: 25, 106, 150 --> 3
Label #3: 26, 103, 132 --> 4
Label #4: 26, 99, 114 --> 5
Label #5: 26, 96, 98 --> 6
Label #6: 26, 94, 82 --> 7
Label #7: 26, 91, 67 --> 8
Label #8: 25, 86, 47 --> 9
Label #9: 24, 80, 26 --> 10
Label #10: 24, 75, 7 --> 11
```