### PR TITLE
Fix errors in the list of available QC processes (`index.html`, `sct_qc.py`)

### DIFF
--- a/spinalcordtoolbox/reports/assets/index.html
+++ b/spinalcordtoolbox/reports/assets/index.html
@@ -335,7 +335,7 @@
             "sct_detect_pmj": "FILES_PMJ",
             "sct_dmri_moco": "FILES_TIMESERIES",
             "sct_fmri_moco": "FILES_TIMESERIES",
-            "sct_image -stitch": "FILES_REG",
+            "sct_image_stitch": "FILES_REG",
             "sct_label_utils": "FILES_LABEL",
             "sct_label_vertebrae": "FILES_LABEL",
             "sct_process_segmentation": "FILES_SEG",

--- a/spinalcordtoolbox/reports/assets/index.html
+++ b/spinalcordtoolbox/reports/assets/index.html
@@ -324,13 +324,13 @@
     function download_yaml(marker) {
         let res = {};
         let seg_cmd_to_seg_type = {
-            "sct_analyze_lesion": "FILES_GMSEG",
+            "sct_analyze_lesion": "FILES_LESION",
             "sct_analyze_texture": "FILES_SEG",
             "sct_create_mask": "FILES_SEG",
             "sct_crop_image": "FILES_SEG",
             "sct_deepseg": "FILES_SEG",
             "sct_deepseg_gm": "FILES_GMSEG",
-            "sct_deepseg_lesion": "FILES_GMSEG",
+            "sct_deepseg_lesion": "FILES_LESION",
             "sct_deepseg_sc": "FILES_SEG",
             "sct_detect_pmj": "FILES_PMJ",
             "sct_dmri_moco": "FILES_TIMESERIES",

--- a/spinalcordtoolbox/reports/assets/index.html
+++ b/spinalcordtoolbox/reports/assets/index.html
@@ -335,6 +335,7 @@
             "sct_detect_pmj": "FILES_PMJ",
             "sct_dmri_moco": "FILES_TIMESERIES",
             "sct_fmri_moco": "FILES_TIMESERIES",
+            "sct_image -stitch": "FILES_REG",
             "sct_label_utils": "FILES_LABEL",
             "sct_label_vertebrae": "FILES_LABEL",
             "sct_process_segmentation": "FILES_SEG",

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -687,7 +687,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         qcslice = Sagittal([Image(fname) for fname in fname_list], p_resample=None)
         action_list = [QcImage.smooth_centerline, QcImage.highlight_pmj, QcImage.listed_seg]
         def qcslice_layout(x): return x.single()
-    elif process in ['sct_image -stitch']:
+    elif process in ['sct_image_stitch']:
         plane = 'Sagittal'
         dpi = 150
         qcslice = Sagittal([Image(fname_in1), Image(fname_in2)], p_resample=None)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -449,7 +449,7 @@ def main(argv: Sequence[str]):
             # generate the QC report itself
             generate_qc(fname_in1=fname_qc_concat, fname_in2=fname_qc_out, args=sys.argv[1:],
                         path_qc=os.path.abspath(arguments.qc), dataset=arguments.qc_dataset,
-                        subject=arguments.qc_subject, process='sct_image -stitch')
+                        subject=arguments.qc_subject, process='sct_image_stitch')
         else:
             printv("WARNING: '-qc' is only supported for 'sct_image -stitch'. QC report will not be generated.",
                    type='warning')

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -31,7 +31,7 @@ def get_parser():
                         choices=('sct_propseg', 'sct_deepseg_sc', 'sct_deepseg_gm', 'sct_deepseg_lesion',
                                  'sct_register_multimodal', 'sct_register_to_template', 'sct_warp_template',
                                  'sct_label_vertebrae', 'sct_detect_pmj', 'sct_label_utils', 'sct_get_centerline',
-                                 'sct_fmri_moco', 'sct_dmri_moco', 'sct_image -stitch'),
+                                 'sct_fmri_moco', 'sct_dmri_moco', 'sct_image_stitch'),
                         required=True)
     parser.add_argument('-s',
                         metavar='SEG',

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -31,7 +31,7 @@ def get_parser():
                         choices=('sct_propseg', 'sct_deepseg_sc', 'sct_deepseg_gm', 'sct_deepseg_lesion',
                                  'sct_register_multimodal', 'sct_register_to_template', 'sct_warp_template',
                                  'sct_label_vertebrae', 'sct_detect_pmj', 'sct_label_utils', 'sct_get_centerline',
-                                 'sct_fmri_moco', 'sct_dmri_moco'),
+                                 'sct_fmri_moco', 'sct_dmri_moco', 'sct_image -stitch'),
                         required=True)
     parser.add_argument('-s',
                         metavar='SEG',


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR started with issue #4149:

- In `index.html`, the QC key `FILES_GMSEG` is erroneously used for lesion-based scripts.

However, examining `index.html` made me realize that we're actually missing the `sct_image -stitch` in the list of keys, too. This resulted in a cascade of changes:

- Add missing `sct_image -stitch` to `index.html`
- Add missing `sct_image -stitch` to `sct_qc`'s `-p` option
- Rename the (internal use only) "process" string from `sct_image -stitch` to `sct_image_stitch`, to avoid issues with spaces on the command line when trying to specify `sct_qc -p sct_image -stitch`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4149.
