### PR TITLE
Test standalone installations via `tests.yml`, but only on the `master` branch

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -13,6 +13,10 @@ export PIP_PROGRESS_BAR=off # disable pip's progress bar for the duration of CI
 export PY_COLORS=1 # Colored pytest output (https://github.com/pytest-dev/pytest/issues/7443#issuecomment-656642591)
 
 install_sct () {
+  # NB: We want to test the "standalone install" when on master, so copy the install script outside the srcdir
+  mkdir -p "$HOME/Downloads"
+  cp install_sct "$HOME/Downloads"
+  cd "$HOME/Downloads"
   # NB: we only force in-place (-i) installs to avoid pytest running from the source
   #     instead of the installed folder, where the extra detection models are.
   #     Further explanation at https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
@@ -22,6 +26,9 @@ install_sct () {
 }
 
 activate_venv_sct(){
+  # NB: If "standalone install" is tested when on master, then `python/` won't exist in the PWD
+  SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+  cd "$HOME/sct_$SCT_VERSION"
   # NB: `python/` won't be available unless `install_sct` is run, hence disabling the check:
   # shellcheck disable=SC1091
   source python/etc/profile.d/conda.sh  # to be able to call conda

--- a/.ci.sh
+++ b/.ci.sh
@@ -14,7 +14,7 @@ export PY_COLORS=1 # Colored pytest output (https://github.com/pytest-dev/pytest
 
 install_sct () {
   # NB: We want to test the "standalone install" when on master, so copy the install script outside the srcdir
-  if [ "$GITHUB_REF_NAME" == "master" ]; then
+  if [ "$GITHUB_REF_NAME" = "master" ]; then
     mkdir -p "$HOME/Downloads"
     cp install_sct "$HOME/Downloads"
     cd "$HOME/Downloads"
@@ -29,7 +29,7 @@ install_sct () {
 
 activate_venv_sct(){
   # NB: If "standalone install" is tested when on master, then `python/` won't exist in the PWD
-  if [ "$GITHUB_REF_NAME" == "master" ]; then
+  if [ "$GITHUB_REF_NAME" = "master" ]; then
     SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
     cd "$HOME/sct_$SCT_VERSION"
   fi

--- a/.ci.sh
+++ b/.ci.sh
@@ -14,9 +14,11 @@ export PY_COLORS=1 # Colored pytest output (https://github.com/pytest-dev/pytest
 
 install_sct () {
   # NB: We want to test the "standalone install" when on master, so copy the install script outside the srcdir
-  mkdir -p "$HOME/Downloads"
-  cp install_sct "$HOME/Downloads"
-  cd "$HOME/Downloads"
+  if [ "$GITHUB_REF_NAME" == "master" ]; then
+    mkdir -p "$HOME/Downloads"
+    cp install_sct "$HOME/Downloads"
+    cd "$HOME/Downloads"
+  fi
   # NB: we only force in-place (-i) installs to avoid pytest running from the source
   #     instead of the installed folder, where the extra detection models are.
   #     Further explanation at https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
@@ -27,8 +29,10 @@ install_sct () {
 
 activate_venv_sct(){
   # NB: If "standalone install" is tested when on master, then `python/` won't exist in the PWD
-  SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
-  cd "$HOME/sct_$SCT_VERSION"
+  if [ "$GITHUB_REF_NAME" == "master" ]; then
+    SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+    cd "$HOME/sct_$SCT_VERSION"
+  fi
   # NB: `python/` won't be available unless `install_sct` is run, hence disabling the check:
   # shellcheck disable=SC1091
   source python/etc/profile.d/conda.sh  # to be able to call conda

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,18 +88,12 @@ jobs:
 
     - name: Install SCT from release branch (Unix)
       if: matrix.os != 'windows-2019'
-      run: |
-        cp install_sct $HOME
-        cd $HOME
-        ./install_sct -yc
+      run: ./install_sct -yc
 
     - name: Install SCT from release branch (Windows)
       if: matrix.os == 'windows-2019'
       shell: cmd
-      run: |
-        cp install_sct.bat %USERPROFILE%
-        cd %USERPROFILE%
-        install_sct.bat
+      run: install_sct.bat
 
     - name: Update environment variables
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Update version.txt (using test value for CI)
       run: |
-        echo "SCT_VERSION=$(cat spinalcordtoolbox/version.txt)" >> $GITHUB_ENV
+        echo "0.0" > spinalcordtoolbox/version.txt
 
     - name: Install SCT from release branch (Unix)
       if: matrix.os != 'windows-2019'
@@ -100,9 +100,9 @@ jobs:
       # In a user install, the user would perform this step using the Windows PATH-changing GUI.
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          # NB: Because `requirements-freeze.txt` is present, SCT gets installed to `~/sct_$SCT_VERSION`, 
+          # NB: Because `requirements-freeze.txt` is present, SCT gets installed to `~/sct_0.0`, 
           # rather than an in-place install. So, we specify this path directly, rather than using $GITHUB_WORKSPACE.
-          echo "${USERPROFILE}\sct_${SCT_VERSION}\bin" >> $GITHUB_PATH
+          echo "${USERPROFILE}\sct_0.0\bin" >> $GITHUB_PATH
         else
           # NB: install_sct edits ~/.bashrc, but those environment changes don't get passed to subsequent steps in GH Actions.
           # So, we filter through the .bashrc and pass the values to $GITHUB_ENV and $GITHUB_PATH.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Update version.txt (using test value for CI)
       run: |
-        echo "0.0" > spinalcordtoolbox/version.txt
+        echo "SCT_VERSION=$(cat spinalcordtoolbox/version.txt)" >> $GITHUB_ENV
 
     - name: Install SCT from release branch (Unix)
       if: matrix.os != 'windows-2019'
@@ -100,9 +100,9 @@ jobs:
       # In a user install, the user would perform this step using the Windows PATH-changing GUI.
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          # NB: Because `requirements-freeze.txt` is present, SCT gets installed to `~/sct_0.0`, 
+          # NB: Because `requirements-freeze.txt` is present, SCT gets installed to `~/sct_$SCT_VERSION`, 
           # rather than an in-place install. So, we specify this path directly, rather than using $GITHUB_WORKSPACE.
-          echo "${USERPROFILE}\sct_0.0\bin" >> $GITHUB_PATH
+          echo "${USERPROFILE}\sct_${SCT_VERSION}\bin" >> $GITHUB_PATH
         else
           # NB: install_sct edits ~/.bashrc, but those environment changes don't get passed to subsequent steps in GH Actions.
           # So, we filter through the .bashrc and pass the values to $GITHUB_ENV and $GITHUB_PATH.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,12 +88,18 @@ jobs:
 
     - name: Install SCT from release branch (Unix)
       if: matrix.os != 'windows-2019'
-      run: ./install_sct -yc
+      run: |
+        cp install_sct $HOME
+        cd $HOME
+        ./install_sct -yc
 
     - name: Install SCT from release branch (Windows)
       if: matrix.os == 'windows-2019'
       shell: cmd
-      run: install_sct.bat
+      run: |
+        cp install_sct.bat %USERPROFILE%
+        cd %USERPROFILE%
+        install_sct.bat
 
     - name: Update environment variables
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -409,7 +409,7 @@ jobs:
       # In a user install, the user would perform this step using the Windows PATH-changing GUI.
       shell: bash
       run: |
-        if [ "$GITHUB_REF_NAME" == "master" ]; then
+        if [ "$GITHUB_REF_NAME" = "master" ]; then
           export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
           echo "$USERPROFILE\sct_$SCT_VERSION\bin" >> $GITHUB_PATH
         else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,11 +398,11 @@ jobs:
       # that the PR is coming from a fork. And, in that case, we won't be able to clone
       # the proper branch, as it exists only on the fork.
       run: |
-        # if %GITHUB_REF_NAME%=="master" (
-        if not exist %USERPROFILE%\Downloads mkdir %USERPROFILE%\Downloads
-        cp install_sct.bat %USERPROFILE%\Downloads
-        cd /d %USERPROFILE%\Downloads
-        # )
+        if %GITHUB_REF_NAME%=="master" (
+          if not exist %USERPROFILE%\Downloads mkdir %USERPROFILE%\Downloads
+          cp install_sct.bat %USERPROFILE%\Downloads
+          cd /d %USERPROFILE%\Downloads
+        )
         install_sct.bat
     - name: Add SCT to path
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,11 +398,11 @@ jobs:
       # that the PR is coming from a fork. And, in that case, we won't be able to clone
       # the proper branch, as it exists only on the fork.
       run: |
-        if %GITHUB_REF_NAME%=="master" (
-          if not exist %HOME%\Downloads mkdir %HOME%\Downloads
-          cp install_sct.bat %HOME%\Downloads
-          cd %HOME%\Downloads
-        )
+        # if %GITHUB_REF_NAME%=="master" (
+        if not exist %USERPROFILE%\Downloads mkdir %USERPROFILE%\Downloads
+        cp install_sct.bat %USERPROFILE%\Downloads
+        cd /d %USERPROFILE%\Downloads
+        # )
         install_sct.bat
     - name: Add SCT to path
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -393,15 +393,22 @@ jobs:
     - name: Install SCT
       # NB: In real-world usage, it's assumed that the user would download the
       # install_sct.bat file from the Downloads page, and _not_ the full repo.
-      # Then, the repo would be cloned to the working directory.
-      # However, this installation method doesn't allow us to test changes
-      # from forks. So, we use an in-place install instead.
-      run: install_sct.bat
+      # Then, the repo would be cloned to a tmpdir, then copied to the destination folder.
+      # However, this only really works on `master`, since for PRs, there is a chance
+      # that the PR is coming from a fork. And, in that case, we won't be able to clone
+      # the proper branch, as it exists only on the fork.
+      run: |
+        if not exist %HOME%\Downloads mkdir %HOME%\Downloads
+        cp install_sct.bat %HOME%\Downloads
+        cd %HOME%\Downloads
+        install_sct.bat
     - name: Add SCT to path
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change
       # In a user install, the user would perform this step using the Windows PATH-changing GUI.
       shell: bash
-      run: echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      run: |
+        export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+        echo "$USERPROFILE/sct_$SCT_VERSION/bin" >> $GITHUB_PATH
     - name: Check dependencies
       run: sct_check_dependencies
     - name: Run pytest test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,17 +398,23 @@ jobs:
       # that the PR is coming from a fork. And, in that case, we won't be able to clone
       # the proper branch, as it exists only on the fork.
       run: |
-        if not exist %HOME%\Downloads mkdir %HOME%\Downloads
-        cp install_sct.bat %HOME%\Downloads
-        cd %HOME%\Downloads
+        if %GITHUB_REF_NAME%=="master" (
+          if not exist %HOME%\Downloads mkdir %HOME%\Downloads
+          cp install_sct.bat %HOME%\Downloads
+          cd %HOME%\Downloads
+        )
         install_sct.bat
     - name: Add SCT to path
       # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change
       # In a user install, the user would perform this step using the Windows PATH-changing GUI.
       shell: bash
       run: |
-        export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
-        echo "$USERPROFILE/sct_$SCT_VERSION/bin" >> $GITHUB_PATH
+        if [ "$GITHUB_REF_NAME" == "master" ]; then
+          export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+          echo "$USERPROFILE/sct_$SCT_VERSION/bin" >> $GITHUB_PATH
+        else
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+        fi
     - name: Check dependencies
       run: sct_check_dependencies
     - name: Run pytest test suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,9 +411,9 @@ jobs:
       run: |
         if [ "$GITHUB_REF_NAME" == "master" ]; then
           export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
-          echo "$USERPROFILE/sct_$SCT_VERSION/bin" >> $GITHUB_PATH
+          echo "$USERPROFILE\sct_$SCT_VERSION\bin" >> $GITHUB_PATH
         else
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE\bin" >> $GITHUB_PATH
         fi
     - name: Check dependencies
       run: sct_check_dependencies

--- a/install_sct
+++ b/install_sct
@@ -22,7 +22,6 @@
 #  -d   Prevent the (re)-installation of the data/ directory
 #  -b   Prevent the (re)-installation of the SCT binaries files
 #  -c   Prevent checks from being run to validate the installation
-#  -g   Specify git ref (branch, tag, commit SHA) to clone when 'install_sct' is run by itself
 #  -v   Full verbose
 #
 #
@@ -57,8 +56,7 @@ NONINTERACTIVE=""
 NO_DATA_INSTALL=""
 NO_SCT_BIN_INSTALL=""
 NO_INSTALL_VALIDATION=""
-# CLI option -g: The git ref to use during the git clone (if `install_sct` is run by itself without source files)
-# (Default value: 'master', however this value is updated on stable release branches.)
+# Default value: 'master', however this value is updated on stable release branches.
 SCT_GIT_REF="master"
 
 # ======================================================================================================================
@@ -351,7 +349,7 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":iydbcg:vh" opt; do
+while getopts ":iydbcvh" opt; do
   case $opt in
   i)
     SCT_INSTALL_TYPE="in-place"
@@ -371,10 +369,6 @@ while getopts ":iydbcg:vh" opt; do
   c)
     echo " no checks will be run (installation will not be validated)"
     NO_INSTALL_VALIDATION="yes"
-    ;;
-  g)
-    echo " if script has been run by itself, git clone will use ref ${OPTARG}"
-    SCT_GIT_REF=${OPTARG}
     ;;
   v)
     echo " Full verbose!"

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -28,12 +28,8 @@ git --version >nul 2>&1 || (
     goto error
 )
 
-rem Set git ref. If no git ref is specified when calling `install_sct.bat`, use a default instead.
-if [%1]==[] (
-  set git_ref=master
-) else (
-  set git_ref=%1
-)
+rem Default value: 'master', however this value is updated on stable release branches.
+set git_ref=master
 
 rem Check to see if the PWD contains the project source files (using `version.txt` as a proxy for the entire source dir)
 rem If it exists, then we can reliably access source files (`version.txt`, `requirements-freeze.txt`) from the PWD.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #4049, we added the ability to run `install_sct` standalone, without needing to download the entire SCT source code beforehand.

As a follow up, to test this new standalone installation method, this PR:

- Adds some additional logic to run `install_sct` outside the source directory, which triggers the "standalone installation" procedures (namely: git clone to a tmpdir, copy files to `~/sct_<version`, etc.)
- This is triggered only on `master`, because trying to make this work for PRs is next to impossible. (It requires passing a git ref to the script so that it can `git clone` the PR's branch, but this doesn't work for forks.)
- Now that we no longer need the "git ref"-related logic, the git ref script arguments are removed.

To test this PR, I did the following: 

- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4121/commits/452bb968bd9f767d71a5a010fa981c00fa3b3679: Added the "run outside the sourcedir" logic unconditionally, to test if it works.
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4121/commits/9ca95996ef6f33b9ddc7475ebaac7ed58e045f1c: Added conditionals to make sure that this logic is run only on master, and isn't run on PRs.

> **Note**: You can ignore the first four commits of this PR. That was just me trying to use `create-release.yml` for this PR, only to realize that `tests.yml` is better suited.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4054.
