### PR TITLE
Improvements of CLI output printed by the `sct_compute_compression`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -614,7 +614,7 @@ def main(argv: Sequence[str]):
     rows = []
     for idx in compressed_levels_dict.keys():
         level = list(compressed_levels_dict[idx].keys())[0]  # TODO change if more than one level
-        printv(f'\nCompression #{idx} at level {level}', verbose=verbose, type='info')
+        printv(f'\nCompression at level {int(level)}', verbose=verbose, type='info')
 
         # Compute metric ratio (non-normalized)
         slice_avg = list(compressed_levels_dict[idx].values())[0]

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -644,11 +644,11 @@ def main(argv: Sequence[str]):
 
         # Display results
         logger.debug(f'\nmetric_a = {metrics_patient[0]}, metric_b = {metrics_patient[1]}, metric_i = {metrics_patient[2]}')
-        printv(f'\n{arguments.metric}_ratio = {metric_ratio_result}', verbose=verbose, type='info')
+        printv(f'{arguments.metric}_ratio = {metric_ratio_result}', verbose=verbose, type='info')
         if arguments.normalize_hc:
-            logger.debug(f'\nPAM50: metric_a = {metrics_patient_PAM50[0]}, metric_b = {metrics_patient_PAM50[1]}, metric_i = {metrics_patient_PAM50[2]}')
-            printv(f'\n{arguments.metric}_ratio_PAM50 = {metric_ratio_PAM50_result}', verbose=verbose, type='info')
-            printv(f'\n{arguments.metric}_ratio_PAM50_normalized = {metric_ratio_norm_result}', verbose=verbose, type='info')
+            logger.debug(f'PAM50: metric_a = {metrics_patient_PAM50[0]}, metric_b = {metrics_patient_PAM50[1]}, metric_i = {metrics_patient_PAM50[2]}')
+            printv(f'{arguments.metric}_ratio_PAM50 = {metric_ratio_PAM50_result}', verbose=verbose, type='info')
+            printv(f'{arguments.metric}_ratio_PAM50_normalized = {metric_ratio_norm_result}', verbose=verbose, type='info')
 
     df_metric_ratios = pd.DataFrame(rows, columns=['filename', 'compression_level', 'slice(I->S)',
                                                    f'{arguments.metric}_ratio',

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -404,7 +404,6 @@ def get_slices_upper_lower_level_from_PAM50(compression_level_dict_PAM50, df_met
             max_slices.append(max(slices))
     level_below = np.argmin(min_slices)
     level_above = np.argmax(max_slices)
-    print('below:', level_below, 'above:', level_above)
     # Get slices to average at distance across the chosen extent for the level above all compressions
     zmin_above = int(max(list(compression_level_dict_PAM50[level_above].values())[0]) + distance/slice_thickness_PAM50)
     zmax_above = int(max(list(compression_level_dict_PAM50[level_above].values())[0]) + distance/slice_thickness_PAM50 + extent/slice_thickness_PAM50)

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -644,11 +644,11 @@ def main(argv: Sequence[str]):
 
         # Display results
         logger.debug(f'\nmetric_a = {metrics_patient[0]}, metric_b = {metrics_patient[1]}, metric_i = {metrics_patient[2]}')
-        printv(f'\n{metric} ratio = {metric_ratio_result}', verbose=verbose, type='info')
+        printv(f'\n{arguments.metric}_ratio = {metric_ratio_result}', verbose=verbose, type='info')
         if arguments.normalize_hc:
             logger.debug(f'\nPAM50: metric_a = {metrics_patient_PAM50[0]}, metric_b = {metrics_patient_PAM50[1]}, metric_i = {metrics_patient_PAM50[2]}')
-            printv(f'\n{metric} ratio norm = {metric_ratio_norm_result}', verbose=verbose, type='info')
-            printv(f'\n{metric} ratio PAM50 = {metric_ratio_PAM50_result}', verbose=verbose, type='info')
+            printv(f'\n{arguments.metric}_ratio_PAM50 = {metric_ratio_PAM50_result}', verbose=verbose, type='info')
+            printv(f'\n{arguments.metric}_ratio_PAM50_normalized = {metric_ratio_norm_result}', verbose=verbose, type='info')
 
     df_metric_ratios = pd.DataFrame(rows, columns=['filename', 'compression_level', 'slice(I->S)',
                                                    f'{arguments.metric}_ratio',


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR fixes minor stylistic issues for the CLI output printed by the `sct_compute_compression` function.

master branch:

```console
...

below: 3 above: 0

Compression #0 at level 3.0

MEAN(area) ratio = -12.303804931123953

MEAN(area) ratio norm = 7.17512630355076

MEAN(area) ratio PAM50 = -11.006326905780517

Compression #1 at level 4.0

MEAN(area) ratio = -5.492130816669349

MEAN(area) ratio norm = 17.477859636238293

MEAN(area) ratio PAM50 = -3.8011501206959952

Compression #2 at level 5.0

MEAN(area) ratio = -10.271278278493323

MEAN(area) ratio norm = 11.726811590094034

MEAN(area) ratio PAM50 = -8.010330837998868

Compression #3 at level 6.0

MEAN(area) ratio = 9.053832317696898

MEAN(area) ratio norm = 17.337087670044482

MEAN(area) ratio PAM50 = 9.38835116302329

Saved: sub-tokyoIngenia01_T2w_seg-manual_compression_metrics.csv
```

This PR:

```console
...

Compression at level 3
area_ratio = -12.303804931123953
area_ratio_PAM50 = -11.006326905780517
area_ratio_PAM50_normalized = 7.17512630355076

Compression at level 4
area_ratio = -5.492130816669349
area_ratio_PAM50 = -3.8011501206959952
area_ratio_PAM50_normalized = 17.477859636238293

Compression at level 5
area_ratio = -10.271278278493323
area_ratio_PAM50 = -8.010330837998868
area_ratio_PAM50_normalized = 11.726811590094034

Compression at level 6
area_ratio = 9.053832317696898
area_ratio_PAM50 = 9.38835116302329
area_ratio_PAM50_normalized = 17.337087670044482

Saved: sub-tokyoIngenia01_T2w_seg-manual_compression_metrics.csv
```

## Linked issues

Fixes: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4168
