### PR TITLE
Make sure that `$SCT_DIR` is set for both Windows installations and `batch_processing.sh`

### DIFF
--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -52,8 +52,9 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
 
-            # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change
-            # In a user install, the user would perform this step using the Windows PATH-changing GUI.
+            # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash to set the environment variables.
+            # In a user install, the user would perform this step using the Windows environment variable changing GUI.
+            echo "SCT_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
             echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
           else

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -58,7 +58,7 @@ start=$(date +%s)
 if [[ "$SCT_BP_DOWNLOAD" == "1" ]]; then
   sct_download_data -d sct_example_data
 fi
-cd data/sct_example_data
+cd "$SCT_DIR/data/sct_example_data"
 
 
 # t2
@@ -85,7 +85,7 @@ sct_register_to_template -i t2.nii.gz -s t2_seg.nii.gz -l labels_vert.nii.gz -c 
 # For example here, we would like to take into account the rotation of the cord, as well as
 # adding a 3rd registration step that uses the image intensity (not only cord segmentations).
 # so we could do something like this:
-# sct_register_multimodal -i ../../../data/PAM50/template/PAM50_t2s.nii.gz -iseg ../../../data/PAM50/template/PAM50_cord.nii.gz -d t2s.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=seg,algo=slicereg,smooth=3:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz
+# sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_t2s.nii.gz -iseg "$SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -d t2s.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=seg,algo=slicereg,smooth=3:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz
 # Warp template without the white matter atlas (we don't need it at this point)
 sct_warp_template -d t2.nii.gz -w warp_template2anat.nii.gz -a 0
 # Compute cross-sectional area (and other morphometry measures) for each slice
@@ -111,7 +111,7 @@ sct_deepseg_sc -i t2s.nii.gz -c t2s -qc "$SCT_BP_QC_FOLDER"
 # Segment gray matter
 sct_deepseg_gm -i t2s.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Register template->t2s (using warping field generated from template<->t2 registration)
-sct_register_multimodal -i ../../../data/PAM50/template/PAM50_t2s.nii.gz -iseg ../../../data/PAM50/template/PAM50_cord.nii.gz -d t2s.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3:step=3,type=im,algo=syn,slicewise=1,iter=1,metric=CC -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -owarp warp_template2t2s.nii.gz -owarpinv warp_t2s2template.nii.gz
+sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_t2s.nii.gz" -iseg "$SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz" -d t2s.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3:step=3,type=im,algo=syn,slicewise=1,iter=1,metric=CC -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -owarp warp_template2t2s.nii.gz -owarpinv warp_t2s2template.nii.gz
 # Warp template
 sct_warp_template -d t2s.nii.gz -w warp_template2t2s.nii.gz
 # Subtract GM segmentation from cord segmentation to obtain WM segmentation
@@ -122,7 +122,7 @@ sct_process_segmentation -i t2s_gmseg.nii.gz -vert 2:5 -perlevel 1 -o csa_gm.csv
 # OPTIONAL: Update template registration using information from gray matter segmentation
 # # <<<
 # # Register WM/GM template to WM/GM seg
-# sct_register_multimodal -i ../../../data/PAM50/template/PAM50_wm.nii.gz -d t2s_wmseg.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=im,algo=syn,slicewise=1,iter=5 -initwarp warp_template2t2s.nii.gz -initwarpinv warp_t2s2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2t2s.nii.gz -owarpinv warp_t2s2template.nii.gz
+# sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_wm.nii.gz" -d t2s_wmseg.nii.gz -dseg t2s_seg.nii.gz -param step=1,type=im,algo=syn,slicewise=1,iter=5 -initwarp warp_template2t2s.nii.gz -initwarpinv warp_t2s2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2t2s.nii.gz -owarpinv warp_t2s2template.nii.gz
 # # Warp template (this time corrected for internal structure)
 # sct_warp_template -d t2s.nii.gz -w warp_template2t2s.nii.gz
 # # >>>
@@ -173,7 +173,7 @@ sct_register_multimodal -i mt0.nii.gz -d mt1_crop.nii.gz -dseg mt1_crop_seg.nii.
 # Register template->mt1
 # Tips: here we only use the segmentations due to poor SC/CSF contrast at the bottom slice.
 # Tips: First step: slicereg based on images, with large smoothing to capture potential motion between anat and mt, then at second step: bpslinesyn in order to adapt the shape of the cord to the mt modality (in case there are distortions between anat and mt).
