### PR TITLE
Use `importlib.metadata` to fetch list of scripts instead of `pkg_resources`

### DIFF
--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -1,8 +1,8 @@
 import pytest
-import pkg_resources
 import importlib
+from importlib.metadata import entry_points
 
-scripts = pkg_resources.get_entry_map('spinalcordtoolbox')['console_scripts'].keys()
+scripts = [cs.name for cs in entry_points()['console_scripts'] if cs.name.startswith("sct_")]
 
 scripts_where_no_args_is_valid = [
     'isct_test_ants',          # No args -> tests ants binaries

--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -2,7 +2,7 @@ import pytest
 import importlib
 from importlib.metadata import entry_points
 
-scripts = [cs.name for cs in entry_points()['console_scripts'] if cs.name.startswith("sct_")]
+scripts = [cs.name for cs in entry_points()['console_scripts'] if cs.value.startswith("spinalcordtoolbox")]
 
 scripts_where_no_args_is_valid = [
     'isct_test_ants',          # No args -> tests ants binaries


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a small change to address a deprecation warning in the test suite:

```
python/envs/venv_sct/lib/python3.8/site-packages/pkg_resources/__init__.py:121
  /github/home/sct_6.0.dev0/python/envs/venv_sct/lib/python3.8/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
```

To address this warning, we remove all usage of `pkg_resources`'s API.

Both the old and new lines of code fetch the list of all 54 scripts defined in SCT's `setup.py` `console_scripts` entry.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4123.