### PR TITLE
Fix buggy `-create-viewer` behavior on initialization (undo crash, blank checkboxes)

### DIFF
--- a/spinalcordtoolbox/gui/sagittal.py
+++ b/spinalcordtoolbox/gui/sagittal.py
@@ -78,7 +78,9 @@ class SagittalDialog(base.BaseDialog):
         super(SagittalDialog, self).on_undo()
         self.sagittal.refresh()
         self.labels.refresh()
-        self.labels.label = self._controller.label
+        # If a label hasn't been selected yet, the controller won't have the `label` attribute
+        if hasattr(self._controller, 'label'):
+            self.labels.label = self._controller.label
 
     def increment_vertical_nav(self):
         x, y, z = self._controller.position

--- a/spinalcordtoolbox/gui/sagittal.py
+++ b/spinalcordtoolbox/gui/sagittal.py
@@ -54,7 +54,6 @@ class SagittalDialog(base.BaseDialog):
         self.sagittal.title(self.params.subtitle)
         self.sagittal.point_selected_signal.connect(self.on_select_point)
         layout.addWidget(self.sagittal)
-        self.labels.refresh()
         self.sagittal.refresh()
 
     def _init_controls(self, parent):

--- a/spinalcordtoolbox/gui/sagittal.py
+++ b/spinalcordtoolbox/gui/sagittal.py
@@ -47,7 +47,7 @@ class SagittalDialog(base.BaseDialog):
         parent.addLayout(layout)
 
         self.labels = widgets.VertebraeWidget(self, self.params.vertebraes)
-        self.labels.label = self.params.start_vertebrae
+        self.labels.label = self._controller.label = self.params.start_vertebrae
         layout.addWidget(self.labels)
 
         self.sagittal = widgets.SagittalCanvas(self, plot_points=True, annotate=True)
@@ -78,9 +78,7 @@ class SagittalDialog(base.BaseDialog):
         super(SagittalDialog, self).on_undo()
         self.sagittal.refresh()
         self.labels.refresh()
-        # If a label hasn't been selected yet, the controller won't have the `label` attribute
-        if hasattr(self._controller, 'label'):
-            self.labels.label = self._controller.label
+        self.labels.label = self._controller.label
 
     def increment_vertical_nav(self):
         x, y, z = self._controller.position


### PR DESCRIPTION
> **Note**: The changes in this PR are small, but they require a lot of context to understand, hence the long description below.

## Background
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

There are two issues with how `-create-viewer` is initilaized:

1. `self._controller` never gets its `label` attribute set. As a result, when you press the undo button without first selecting a point, the following line crashes, because it tries to access the nonexistent `self._controller.label`:

    https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7c82c359bfb0a24cc852fa4124701bd1b31d659/spinalcordtoolbox/gui/sagittal.py#L81

    This was previously reported in #4104.

2. The second issue is that the label checkboxes all start out unchecked:

   ![image](https://user-images.githubusercontent.com/16181459/234913528-b693b716-91f3-42a1-8e6d-ac0aa1e28201.png)

   However, what it _should_ look like is this:

   ![image](https://user-images.githubusercontent.com/16181459/234923542-dccce43d-c44e-49bb-a4ef-c2ec029ea6e7.png)

    This "partially checked" state indicates that this label is the one being selected currently.

## Proposed solution (undo crash)

To solve the undo crash, I had two ideas:

1. Skip accessing `self._controller.label` if it hasn't been assigned yet. 
2. Keep accessing `self._controller.label`, but make sure to first assign it a value on initialization.

I'm fine with either solution, but I was hoping that the second idea would solve the problem of the "blank iniitial checkboxes" too, because I thought the problems were linked; however, the checkboxes were still blank, even when `self._controller.label` had a value. 

Digging more deeply, I found that the blank checkbox issue was actually entirely separate from `self._controller.label`!

## Proposed solution (blank checkboxes)

When investigating, I found that `SagittalDialog` includes the following steps to initialize the checkbox widget:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7c82c359bfb0a24cc852fa4124701bd1b31d659/spinalcordtoolbox/gui/sagittal.py#L49-L51

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7c82c359bfb0a24cc852fa4124701bd1b31d659/spinalcordtoolbox/gui/sagittal.py#L57

Some notes:

- Here, `self.labels.label` is actually a `setter` method, and it [sets its own state to `QtCore.Qt.PartiallyChecked`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7c82c359bfb0a24cc852fa4124701bd1b31d659/spinalcordtoolbox/gui/widgets.py#L81).
- However, `self.labels.refresh()` [_wipes out the state of all checkboxes_](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e7c82c359bfb0a24cc852fa4124701bd1b31d659/spinalcordtoolbox/gui/widgets.py#L64-L65), then rebuilds.
- So, the fact that `self.labels.refresh()` is called on initialization means that we immediately lose the `PartiallyChecked` state that the checkbox was set to just a few lines earlier!

I think we just plain do not need the call to `self.labels.refresh()` on initialization, because the steps in that method serve no purpose on initialization (when no points have been selected yet).

## Testing this PR

You can test with a simple `sct_label_utils -i t2.nii.gz -create-viewer 1,2,3` call using any image.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4104.