### PR TITLE
Use the `pandas.DataFrame.combine_first` method

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 NEAR_ZERO_THRESHOLD = 1e-6
+INDEX_COLUMNS = ['filename', 'compression_level', 'slice(I->S)']
 
 
 # PARSER
@@ -500,14 +501,12 @@ def save_df_to_csv(dataframe, fname_out):
     :return:
     """
     if os.path.isfile(fname_out):
-        # Concatenate existing CSV file to the new CSV file
-        dataframe_old = pd.read_csv(fname_out)
-        dataframe = pd.concat([dataframe_old, dataframe], axis=0, ignore_index=True)
-        # Merge rows that have the same 'filename', 'compression_level', and 'slice(I->S)'
-        dataframe = dataframe.groupby(
-            [dataframe.iloc[:, 0], dataframe.iloc[:, 1], dataframe.iloc[:, 2]]
-        ).max()  # Use max for a tiebreaker (this should never happen unless the user computes the same metric twice)
-    dataframe.to_csv(fname_out, na_rep='n/a', index=False)
+        # Combine the data with the existing CSV file.
+        # Rows with the same (filename, compression_level, slice) triple are merged together.
+        # Metric values from the new dataframe take priority over old CSV file values.
+        dataframe_old = pd.read_csv(fname_out, index_col=INDEX_COLUMNS)
+        dataframe = dataframe.combine_first(dataframe_old)
+    dataframe.to_csv(fname_out, na_rep='n/a')
 
 
 def main(argv: Sequence[str]):
@@ -650,10 +649,12 @@ def main(argv: Sequence[str]):
             printv(f'\n{metric} ratio norm = {metric_ratio_norm_result}', verbose=verbose, type='info')
             printv(f'\n{metric} ratio PAM50 = {metric_ratio_PAM50_result}', verbose=verbose, type='info')
 
-    df_metric_ratios = pd.DataFrame(rows, columns=['filename', 'compression_level', 'slice(I->S)',
-                                                   f'{arguments.metric}_ratio',
-                                                   f'{arguments.metric}_ratio_PAM50',
-                                                   f'{arguments.metric}_ratio_PAM50_normalized'])
+    metric_columns = [
+        f'{arguments.metric}_ratio',
+        f'{arguments.metric}_ratio_PAM50',
+        f'{arguments.metric}_ratio_PAM50_normalized',
+    ]
+    df_metric_ratios = pd.DataFrame.from_records(rows, index=INDEX_COLUMNS, columns=INDEX_COLUMNS + metric_columns)
     save_df_to_csv(df_metric_ratios, fname_out)
     printv(f'\nSaved: {fname_out}')
 


### PR DESCRIPTION
This is a followup suggestion for #4172.

The Pandas builtin method [`combine_first`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.combine_first.html) does exactly what we want: the row and column indexes of the resulting DataFrame is the union of the two input DataFrames.