-sct_register_multimodal -i ../../../data/PAM50/template/PAM50_t2.nii.gz -iseg ../../../data/PAM50/template/PAM50_cord.nii.gz -d mt1_crop.nii.gz -dseg mt1_crop_seg.nii.gz -param step=1,type=seg,algo=slicereg,smooth=3:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -owarp warp_template2mt.nii.gz -owarpinv warp_mt2template.nii.gz
+sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz" -iseg "$SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz" -d mt1_crop.nii.gz -dseg mt1_crop_seg.nii.gz -param step=1,type=seg,algo=slicereg,smooth=3:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -owarp warp_template2mt.nii.gz -owarpinv warp_mt2template.nii.gz
 # Warp template
 sct_warp_template -d mt1_crop.nii.gz -w warp_template2mt.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Compute mtr
@@ -190,7 +190,7 @@ sct_extract_metric -i mtr.nii.gz -method map -o mtr_in_wm.csv -l 51 -vert 2:5
 sct_extract_metric -i mtsat.nii.gz -method map -o mtsat_in_wm.csv -l 51 -vert 2:5
 sct_extract_metric -i t1map.nii.gz -method map -o t1_in_wm.csv -l 51 -vert 2:5
 # Bring MTR to template space (e.g. for group mapping)
-sct_apply_transfo -i mtr.nii.gz -d ../../../data/PAM50/template/PAM50_t2.nii.gz -w warp_mt2template.nii.gz
+sct_apply_transfo -i mtr.nii.gz -d "$SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz" -w warp_mt2template.nii.gz
 # Go back to root folder
 cd ..
 
@@ -214,7 +214,7 @@ sct_deepseg_sc -i dmri_crop_moco_dwi_mean.nii.gz -c dwi -qc "$SCT_BP_QC_FOLDER"
 sct_qc -i dmri_crop.nii.gz -d dmri_crop_moco.nii.gz -s dmri_crop_moco_dwi_mean_seg.nii.gz -p sct_dmri_moco -qc "$SCT_BP_QC_FOLDER"
 # Register template to dwi
 # Tips: Again, here, we prefer to stick to segmentation-based registration. If there are susceptibility distortions in your EPI, then you might consider adding a third step with bsplinesyn or syn transformation for local adjustment.
-sct_register_multimodal -i ../../../data/PAM50/template/PAM50_t1.nii.gz -iseg ../../../data/PAM50/template/PAM50_cord.nii.gz -d dmri_crop_moco_dwi_mean.nii.gz -dseg dmri_crop_moco_dwi_mean_seg.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,metric=MeanSquares,smooth=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2dmri.nii.gz -owarpinv warp_dmri2template.nii.gz
+sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz" -iseg "$SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz" -d dmri_crop_moco_dwi_mean.nii.gz -dseg dmri_crop_moco_dwi_mean_seg.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,metric=MeanSquares,smooth=1,iter=3 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2dmri.nii.gz -owarpinv warp_dmri2template.nii.gz
 # Warp template and white matter atlas
 sct_warp_template -d dmri_crop_moco_dwi_mean.nii.gz -w warp_template2dmri.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Compute DTI metrics
@@ -223,7 +223,7 @@ sct_dmri_compute_dti -i dmri_crop_moco.nii.gz -bval bvals.txt -bvec bvecs.txt
 # Compute FA within right and left lateral corticospinal tracts from slices 2 to 14 using weighted average method
 sct_extract_metric -i dti_FA.nii.gz -z 2:14 -method wa -l 4,5 -o fa_in_cst.csv
 # Bring metric to template space (e.g. for group mapping)
-sct_apply_transfo -i dti_FA.nii.gz -d ../../../data/PAM50/template/PAM50_t2.nii.gz -w warp_dmri2template.nii.gz
+sct_apply_transfo -i dti_FA.nii.gz -d "$SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz" -w warp_dmri2template.nii.gz
 # Go back to root folder
 cd ..
 
@@ -249,7 +249,7 @@ sct_fmri_moco -i fmri_crop.nii.gz -g 1
 # Generate QC for sct_fmri_moco ('fmri_crop_moco_mean_seg_manual.nii.gz' is needed to align each slice in the QC mosaic)
 sct_qc -i fmri_crop.nii.gz -d fmri_crop_moco.nii.gz -s fmri_crop_moco_mean_seg_manual.nii.gz -p sct_fmri_moco -qc "$SCT_BP_QC_FOLDER"
 # Register template->fmri
