### PR TITLE
Fix Debian 9 CI failures by adding `archive` links to `/etc/apt/sources.list`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,8 +157,8 @@ jobs:
         run: |  
           echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
-          echo "deb http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3
       - name: Install SCT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,12 +152,8 @@ jobs:
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
         run: |  
-          echo "Before:"
           cat /etc/apt/sources.list
           sed -i -e 's/\(deb\|security\)\.debian\.org/archive.debian.org/' /etc/apt/sources.list
-          sed -i -e 's/stretch-updates/stretch-proposed-updates/' /etc/apt/sources.list
-          echo
-          echo "After:"
           cat /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,9 +152,10 @@ jobs:
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
         run: |  
-          cat /etc/apt/sources.list
-          sed -i -e 's/\(deb\|security\)\.debian\.org/archive.debian.org/' /etc/apt/sources.list
-          cat /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3
       - name: Install SCT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:9
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,8 +152,12 @@ jobs:
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
         run: |  
+          echo "Before:"
           cat /etc/apt/sources.list
           sed -i -e 's/\(deb\|security\)\.debian\.org/archive.debian.org/' /etc/apt/sources.list
+          sed -i -e 's/stretch-updates/stretch-proposed-updates/' /etc/apt/sources.list
+          echo
+          echo "After:"
           cat /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         #       just to test, but I'm not 100% confident in my understanding of `sources.list`.
         #       Q: Do I simply append these new links? Or do I need to remove the old source links instead?
         run: |  
-          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,9 +151,6 @@ jobs:
       - name: Dependencies
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
-        # TODO: I'm following https://www.howtoforge.com/using-old-debian-versions-in-your-sources.list
-        #       just to test, but I'm not 100% confident in my understanding of `sources.list`.
-        #       Q: Do I simply append these new links? Or do I need to remove the old source links instead?
         run: |  
           echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
           echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,10 +152,9 @@ jobs:
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
         run: |  
-          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
-          echo "deb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
+          cat /etc/apt/sources.list
+          sed -i -e 's/\(deb\|security\)\.debian\.org/archive.debian.org/' /etc/apt/sources.list
+          cat /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3
       - name: Install SCT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:9
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,16 @@ jobs:
     container: debian:9
     steps:
       - name: Dependencies
-        run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
+        # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
+        # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
+        # TODO: I'm following https://www.howtoforge.com/using-old-debian-versions-in-your-sources.list
+        #       just to test, but I'm not 100% confident in my understanding of `sources.list`.
+        #       Q: Do I simply append these new links? Or do I need to remove the old source links instead?
+        run: |  
+          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian-security/ stretch-updates main non-free contrib" >> /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v3
       - name: Install SCT


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Debian 9 hit EOL in June 2022. Despite this, SCT has still supported Debian 9 because it's been easy to do so: the distribution channels for Debian 9 packages had remained on http://deb.debian.org/ for some time after EOL status, requiring no action on our part. However, over March-April 2023, these channels were migrated to http://archive.debian.org and removed from http://deb.debian.org/.

This removal has caused our CI runs for Debian 9 to fail. To fix this, we must overwrite the existing entries in `/etc/apt/sources.list`, and add new sources that point to the archive location. This PR does exactly that.

Long-term, we should think about our plans to phase EOL distributions out of our test suite (as well as adding newly-released distributions). It would be nice to have a more concrete schedule/plan. (Do we support three versions of Debian (9-11)? Four (9-12)? What about other OSs such as Ubuntu or macOS?) Right now, we handle this ad hoc, when it would be nice to plan ahead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4105.
