### PR TITLE
Silence unnecessary "overwriting" messages when updating output image header

### DIFF
--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -659,7 +659,7 @@ def propseg(img_input, options_dict):
     for fname in list_fname:
         im = Image(fname)
         im.header = image_input.header
-        im.save(dtype='int8')  # they are all binary masks hence fine to save as int8
+        im.save(dtype='int8', verbose=0)  # they are all binary masks hence fine to save as int8
 
     return Image(fname_seg)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a tiny, tiny PR: We set `verbose=0` when changing the header of an existing image in `sct_propseg`, so that we silence the unnecessary "overwriting" messages.

We already use this approach elsewhere, too, e.g. in `sct_apply_transfo`:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/e26a173400fc03dbbb6523186de8a73754ae5168/spinalcordtoolbox/scripts/sct_apply_transfo.py#L292-L296

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2771.
