### PR TITLE
Ensure CI avoids older ReadTheDocs docker images to address OpenSSL mismatch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: documentation/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+      python: 3.8
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -14,7 +16,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
-      python: 3.8
+      python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This follows the advice from https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4113#issuecomment-1535392170 to address the recently-failing RTD builds.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4113.