### PR TITLE
Make matplotlib less verbose

### DIFF
--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -141,6 +141,9 @@ def set_loglevel(verbose):
     # Set the logging level globally, but only when scripts are directly invoked (e.g. from the command line)
     if caller_module_name == "__main__":
         logging.root.setLevel(getattr(logging, log_level))
+        # matplotlib is particularly chatty, so keep it at the default level
+        # see: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4086
+        logging.getLogger('matplotlib').setLevel(logging.INFO)
     else:
         # NB: Nothing will be set if we're calling a CLI script in-code, i.e. <sct_cli_script>.main(). This keeps
         # the loglevel changes from leaking: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3341

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -143,7 +143,7 @@ def set_loglevel(verbose):
         logging.root.setLevel(getattr(logging, log_level))
         # matplotlib is particularly chatty, so keep it at the default level
         # see: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4086
-        logging.getLogger('matplotlib').setLevel(logging.INFO)
+        logging.getLogger('matplotlib').setLevel(logging.WARNING)
     else:
         # NB: Nothing will be set if we're calling a CLI script in-code, i.e. <sct_cli_script>.main(). This keeps
         # the loglevel changes from leaking: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3341


### PR DESCRIPTION
Otherwise it can easily fill the terminal scrollback buffer with irrelevant messages about fonts.

(This PR is basically following the recommendations in [matplotlib's `set_loglevel` documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.set_loglevel.html).)

Fixes #4086.