### PR TITLE
Fix upper/lower TR bounds used when plotting Ernst angles (argument `-b`)

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -90,7 +90,7 @@ def get_parser():
     optional.add_argument(
         "-b",
         type=float,
-        nargs='*',
+        nargs=2,
         metavar=Metavar.float,
         help='Min/Max range of TR (in ms) separated with space. Only use with -v 2. Example: 500 3500',
         default=[500, 3500],

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -129,15 +129,10 @@ def main(argv: Sequence[str]):
     # Initialization
     input_t1 = arguments.t1
     input_fname_output = None
-    input_tr_min = 500
-    input_tr_max = 3500
     input_tr = None
     fname_output_file = arguments.o
     if arguments.ofig is not None:
         input_fname_output = arguments.ofig
-    if arguments.b is not None:
-        input_tr_min = arguments.b[0]
-        input_tr_max = arguments.b[1]
     if arguments.tr is not None:
         input_tr = arguments.tr
 
@@ -145,16 +140,23 @@ def main(argv: Sequence[str]):
     if input_tr is not None:
         printv("\nValue of the Ernst Angle with T1=" + str(graph.t1) + "ms and TR=" + str(input_tr) + "ms :", verbose=verbose, type='info')
         printv(str(graph.getErnstAngle(input_tr)))
-        if input_tr > input_tr_max:
-            input_tr_max = input_tr + 500
-        elif input_tr < input_tr_min:
-            input_tr_min = 0
         # save text file
         f = open(fname_output_file, 'w')
         f.write(str(graph.getErnstAngle(input_tr)))
         f.close()
 
     if verbose == 2:
+        # The upper and lower bounds of the TR values to use for plotting the Ernst angle curve
+        input_tr_min = 500
+        input_tr_max = 3500
+        if arguments.b is not None:
+            input_tr_min = arguments.b[0]
+            input_tr_max = arguments.b[1]
+        # If the input TR value is outside the default plotting range, then widen the range
+        if input_tr > input_tr_max:
+            input_tr_max = input_tr + 500
+        elif input_tr < input_tr_min:
+            input_tr_min = 0
         graph.draw(input_tr_min, input_tr_max)
 
 

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -93,6 +93,7 @@ def get_parser():
         nargs='*',
         metavar=Metavar.float,
         help='Min/Max range of TR (in ms) separated with space. Only use with -v 2. Example: 500 3500',
+        default=[500, 3500],
         required=False)
     optional.add_argument(
         "-o",
@@ -147,11 +148,8 @@ def main(argv: Sequence[str]):
 
     if verbose == 2:
         # The upper and lower bounds of the TR values to use for plotting the Ernst angle curve
-        input_tr_min = 500
-        input_tr_max = 3500
-        if arguments.b is not None:
-            input_tr_min = arguments.b[0]
-            input_tr_max = arguments.b[1]
+        input_tr_min = arguments.b[0]
+        input_tr_max = arguments.b[1]
         # If the input TR value is outside the default plotting range, then widen the range
         if input_tr > input_tr_max:
             input_tr_max = input_tr + 500

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -148,7 +148,7 @@ def main(argv: Sequence[str]):
         if input_tr > input_tr_max:
             input_tr_max = input_tr + 500
         elif input_tr < input_tr_min:
-            input_tr_min = input_tr - 500
+            input_tr_min = 0
         # save text file
         f = open(fname_output_file, 'w')
         f.write(str(graph.getErnstAngle(input_tr)))


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`sct_compute_ernst_angle` will display a "Repetition Time (TR) vs. Ernst angle" plot if `-v 2` is supplied. 

The script starts with a range of TR values `[500ms, 3500ms]` for the x axis of the plot. But, due to a bug in the code, if the input TR value is less than 500ms, a negative TR lower bound will be produced, which results in a `nan` Ernst angle causes an error.

This PR contains 4 commits:

- Commit 99bf2510a15e4c703e29858cd30ab49ce5c51b57 fixes the bug by capping the lower bound at 0ms.
- The remaining 3 commits clean up the `-b` argument to make it easier to use, and the `verbose == 2` block to make the code a little easier to understand.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4130.
