### PR TITLE
`install_sct`: Use explicit paths to python/pip executables

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -599,7 +599,7 @@ set -u # reactivate safeties
 
 # Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
 if [[ $OS == linux ]]; then
-  python/bin/conda install -y -c conda-forge libstdcxx-ng
+  conda install -y -c conda-forge libstdcxx-ng
 fi
 
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)

--- a/install_sct
+++ b/install_sct
@@ -625,11 +625,11 @@ fi
 
 # Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
 if [[ $OS == linux ]]; then
-  conda install -y -c conda-forge libstdcxx-ng
+  python/bin/conda install -y -c conda-forge libstdcxx-ng
 fi
 
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
-python -m pip install -U "pip!=21.2.*"
+python/envs/venv_sct/bin/python -m pip install -U "pip!=21.2.*"
 
 ## Install the spinalcordtoolbox into the Conda venv
 print info "Installing Python dependencies..."
@@ -645,9 +645,9 @@ fi
 (
   # We use "--ignore-installed" to preserve the version of `certifi` installed into the conda
   # env, which prevents https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3609
-  pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
+  python/envs/venv_sct/bin/pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
   print info "Installing spinalcordtoolbox..." &&
-  pip install -e .
+  python/envs/venv_sct/bin/pip install -e .
 ) ||
   die "Failed running pip install: $?"
 

--- a/install_sct
+++ b/install_sct
@@ -661,7 +661,7 @@ else
 fi
 
 # Install deep learning models
-python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.models.install_default_models()'
+python/envs/venv_sct/bin/python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.models.install_default_models()'
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/install_sct
+++ b/install_sct
@@ -314,23 +314,6 @@ function usage() {
   ' "$0"
 }
 
-if [ "$(uname)" = "Darwin" ]; then
-  # macOS polyfills
-
-  # Linux has `realpath` and `readlink -f`.
-  # BSD has `readlink -f`.
-  # macOS has neither: https://izziswift.com/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac/
-  # even though it *has* the function in its libc: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html
-  # Someone even wrote a whole C program just for this: https://github.com/harto/realpath-osx/.
-  # https://stackoverflow.com/a/3572105 suggests some bash trickery but it
-  # seems pretty fragile and that it probably doesn't actually expand symlinks.
-  # So here, solve it with python. It's not great either, but since much of
-  # this script already is just calling python at least it's reliable.
-  (command -v realpath >/dev/null) || realpath() {
-    python3 -c 'import sys, os; [print(os.path.realpath(f)) for f in sys.argv[1:]]' "$@"
-  }
-fi
-
 # ======================================================================================================================
 # SCRIPT STARTS HERE
 # ======================================================================================================================

--- a/install_sct
+++ b/install_sct
@@ -614,15 +614,6 @@ set +u #disable safeties, for conda is not written to their standard.
 conda activate "$SCT_DIR/$PYTHON_DIR/envs/venv_sct"
 set -u # reactivate safeties
 
-# double-check conda activated (it can be glitchy): https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3029
-print info "Validating that conda environment can be activated..."
-EXPECTED_PYTHON="$(realpath "$(command -v python/envs/venv_sct/bin/python)")"
-ACTUAL_PYTHON="$(realpath "$(command -v python)")"
-if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
-  echo "Error: Activating venv_sct failed to switch Python interpreter to Miniconda. (Incorrect interpreter loaded: $ACTUAL_PYTHON)" >&2
-  exit 1
-fi
-
 # Ensure that packaged GLIBC version is up to date (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927)
 if [[ $OS == linux ]]; then
   python/bin/conda install -y -c conda-forge libstdcxx-ng

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -180,9 +180,9 @@ if exist requirements-freeze.txt (
 echo:
 echo ### Installing SCT and its dependencies from %requirements_file%...
 rem Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
-python -m pip install -U "pip^!=21.2.*" || goto error
-pip install -r %requirements_file% || goto error
-pip install -e . || goto error
+python\envs\venv_sct\python -m pip install -U "pip^!=21.2.*" || goto error
+python\envs\venv_sct\Scripts\pip install -r %requirements_file% || goto error
+python\envs\venv_sct\Scripts\pip install -e . || goto error
 
 rem Install external dependencies
 echo:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR ensures that we always invoke the correct `python`/`pip` executables during installation, as there are cases when system `python`/`pip` can be prioritized incorrectly, _even when the conda environment is activated_. (#3029, #4142)

Previously, we tried to mitigate this issue in the `python` case by throwing an error:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/117e1cbd6be53db336a5ce16854cfa58abaa402e/install_sct#L617-L624

We could add a second check for `pip` to fix #4142. But, by throwing an error, we halt the installation and create debugging work that is often unnecessary, since even in the case of a mismatch, we can still just access the correct executables directly. So, this PR removes this check/error as well.

And, because we remove the `python` check, we also no longer need the `realpath` MacOS polyfill introduced in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3103.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4142.
Fixes #3029. (Previously fixed by https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3103)