### PR TITLE
Gracefully handle infinity as well as NaN values in QC

### DIFF
--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -191,7 +191,7 @@ class Slice(object):
         invalid = ~valid
         if np.all(invalid):
             A.fill(0)
-        else:
+        elif np.any(invalid):
             A[invalid] = np.interp(
                 np.nonzero(invalid)[0],
                 np.nonzero(valid)[0],

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -183,21 +183,19 @@ class Slice(object):
         return matrix
 
     @staticmethod
-    def nan_fill(A):
-        """Interpolate NaN values with neighboring values in array (in-place)
-        If only NaNs, return an array of zeros.
+    def inf_nan_fill(A):
+        """Interpolate inf and NaN values with neighboring values in a 1D array, in-place.
+        If only inf and NaNs, fills the array with zeros.
         """
-        nans = np.isnan(A)
-        if ~np.any(nans):
-            return A
-        elif np.all(nans):
-            A[:] = np.zeros_like(A)
-            return A
-        xp = (~nans).ravel().nonzero()[0]
-        fp = A[~nans]
-        x = nans.ravel().nonzero()[0]
-        A[nans] = np.interp(x, xp, fp)
-        return A
+        valid = np.isfinite(A)
+        invalid = ~valid
+        if np.any(valid):
+            A[invalid] = np.interp(
+                np.nonzero(invalid)[0],
+                np.nonzero(valid)[0],
+                A[valid])
+        else:
+            A.fill(0)
 
     @abc.abstractmethod
     def get_slice(self, data, i):

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -229,12 +229,8 @@ class Slice(object):
         centers_y = np.zeros(nz)
         for i in range(nz):
             centers_x[i], centers_y[i] = center_of_mass(data[i, :, :])
-        try:
-            Slice.nan_fill(centers_x)
-            Slice.nan_fill(centers_y)
-        except ValueError as err:
-            logger.error("Axial center of the spinal cord is not found: %s", err)
-            raise
+        Slice.inf_nan_fill(centers_x)
+        Slice.inf_nan_fill(centers_y)
         return centers_x, centers_y
 
     @abc.abstractmethod

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -189,13 +189,13 @@ class Slice(object):
         """
         valid = np.isfinite(A)
         invalid = ~valid
-        if np.any(valid):
+        if np.all(invalid):
+            A.fill(0)
+        else:
             A[invalid] = np.interp(
                 np.nonzero(invalid)[0],
                 np.nonzero(valid)[0],
                 A[valid])
-        else:
-            A.fill(0)
 
     @abc.abstractmethod
     def get_slice(self, data, i):


### PR DESCRIPTION
Fixes #4173.

I'm not sure that this warrants an automated test?

From manually re-running the steps to reproduce the issue, the crash is gone. There's still a warning printed in the output (from `scipy.ndimage.center_of_mass`, which is maybe hard to avoid):

```
QcImage: layout with Axial slice
Compute center of mass at each slice
.../spinalcordtoolbox/python/sct/lib/python3.9/site-packages/scipy/ndimage/_measurements.py:1535:
RuntimeWarning: invalid value encountered in double_scalars
  results = [sum(input * grids[dir].astype(float), labels, index) / normalizer
.../spinalcordtoolbox/python/sct/lib/python3.9/site-packages/scipy/ndimage/_measurements.py:1535:
RuntimeWarning: divide by zero encountered in double_scalars
  results = [sum(input * grids[dir].astype(float), labels, index) / normalizer
```

However, the QC report image looks strange, so it may be worth investigating some more:

![Screenshot from 2023-08-10 17-12-55](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/928742/8dc4b97b-4cc0-4f3f-87aa-1ceb7b4eea96)