### PR TITLE
Fix `IndexError` during straightening if `-dest` image is shorter than centerline image (`-s`)

### DIFF
--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -478,6 +478,9 @@ class Centerline:
             else:
                 return self.get_closest_to_relative_position(vertebral_level=vertebral_level, relative_position=relative_position)
 
+        if backup_index >= backup_centerline.number_of_points:
+            return None
+
         position_reference_backup = backup_centerline.dist_points[backup_centerline.index_disc[backup_centerline.regions_labels[label]]]
         position_reference_self = self.dist_points[self.index_disc[self.regions_labels[label]]]
         relative_position_from_reference_backup = backup_centerline.dist_points[backup_index] - position_reference_backup


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

https://github.com/neuropoly/template/issues/60 describes a case where the `-dest` image is smaller than the input centerline image. (For context, the template generation pipeline allows you to specify a `last_disc` config setting to exclude lower discs from the `-dest` image.)

The trace of `sct_straighten_spinalcord` goes like this:

- `-dest` becomes `centerline_reference_filename` which becomes the `centerline_straight` variable
- `-s` becomes `centerline_file` which becomes the `centerline` variable
- During the "[create look-up table curved to straight](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/f5de501d3fe98c53861b54c60b9f5f5b96732772/spinalcordtoolbox/straightening.py#L383-L393)" portion of the straightening, we:
    - Loop through the points of `centerline`
    - Get the closest index in `centerline_straight` using relative positions
    - If that fails, we fallback to absolute positions, directly accessing `centerline_straight` using the index from `centerline`
- Thus, we get an IndexError when `centerline_straight` is shorter than `centerline` (i.e. `-dest` is shorter than `-s`)

To fix this, I applied the following solution:

> It looks like the outer loop [already has a condition](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/f5de501d3fe98c53861b54c60b9f5f5b96732772/spinalcordtoolbox/straightening.py#L387-L393) for when the return value from `get_closest_to_absolute_position` is equal to `None`. So, adding a simple check and returning `None` is the first thing that came to mind

I think this is a pretty safe + minimal change, and shouldn't have any effect on existing behavior besides preventing the `IndexError`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/neuropoly/template/issues/60.