### PR TITLE
Upgrade SCT's conda environment to Python 3.9

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -596,7 +596,7 @@ find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +
 # create conda environment
 print info "Creating conda environment..."
 # NB: We use an absolute path (-p) rather than a relative name (-n) to better isolate the conda environment
-python/bin/conda create -y -p "$SCT_DIR/$PYTHON_DIR/envs/venv_sct" python=3.8
+python/bin/conda create -y -p "$SCT_DIR/$PYTHON_DIR/envs/venv_sct" python=3.9
 
 # Reapply the touch fix to avoid `pip` connection issues on WSL
 find "$SCT_DIR/$PYTHON_DIR" -type f -exec touch {} +

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -167,7 +167,7 @@ start /wait "" %TMP_DIR%\miniconda.exe /InstallationType=JustMe /AddToPath=0 /Re
 rem Create and activate miniconda environment to install SCT into
 echo:
 echo ### Using Conda to create virtual environment...
-python\Scripts\conda create -y -p python\envs\venv_sct python=3.8 || goto error
+python\Scripts\conda create -y -p python\envs\venv_sct python=3.9 || goto error
 CALL python\Scripts\activate.bat python\envs\venv_sct || goto error
 echo Virtual environment created and activated successfully!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,8 +29,9 @@ portalocker
 psutil
 # pyqt5=5.11.X causes https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3916#discussion_r997435037
 # pyqt5=5.15.X causes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3925
-# So, we limit the range to 5.12-5.14.
-pyqt5>=5.12.0,<5.15.0
+# Additionally, for versions between 5.12-5.14, the only release to have Python 3.9 wheels is 5.12.3. So, we pin it.
+# See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3367#issuecomment-1533181462
+pyqt5==5.12.3
 pytest
 pytest-cov
 requests

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,13 @@ setup(
         'Operating System :: MacOS',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='Magnetic Resonance Imaging MRI spinal cord analysis template',
     packages=find_packages(exclude=['.git', 'data', 'dev', 'dev.*',
                                     'install', 'testing']),
     include_package_data=True,
-    python_requires="==3.8.*",
+    python_requires="==3.9.*",
     extras_require={
         'docs': [
             'sphinxcontrib-programoutput',


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a relatively straightforward PR that updates the SCT conda environment from Python 3.8 to Python 3.9. It contains typical updates the install scripts, and also fixes 1 blocker: `pyqt5` only has Python 3.9 wheels for version `15.2.3`.

I'm not sure when we want to merge this, as we have until October 2024 for the Python 3.8 EOL. But, I was thinking that, because we're releasing a new major version (SCT v6.0), and we're switching from system Python to conda installation for Windows (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4027), now might be a good time to bump the Python version, as another way of distinguishing between 5.X releases and 6.X releases. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3367. 
