### PR TITLE
Remove parent parts from `fname_out` to fix buggy `-o` behavior

### DIFF
--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -441,6 +441,7 @@ def propseg(img_input, options_dict):
         folder_output = os.path.abspath(arguments.ofolder)
     else:
         folder_output = str(pathlib.Path(fname_out).parent)
+        fname_out = pathlib.Path(fname_out).name
     if not os.path.isdir(folder_output) and os.path.exists(folder_output):
         logger.error("output directory %s is not a valid directory" % folder_output)
     if not os.path.exists(folder_output):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

With command:

```
sct_propseg -i ./t2.nii.gz -c t2 -o ./test/t2_seg.nii.gz
```

We see the following behavior:

- `-o` becomes `fname_out` (but isn't processed in any way to remove anything before the filename)
- `folder_output` is derived from `fname_out` using `str(pathlib.Path(fname_out).parent)`
- Then, `folder_output` is combined with the unprocessed `fname_out`, leading to `'test/./test/t2_seg.nii.gz'`

To fix this, we process `fname_out` to only use the actual filename, since subfolders are captured within `folder_output`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4167.
