### PR TITLE
Add prototype for generating JSON sidecar files using `launcher.py`

### DIFF
--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -13,6 +13,7 @@ import importlib
 
 from spinalcordtoolbox import __file__ as package_init_file
 from spinalcordtoolbox.utils.sys import init_sct
+from spinalcordtoolbox.utils.fs import generate_json_sidecar
 
 
 def main(argv=None):
@@ -45,4 +46,10 @@ def main(argv=None):
     else:
         init_sct()
         module = importlib.import_module(name=f"spinalcordtoolbox.scripts.{command}")
-        module.main(argv)
+        return_values = module.main(argv)
+        if isinstance(return_values, tuple) and len(return_values) == 2:
+            generate_json_sidecar(
+                script_name=command,
+                output_folder=return_values[0],
+                output_files=return_values[1],
+            )

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -199,6 +199,8 @@ def main(argv: Sequence[str]):
                     dataset=qc_dataset, subject=qc_subject, process='sct_deepseg_sc')
     display_viewer_syntax([fname_image, fname_seg], im_types=['anat', 'seg'], opacities=['', '0.7'], verbose=verbose)
 
+    return output_folder, fname_seg
+
 
 if __name__ == "__main__":
     init_sct()

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -16,7 +16,13 @@ import sys
 
 from spinalcordtoolbox import __sct_dir__
 
-if __name__ == "__main__":
+
+def main(argv):
     # Treat `sct_testing` as an alias to `pytest`. If no arguments are passed,
     # simply point pytest at the repo (to avoid looking for tests in the pwd).
-    sys.exit(pytest.main(sys.argv[1:] if sys.argv[1:] else [__sct_dir__]))
+    sys.exit(pytest.main(argv if sys.argv[1:] else [__sct_dir__]))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -25,4 +25,3 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-

--- a/spinalcordtoolbox/scripts/sct_version.py
+++ b/spinalcordtoolbox/scripts/sct_version.py
@@ -3,7 +3,7 @@
 from spinalcordtoolbox import __version__
 
 
-def main():
+def main(argv=None):  # Unused, but necessary since `launcher.py` passes sys.argv[:1] to main()
     print(__version__)
 
 

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -12,9 +12,10 @@ import shutil
 import tempfile
 import datetime
 import logging
+import json
 from pathlib import Path
 
-from .sys import printv
+from .sys import printv, __version__
 
 logger = logging.getLogger(__name__)
 
@@ -258,3 +259,29 @@ def relpath_or_abspath(child_path, parent_path):
         return abspath.relative_to(parent_path)
     except ValueError:
         return abspath
+
+
+def generate_json_sidecar(script_name, output_folder, output_files):
+    data = {
+        "Name": "SCT Outputs",
+        "BIDSVersion": "1.4.0",
+        "DatasetType": "derivative",
+        "GeneratedBy": [
+            {
+              "Name": script_name,
+              "Version": __version__,
+              "Date": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            },
+        ],
+    }
+    data_json = json.dumps(data, indent=4)
+
+    if isinstance(output_files, str):
+        output_file = output_files
+    else:
+        output_file = output_files[0]
+    output_fname = os.path.basename(os.path.realpath(output_file)).split(".")[0]
+
+    with open(os.path.join(output_folder, f"{output_fname}.json"), 'w') as fp:
+        print(data_json, file=fp)
+

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -284,4 +284,3 @@ def generate_json_sidecar(script_name, output_folder, output_files):
 
     with open(os.path.join(output_folder, f"{output_fname}.json"), 'w') as fp:
         print(data_json, file=fp)
-


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR:

- Adds a new function called `generate_json_sidecar`, which follows the template laid out in @jcohenadad's comment [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3394#issue-894485189)).
- Updates `compat/launcher.py` so that SCT scripts are run in-process, allowing us to fetch return values (such as the output folder and output files).
- Updates `sct_deepseg_sc` to pass the necessary return values, which in turn enables a JSON sidecar file to be created.

To test, just run `sct_deepseg_sc -c t2 -i t2.nii.gz` in the `sct_testing_data/t2/` folder. 

As a result, a file called `t2_seg.json` will be created alongside `t2_seg.nii.gz` with the following contents:

```json
{
    "Name": "SCT Outputs",
    "BIDSVersion": "1.4.0",
    "DatasetType": "derivative",
    "GeneratedBy": [
        {
            "Name": "sct_deepseg_sc",
            "Version": "git-jn/3394-sidecar-launcher.py-prototype-00774fbb288a500150c8043d581702953352c4b3",
            "Date": "2023-07-19 11:28:08"
        }
    ]
}
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3394.
