### PR TITLE
Use a more appropriate filename for the first QC image for `sct_image -stitch`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -439,7 +439,8 @@ def main(argv: Sequence[str]):
             printv("Generating QC Report...", verbose=verbose)
             # specify filenames to use in QC report
             path_tmp = tmp_create(basename="stitching-qc")
-            fname_qc_concat = os.path.join(path_tmp, "concatenated_input_images.nii.gz")
+            fname_qc_concat = "-".join([os.path.basename(p).split(".")[0] for p in fname_in]) + ".nii.gz"
+            fname_qc_concat = os.path.join(path_tmp, fname_qc_concat)
             fname_qc_out = os.path.join(path_tmp, os.path.basename(fname_out))
             # generate 2 images to compare in QC report
             # (1. naively concatenated input images, and 2. stitched image) padded so both have same dimensions


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a small change to fix a small bug. Currently, we are using a generic name for the concatenated images used in the QC report. The problem is, this results in the following QC:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/742f0083-78bd-4a45-a7fd-4b2c1555c084)

And the following YML when exporting QC fails:

```yml
FILES_REG:
    - /home/joshua/repos/spinalcordtoolbox/data/sct_testing_data/concatenated_input_images.nii.gz
```

This generic name is basically useless, since it doesn't tell you which input images were actually used?

So, I've updated the filename so that it shows the original input filenames:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/ab929c56-4690-44d9-9250-3f7685dbf402)

This seems more useful in QC? 

But, the only issue is, `t2_roi1-t2_roi2.nii.gz` isn't actually a file -- they're two separate files (`t2_roi1.nii.gz` and `t2_roi2.nii.gz`). Do we want our YML file to point to an actual file for further processing? If so, then maybe we can just use the name of the first input image instead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4152.