-sct_register_multimodal -i ../../../data/PAM50/template/PAM50_t2.nii.gz -iseg ../../../data/PAM50/template/PAM50_cord.nii.gz -d fmri_crop_moco_mean.nii.gz -dseg fmri_crop_moco_mean_seg_manual.nii.gz -param step=1,type=seg,algo=slicereg,metric=MeanSquares,smooth=2:step=2,type=im,algo=bsplinesyn,metric=MeanSquares,iter=5,gradStep=0.5 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2fmri.nii.gz -owarpinv warp_fmri2template.nii.gz
+sct_register_multimodal -i "$SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz" -iseg "$SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz" -d fmri_crop_moco_mean.nii.gz -dseg fmri_crop_moco_mean_seg_manual.nii.gz -param step=1,type=seg,algo=slicereg,metric=MeanSquares,smooth=2:step=2,type=im,algo=bsplinesyn,metric=MeanSquares,iter=5,gradStep=0.5 -initwarp ../t2/warp_template2anat.nii.gz -initwarpinv ../t2/warp_anat2template.nii.gz -qc "$SCT_BP_QC_FOLDER" -owarp warp_template2fmri.nii.gz -owarpinv warp_fmri2template.nii.gz
 # Warp template and spinal levels (here we don't need the WM atlas)
 sct_warp_template -d fmri_crop_moco_mean.nii.gz -w warp_template2fmri.nii.gz -a 0 -s 1
 # Note, once you have computed fMRI statistics in the subject's space, you can use

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -267,8 +267,8 @@ echo "Ran on:          $(uname -nsr)"
 echo "Duration:        $((runtime / 3600))hrs $(((runtime / 60) % 60))min $((runtime % 60))sec"
 echo "---"
 # The file `test_batch_processing.py` will output tested values when run as a script
-./python/envs/venv_sct/bin/python testing/batch_processing/test_batch_processing.py ||
-./python/envs/venv_sct/python.exe testing/batch_processing/test_batch_processing.py
+"$SCT_DIR"/python/envs/venv_sct/bin/python "$SCT_DIR"/testing/batch_processing/test_batch_processing.py ||
+"$SCT_DIR"/python/envs/venv_sct/python.exe "$SCT_DIR"/testing/batch_processing/test_batch_processing.py
 echo "~~~"
 
 # Display syntax to open QC report on web browser

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -255,9 +255,6 @@ sct_warp_template -d fmri_crop_moco_mean.nii.gz -w warp_template2fmri.nii.gz -a 
 # Note, once you have computed fMRI statistics in the subject's space, you can use
 # warp_fmri2template.nii.gz to bring the statistical maps on the template space, for group analysis.
 
-# Go back to sct_example_data -> data -> $SCT_DIR
-cd ../../..
-
 
 # Display results (to easily compare integrity across SCT versions)
 # ===========================================================================================

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -200,13 +200,17 @@ echo ### Installation finished!
 echo:
 echo To use SCT's command-line scripts in Command Prompt, please follow these instructions:
 echo:
-echo 1. Open the Start Menu -^> Type 'path' -^> Open 'Edit environment variables for your account'
-echo 2. Under the section 'User variables for ____', highlight the 'Path' entry, then click the 'Edit...' button.
-echo 3. Click 'New', then copy and paste this directory:
+echo 1. Open the Start Menu -^> Type 'edit environment' -^> Open 'Edit environment variables for your account'
+echo 2. Click 'New', then enter 'SCT_DIR' for the variable name. For the value, copy and paste this directory:
+echo:
+echo    %CD%
+echo:
+echo 3. Click 'OK', then click on the 'Path' variable, then click the 'Edit...' button.
+echo 4. Click 'New', then copy and paste this directory:
 echo:
 echo    %CD%\bin\
 echo:
-echo 4. Click 'OK' three times. You can now access SCT's scripts in the Command Prompt.
+echo 5. Click 'OK' three times. You can now access SCT's scripts in the Command Prompt.
 echo:
 echo If you have any questions or concerns, feel free to create a new topic on SCT's forum:
 echo   --^> http://forum.spinalcordmri.org/c/sct

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -283,7 +283,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
         'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS': str(itk_threads),
         'SCT_PROGRESS_BAR': 'off'
     })
-    if 'SCT_DIR' not in envir:  # For native Windows installations, the install script won't add SCT_DIR
+    if 'SCT_DIR' not in envir:
         envir['SCT_DIR'] = __sct_dir__
 
     cmd = [script_full, subj_dir] + script_args.split(' ')


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When we first introduced our Windows installation, we decided not to instruct users to set `$SCT_DIR`, as it was already a lot to ask users to update the `$PATH`, and we figured that `$SCT_DIR` wasn't entirely necessary for SCT to run.

That said, having `$SCT_DIR` set makes things a _lot_ easier (in terms of the SCT course, tutorials, `batch_processing.sh`, etc.), since it means we can more easily access assets from within the SCT repo (namely the PAM50 template). Plus, having consistent instructions for all OSs will help a lot when actually teaching the SCT course.

So, this PR brings the Windows installation back in line with Linux/macOS installations, and updates `batch_processing.sh` accordingly so that it can use `$SCT_DIR`, fixing #4146.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4146.