### PR TITLE
Ensure that qform/sform codes are preserved when generating segmentation

### DIFF
--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -437,7 +437,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
 
     # Resample image to 0.5mm in plane
     im_image_res = \
-        resampling.resample_nib(im_image, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm', interpolation='linear')
+        resampling.resample_nib(im_image, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm',
+                                interpolation='linear', preserve_codes=True)
 
     fname_orient = 'image_in_RPI_res.nii'
     im_image_res.save(fname_orient)
@@ -454,7 +455,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
 
     if ctr_algo == 'file':
         im_ctl = \
-            resampling.resample_nib(im_ctl, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm', interpolation='linear')
+            resampling.resample_nib(im_ctl, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm',
+                                    interpolation='linear', preserve_codes=True)
 
     # crop image around the spinal cord centerline
     logger.info("Cropping the image around the spinal cord...")
@@ -514,7 +516,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
 
     # resample to initial resolution
     logger.info("Resampling the segmentation to the native image resolution using linear interpolation...")
-    im_seg_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
+    im_seg_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear', preserve_codes=True)
 
     if ctr_algo == 'viewer':  # for debugging
         im_labels_viewer.save(add_suffix(fname_orient, '_labels-viewer'))

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -44,7 +44,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
     if type(image) == nib.nifti1.Nifti1Image:
         img = image
     elif type(image) == Image:
-        img = nib.nifti1.Nifti1Image(image.data, image.hdr.get_best_affine())
+        img = nib.nifti1.Nifti1Image(image.data, image.hdr.get_best_affine(), image.hdr)
     else:
         raise TypeError(f'Invalid image type: {type(image)}')
 

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -19,7 +19,8 @@ from spinalcordtoolbox.utils import display_viewer_syntax
 logger = logging.getLogger(__name__)
 
 
-def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, interpolation='linear', mode='nearest'):
+def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, interpolation='linear', mode='nearest',
+                 preserve_codes=False):
     """
     Resample a nibabel or Image object based on a specified resampling factor.
     Can deal with 2d, 3d or 4d image objects.
@@ -34,6 +35,13 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         are ignored
     :param interpolation: {'nn', 'linear', 'spline'}. The interpolation type
     :param mode: Outside values are filled with 0 ('constant') or nearest value ('nearest').
+    :param preserve_codes: bool: Whether to preserve the qform/sform codes from the original image.
+        - If set to False, nibabel will overwrite the existing qform/sform codes with `0` and `2` respectively.
+        - This option is set to False by default, as resampling typically implies that the new image is in a different
+          space. Therefore, since the image is no longer aligned to any scan, the previous codes are now invalid.
+        - However, if you plan to eventually resample back to the native space later on, you may wish to set this
+          option to True to preserve the codes. (For more information, see:
+          https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3005)
     :return: The resampled nibabel or Image image (depending on the input object type).
     """
 
@@ -127,6 +135,11 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         img_r = nib.nifti1.Nifti1Image(data4d, affine_r)
         # Copy over the TR parameter from original 4D image (otherwise it will be incorrectly set to 1)
         img_r.header.set_zooms(list(img_r.header.get_zooms()[0:3]) + [img.header.get_zooms()[3]])
+
+    # preserve the codes from the original image, which will otherwise get overwritten with 0/2
+    if preserve_codes:
+        img_r.header['qform_code'] = img.header['qform_code']
+        img_r.header['sform_code'] = img.header['sform_code']
 
     # Convert back to proper type
     if type(image) == nib.nifti1.Nifti1Image:

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -4,17 +4,26 @@ import logging
 import os
 
 import pytest
+import numpy as np
 
 from spinalcordtoolbox.scripts import sct_deepseg_sc
 from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.image import Image
 
 logger = logging.getLogger(__name__)
 
 
-def test_sct_deepseg_sc_check_output_exists(tmp_path):
+def test_sct_deepseg_sc_check_output_qform_sform(tmp_path):
+    fname_in = sct_test_path('t2', 't2.nii.gz')
     fname_out = str(tmp_path / 'test_seg.nii.gz')
-    sct_deepseg_sc.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-o', fname_out])
-    assert os.path.isfile(fname_out)
+    sct_deepseg_sc.main(argv=['-i', fname_in, '-c', 't2', '-o', fname_out])
+    # Ensure sform/qform of the segmentation matches that of the input images
+    im_in = Image(fname_in)
+    im_seg = Image(fname_out)
+    assert np.array_equal(im_in.header.get_sform(), im_seg.header.get_sform())
+    assert np.array_equal(im_in.header.get_qform(), im_seg.header.get_qform())
+    assert im_in.header['sform_code'] == im_seg.header['sform_code']
+    assert im_in.header['qform_code'] == im_seg.header['qform_code']
 
 
 @pytest.mark.sct_testing


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

During `sct_deepseg_sc`, we resample images to 0.5mm prior to inference, then resample back to the native resolution after inference. However, resampling has a known issue: 

- https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3005

In this case, we _definitely_ want to preserve the codes, because we're resampling back to the native space. So, the segmentation image should be aligned to the same space as the input image, and thus the codes should not change. If we don't preserve the codes, we run into #4132, which can cause issues later down the line when working with e.g. SimpleITK.

To fix this, I could have changed the behavior of the resampling code unconditionally to address #3005 outright. However, there are some cases where the overwriting of the codes may be desirable behavior (see: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3005#issuecomment-1404347614). So, I decided to make the `preserve_codes` behavior opt-in, and enable it only in the `sct_deepseg_sc` case. ((And, as an added benefit, creating an option ensures the behavior is documented in-code via the docstring.))

I also added a test that fails before this PR, but passes after this PR.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses #3005.
Fixes #4132.

> **Note**: Issue https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4134 was also discovered as part of the investigation for #4132. However, fixing it is not necessary for this specific PR, as addressing the resampling behavior skips over the orientation behavior described in #4134.
