### PR TITLE
Fix QC for soft segmentations that have light regions close to `1.0` (e.g. `0.999`)

### DIFF
--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -60,7 +60,7 @@ class Slice(object):
                 # Check if image is a segmentation (binary or soft) by making sure:
                 # - 0/1 are the two most common voxel values
                 # - 0/1 account for >95% of voxels (to allow for some soft voxels)
-                unique, counts = np.unique(img.data, return_counts=True)
+                unique, counts = np.unique(np.round(img.data, decimals=1), return_counts=True)
                 unique, counts = unique[np.argsort(counts)[::-1]], counts[np.argsort(counts)[::-1]]  # Sort by counts
                 binary_most_common = set(unique[0:2].astype(float)) == {0.0, 1.0}
                 binary_percentage = np.sum(counts[0:2]) / np.sum(counts)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4133, we added a heuristic-based check for segmentations by making sure the values `0.0` or `1.0` are the most common in the image.

However, some softsegs have light regions that are not exactly `1.0`:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/ef513151-d330-4bc0-88a4-d170151705ce)

So, this PR rounds the segmentation values to 1 decimal place, which ensure that values `>0.95` and `<0.05` must be the most common values in the image, rather than exactly `1.0` and `0.0`.

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/7df8c746-0bc2-473d-a799-3a874e001db3)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4178.
Fixes QC issues in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4189.
