### PR TITLE
Update outdated GitHub Actions to versions that use Node.js 16

### DIFF
--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         pip install git+https://github.com/neuropoly/changelog@master
     - name: Checkout '${{ github.event.repository.name }}'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ${{ github.event.repository.name }}
     - name: Update '${{ github.event.inputs.fname_changelog }}' for '${{ github.event.repository.name }}'

--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -30,7 +30,7 @@ jobs:
         changelog spinalcordtoolbox/spinalcordtoolbox --update --name "${{ github.event.inputs.fname_changelog }}" --milestone ${{ github.event.inputs.milestone_title }} --use-milestone-due-date
         rm -f "${{ github.event.inputs.fname_changelog }}.bak"
     - name: Create pull request for updated changelog
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         path: "${{ github.event.repository.name }}"
         branch: "bot/v${{ github.event.inputs.milestone_title }}"

--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python (to install 'changelog')
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
     - name: Install 'changelog'
       run: |
         pip install git+https://github.com/neuropoly/changelog@master

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -6,7 +6,7 @@ jobs:
   run_flake8_and_shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Fetches all references, which is needed to `git diff` with origin/master
     - name: Set up Python

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -10,9 +10,9 @@ jobs:
       with:
         fetch-depth: 0  # Fetches all references, which is needed to `git diff` with origin/master
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.x'
     - name: Install dependencies
       run: pip install flake8
     # Note: flake8 picks up project-wide configuration options from 'setup.cfg' in SCT's root directory

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Checkout spinalcordtoolbox
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install spinalcordtoolbox
       run: |
@@ -75,7 +75,7 @@ jobs:
         shell: bash
     steps:
     - name: Checkout spinalcordtoolbox
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Download requirements-freeze.txt
       uses: actions/download-artifact@v3
@@ -133,7 +133,7 @@ jobs:
         git config --global user.name "GitHub Actions Bot"
 
     - name: Checkout spinalcordtoolbox (main branch)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ env.MAIN_BRANCH }}
         fetch-depth: 0

--- a/.github/workflows/generate-sidebar.yml
+++ b/.github/workflows/generate-sidebar.yml
@@ -13,7 +13,7 @@ jobs:
           # Each repo with at least 1 wiki page has a corresponding <repo>.wiki repo
           repository: "${{ github.repository }}.wiki"  
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - run: npm install github-wiki-sidebar -g
       
       # Dummy credentials to be listed in _Sidebar.md update commit for Wiki 

--- a/.github/workflows/generate-sidebar.yml
+++ b/.github/workflows/generate-sidebar.yml
@@ -8,7 +8,7 @@ jobs:
   generate-sidebar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Each repo with at least 1 wiki page has a corresponding <repo>.wiki repo
           repository: "${{ github.repository }}.wiki"  

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout SCT
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install SCT (Unix)
         if: matrix.os != 'windows-2019'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -292,7 +292,7 @@ jobs:
       run:
         shell: wsl-bash {0} # https://github.com/marketplace/actions/setup-wsl#default-shell
     steps:
-    - uses: Vampire/setup-wsl@v1
+    - uses: Vampire/setup-wsl@v2
       with:
         # other WSL container choices at: https://github.com/marketplace/actions/setup-wsl#distribution
         distribution: Ubuntu-22.04
@@ -340,7 +340,7 @@ jobs:
       run:
         shell: wsl-bash {0} # https://github.com/marketplace/actions/setup-wsl#default-shell
     steps:
-    - uses: Vampire/setup-wsl@v1
+    - uses: Vampire/setup-wsl@v2
       with:
         # other WSL container choices at: https://github.com/marketplace/actions/setup-wsl#distribution
         distribution: Ubuntu-20.04


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Our current GitHub Actions workflows include a number of external actions that are outdated, as they depend on Node.js 12. 

This triggers the following warning:

![image](https://user-images.githubusercontent.com/16181459/234628515-07fe20f1-dad0-4a40-9591-16acdd30ce7c.png)

To address this warning, I have gone through each of our workflows and looked at the warnings to determine which actions are outdated. Then, I looked at the changelogs for each action to determine if it is safe to update to the latest version. In all cases, I think it is, but I'll let the automated PR checks confirm this.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4096.