### PR TITLE
Add warning filters for upstream `pkg_resources` warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,11 @@ filterwarnings =
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
     # This warning is for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
+    # These warnings are due to a deprecation for a call that is still used by many upstream packages. In our case:
+    # - matplotlib: https://github.com/matplotlib/matplotlib/issues/25244
+    # - google_auth: https://github.com/googleapis/google-cloud-python/issues/11184#issuecomment-1564488281
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    ignore:Deprecated call to \`pkg_resources.declare_namespace\('.*'\)\`.*:DeprecationWarning
 
 [flake8]
 max-line-length = 179


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #4124, we attempted to address `pkg_resources` API usage DeprecationWarnings by removing all usage of `pkg_resources` from SCT. As it turns out, though, SCT wasn't the only source of these warnings. 

Instead, the call-specific warnings are from upstream packages. (There are open issues for solving these warnings in their respective packages (matplotlib, google_auth), see: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4123#issuecomment-1568505666)

So, the best we can do is filter these warnings while we wait. (This is the option chosen by many projects, see: https://github.com/search?q=ignore%3ADeprecated+call&type=code)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4123
