### PR TITLE
Use pandas for `.csv` saving to correctly merge existing output metric columns

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -497,11 +497,6 @@ def save_df_to_csv(dataframe, fname_out):
     """
     Save .csv file of MSCC results.
     :param fname_out:
-    :param level: int: Level of compression.
-    :param metric: str: metric to perform normalization
-    :param metric_ratio: float:
-    :param metric_ratio_norm:
-    :param filename: str: input filename
     :return:
     """
     if os.path.isfile(fname_out):

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -507,7 +507,7 @@ def save_csv(fname_out, level, slices, metric, metric_ratio, metric_ratio_PAM50,
     """
     if not os.path.isfile(fname_out):
         with open(fname_out, 'w') as csvfile:
-            header = ['filename', 'compression_level', 'slice(I->S)', metric + '_ratio', metric + '_ratio_PAM50', metric + '_ratio_PAM50_normalized']
+            header = ['filename', 'compression_level', 'slice(I->S)', f'{metric}_ratio', f'{metric}_ratio_PAM50', f'{metric}_ratio_PAM50_normalized']
             writer = csv.DictWriter(csvfile, fieldnames=header)
             writer.writeheader()
     with open(fname_out, 'a') as csvfile:

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -512,7 +512,7 @@ def save_df_to_csv(dataframe, fname_out):
         dataframe = dataframe.groupby(
             [dataframe.iloc[:, 0], dataframe.iloc[:, 1], dataframe.iloc[:, 2]]
         ).max()  # Use max for a tiebreaker (this should never happen unless the user computes the same metric twice)
-    dataframe.to_csv(fname_out, index=False)
+    dataframe.to_csv(fname_out, na_rep='n/a', index=False)
 
 
 def main(argv: Sequence[str]):

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -189,8 +189,8 @@ def get_verterbral_level_from_slice(slices, df_metrics):
                              f"Check vertebral labeling file.")
     level_slice_dict = {}
     # TODO adjust for multiple slices for one compresssion (that can have multiple levels too)
-    #slices_combined = []
-    #for slice in slices:
+    # slices_combined = []
+    # for slice in slices:
     #    slices_same_compression = [slice_1 for slice_1 in slices if np.abs((slice - slice_1)) == 1]
     #    if slices_same_compression:
     #        if slices_same_compression[0] < slices_same_compression[1]:

--- a/testing/cli/test_cli_sct_compute_compression.py
+++ b/testing/cli/test_cli_sct_compute_compression.py
@@ -121,8 +121,8 @@ def test_sct_compute_compression_no_normalization(tmp_path, dummy_3d_mask_nib, d
         row = next(reader)
         assert float(row['compression_level']) == 5.0
         assert float(row['diameter_AP_ratio']) == pytest.approx(20.040803711692355)
-        assert row['diameter_AP_ratio_PAM50'] == ''
-        assert row['diameter_AP_ratio_PAM50_normalized'] == ''
+        assert row['diameter_AP_ratio_PAM50'] == 'n/a'
+        assert row['diameter_AP_ratio_PAM50_normalized'] == 'n/a'
 
 
 def test_sct_compute_compression(tmp_path, dummy_3d_mask_nib, dummy_3d_compression_label, dummy_3d_vert_label):

--- a/testing/cli/test_cli_sct_compute_compression.py
+++ b/testing/cli/test_cli_sct_compute_compression.py
@@ -130,6 +130,10 @@ def test_sct_compute_compression(tmp_path, dummy_3d_mask_nib, dummy_3d_compressi
     filename = str(tmp_path / 'tmp_file_out.csv')
     sct_compute_compression.main(argv=['-i', dummy_3d_mask_nib, '-l', dummy_3d_compression_label,
                                        '-vertfile', dummy_3d_vert_label, '-normalize-hc',  '1', '-o', filename])
+    # Run sct_compute_compression a second time with a different metric than the default
+    sct_compute_compression.main(argv=['-i', dummy_3d_mask_nib, '-l', dummy_3d_compression_label,
+                                       '-vertfile', dummy_3d_vert_label, '-normalize-hc',  '1', '-o', filename,
+                                       '-metric', 'area'])
     with open(filename, "r") as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         row = next(reader)
@@ -137,6 +141,12 @@ def test_sct_compute_compression(tmp_path, dummy_3d_mask_nib, dummy_3d_compressi
         assert float(row['diameter_AP_ratio']) == pytest.approx(20.040803711692355)
         assert float(row['diameter_AP_ratio_PAM50']) == pytest.approx(12.525502319807725)
         assert float(row['diameter_AP_ratio_PAM50_normalized']) == pytest.approx(16.985020560800656)
+        assert float(row['area_ratio']) == pytest.approx(19.999959045301974)
+        assert float(row['area_ratio_PAM50']) == pytest.approx(12.499982988595415)
+        assert float(row['area_ratio_PAM50_normalized']) == pytest.approx(20.45962624772345)
+        # Ensure that there isn't a duplicate appended row from running sct_compute_compression twice
+        with pytest.raises(StopIteration):
+            next(reader)
 
 
 def test_sct_compute_compression_sex_F(tmp_path, dummy_3d_mask_nib, dummy_3d_compression_label, dummy_3d_vert_label):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, the existing behavior for saving `sct_compute_compression` CSV files doesn't account for differing column names. So, if a user runs `sct_compute_compression` more than once with different metrics, new columns won't be created -- the data will be incorrectly appended to the existing columns.

So, this PR adds a test for that use-case, and then uses Pandas to correctly merge two different tables with different columns. We also use Pandas to combine rows that have the same filename/compression level/slice, eliminating any duplicate rows with `NaN` values.

((Side note: One day, I would like to use the exact same simplification on `aggregate_per_slice_or_level` too. See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4005#issuecomment-1398737874 for my thoughts.))

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4169.