### PR TITLE
Update changelog PR workflow to fix milestone title error and to also change `version.txt`

### DIFF
--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -10,6 +10,9 @@ on:
       milestone_title:
         description: 'Milestone title'
         required: true
+      future_milestone_title:
+        description: 'Next milestone title (used to update dev version.txt on master)'
+        required: true
 
 jobs:
   create-changelog-PR:
@@ -31,16 +34,20 @@ jobs:
         cd ${{ github.event.repository.name }}
         changelog spinalcordtoolbox/spinalcordtoolbox --update --name "${{ github.event.inputs.fname_changelog }}" --milestone ${{ github.event.inputs.milestone_title }} --use-milestone-due-date
         rm -f "${{ github.event.inputs.fname_changelog }}.bak"
-    - name: Create pull request for updated changelog
+    - name: Update version.txt
+      run: |
+        cd ${{ github.event.repository.name }}
+        echo "${{ github.event.inputs.future_milestone_title }}.dev0" > spinalcordtoolbox/version.txt
+    - name: Create pull request for updated changelog and version.txt
       uses: peter-evans/create-pull-request@v5
       with:
         path: "${{ github.event.repository.name }}"
         branch: "bot/v${{ github.event.inputs.milestone_title }}"
-        commit-message  : "Update ${{ github.event.inputs.fname_changelog }} for ${{ github.event.inputs.milestone_title }} release"
-        title: "Update ${{ github.event.inputs.fname_changelog }} for ${{ github.event.inputs.milestone_title }} release"
+        commit-message  : "Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release"
+        title: "Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release"
         milestone: "${{ github.event.inputs.milestone_title }}"
         body: |
-          Update ${{ github.event.inputs.fname_changelog }} for ${{ github.event.inputs.milestone_title }} release.
+          Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release.
           
           Carried out as a part of the [release](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release) checklist.
         delete-branch: true

--- a/.github/workflows/automate-changelog-PR.yml
+++ b/.github/workflows/automate-changelog-PR.yml
@@ -7,8 +7,11 @@ on:
         description: 'Changelog filename'
         required: true
         default: 'CHANGES.md'
+      milestone_number:
+        description: 'Milestone number (get this from the milestone URL)'
+        required: true
       milestone_title:
-        description: 'Milestone title'
+        description: 'Milestone title (e.g. 6.1)'
         required: true
       future_milestone_title:
         description: 'Next milestone title (used to update dev version.txt on master)'
@@ -45,7 +48,7 @@ jobs:
         branch: "bot/v${{ github.event.inputs.milestone_title }}"
         commit-message  : "Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release"
         title: "Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release"
-        milestone: "${{ github.event.inputs.milestone_title }}"
+        milestone: "${{ github.event.inputs.milestone_number }}"
         body: |
           Update ${{ github.event.inputs.fname_changelog }} and version.txt for ${{ github.event.inputs.milestone_title }} release.
           

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,9 +6,6 @@ on:
       milestone_title:
         description: 'Milestone title (this release)'
         required: true
-      future_milestone_title:
-        description: 'Milestone title (next release)'
-        required: true
   push:
     branches:
       - master


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR follows up on 2 past errors from previous runs of the workflow.

Please refer to the extended commit message of 751bd42d1c538d0007fdef80b97667cc1292173c for an investigation into why using the milestone title doesn't work for the `create-pull-request` GitHub Action.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Follows https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/eeabbe72f674d107109dd1a461b7e24151106ceb
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3968.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4160.
