### PR TITLE
Speed up `-remove-reference` by removing unnecessary iteration

### DIFF
--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -358,12 +358,13 @@ def remove_missing_labels(img: Image, ref: Image):
     :param ref: reference image
     :returns: image with labels missing from reference removed
     """
+    # Get all label values in the reference image
+    ref_values = set(coord.value for coord in ref.getNonZeroCoordinates())
+    # Transfer only the source labels that match values present in the reference image
     out = zeros_like(img)
-
     for src_coord in img.getNonZeroCoordinates():
-        for ref_coord in ref.getNonZeroCoordinates():
-            if src_coord.value == ref_coord.value:
-                out.data[src_coord.x, src_coord.y, src_coord.z] = src_coord.value
+        if src_coord.value in ref_values:
+            out.data[src_coord.x, src_coord.y, src_coord.z] = src_coord.value
     return out
 
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a very simple optimization:

- **Before:** Iterate through all possible "src-ref" pairs of labels, comparing their values (`O(n * m)`)
- **After:** Pre-fetch the set of ref labels, then only iterate through the "src" labels (`O(n + m)`)

This works because we only ever access the `value` from the ref labels -- we don't care about the actual coordinates of the ref labels. So, there was no need to compare all of the individual `ref_coord` objects!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4191.
