### PR TITLE
Swap order of `sct_image -stitch` QC images to fix incorrect YML path

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -447,7 +447,7 @@ def main(argv: Sequence[str]):
             im_concat.save(fname_qc_concat)
             im_out_padded.save(fname_qc_out)
             # generate the QC report itself
-            generate_qc(fname_in1=fname_qc_concat, fname_in2=fname_qc_out, args=sys.argv[1:],
+            generate_qc(fname_in1=fname_qc_out, fname_in2=fname_qc_concat, args=sys.argv[1:],
                         path_qc=os.path.abspath(arguments.qc), dataset=arguments.qc_dataset,
                         subject=arguments.qc_subject, process='sct_image_stitch')
         else:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This change undoes a previous commit from PR #4052. (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4052/commits/ba8d4d57b82d233a82c482f4fcccb82a11bc06e8)

The purpose of the previous commit was to fix a QC report usability issue (#4051). However, this change inadvertently introduced a second bug: incorrect QC report filepaths (#4152).

Currently, I don't think there is a good way to fix both issues at once, since our QC reporting code is built around the assumption that the first image will be an anat image, and the second image will be the overlay on top of the first image. (But, maybe I'm missing something? Maybe there is a good way to fix both at once...)

Still, if we have to fix one of the two issues, I think that the QC path issue is the more critical of the two? But maybe this is debatable, too. There may be an argument for prioritizing a more usable QC report over having the correct filepath. (Up for discussion!)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4152.
Reopens #4051.