### PR TITLE
Add checks for empty arrays post-segmentation

### DIFF
--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -19,6 +19,7 @@ from spinalcordtoolbox.deepseg_.postprocessing import post_processing_volume_wis
 from spinalcordtoolbox.image import Image, empty_like, change_type, zeros_like, add_suffix, concat_data, split_img_data
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.utils import sct_dir_local_path, TempFolder
+from spinalcordtoolbox.types import EmptyArrayError
 
 # Thresholds to apply to binarize segmentations from the output of the 2D CNN. These thresholds were obtained by
 # minimizing the standard deviation of cross-sectional area across contrasts. For more details, see:
@@ -523,8 +524,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
 
     # Check for empty array post-resampling, but pre-binarization
     if not np.any(im_seg_r.data):
-        raise ValueError("Empty array: Spinal cord not detected. Please make sure that there is sufficient contrast "
-                         "between the spinal cord and CSF to ensure good results.")
+        raise EmptyArrayError("Spinal cord not detected. Please make sure that there is sufficient contrast "
+                              "between the spinal cord and CSF to ensure good results.")
 
     # Binarize the resampled image (except for soft segmentation, defined by threshold_seg=-1)
     if threshold_seg >= 0:
@@ -535,8 +536,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         if not np.any(im_seg_r.data):
             # TODO: Address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4198 so that we can instruct
             #       users to lower the threshold using the `-thr` argument.
-            raise ValueError(f"Empty array due to binarization with threshold '{0.5}'. "
-                             f"(Values before binarization: min: {val_min}, max: {val_max})")
+            raise EmptyArrayError(f"Binarization with threshold '{0.5}' resulted in empty array. "
+                                  f"(Values before binarization: min: {val_min}, max: {val_max})")
 
     # post processing step to z_regularized
     im_seg_r_postproc = post_processing_volume_wise(im_seg_r)

--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -521,10 +521,22 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     if ctr_algo == 'viewer':  # for debugging
         im_labels_viewer.save(add_suffix(fname_orient, '_labels-viewer'))
 
+    # Check for empty array post-resampling, but pre-binarization
+    if not np.any(im_seg_r.data):
+        raise ValueError("Empty array: Spinal cord not detected. Please make sure that there is sufficient contrast "
+                         "between the spinal cord and CSF to ensure good results.")
+
     # Binarize the resampled image (except for soft segmentation, defined by threshold_seg=-1)
     if threshold_seg >= 0:
         logger.info("Binarizing the resampled segmentation...")
+        val_min, val_max = im_seg_r.data.min, im_seg_r.data.max
         im_seg_r.data = (im_seg_r.data > 0.5).astype(np.uint8)
+        # Check for empty array post-binarization to make sure that the threshold didn't wipe out the segmentation.
+        if not np.any(im_seg_r.data):
+            # TODO: Address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4198 so that we can instruct
+            #       users to lower the threshold using the `-thr` argument.
+            raise ValueError(f"Empty array due to binarization with threshold '{0.5}'. "
+                             f"(Values before binarization: min: {val_min}, max: {val_max})")
 
     # post processing step to z_regularized
     im_seg_r_postproc = post_processing_volume_wise(im_seg_r)

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -15,6 +15,7 @@ from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import Image, check_dim
 from spinalcordtoolbox.deepseg_.sc import deep_segmentation_spinalcord
 from spinalcordtoolbox.reports.qc import generate_qc
+from spinalcordtoolbox.types import EmptyArrayError
 
 
 def get_parser():
@@ -184,10 +185,15 @@ def main(argv: Sequence[str]):
 
     im_image = Image(fname_image)
     # note: below we pass im_image.copy() otherwise the field absolutepath becomes None after execution of this function
-    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp = \
-        deep_segmentation_spinalcord(im_image.copy(), contrast_type, ctr_algo=ctr_algo,
-                                     ctr_file=manual_centerline_fname, brain_bool=brain_bool, kernel_size=kernel_size,
-                                     threshold_seg=threshold, remove_temp_files=remove_temp_files, verbose=verbose)
+    try:
+        im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp = \
+            deep_segmentation_spinalcord(im_image.copy(), contrast_type, ctr_algo=ctr_algo,
+                                         ctr_file=manual_centerline_fname, brain_bool=brain_bool,
+                                         kernel_size=kernel_size, threshold_seg=threshold,
+                                         remove_temp_files=remove_temp_files, verbose=verbose)
+    except EmptyArrayError:
+        printv(f"Spinal cord could not be detected (empty array) for {fname_image}", 1, 'error')
+        sys.exit(1)
 
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, fname_out))

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -191,9 +191,9 @@ def main(argv: Sequence[str]):
                                          ctr_file=manual_centerline_fname, brain_bool=brain_bool,
                                          kernel_size=kernel_size, threshold_seg=threshold,
                                          remove_temp_files=remove_temp_files, verbose=verbose)
-    except EmptyArrayError:
-        printv(f"Spinal cord could not be detected (empty array) for {fname_image}", 1, 'error')
-        sys.exit(1)
+    except EmptyArrayError as e:
+        printv(f"Spinal cord could not be detected for {fname_image}\n"
+               f"    {e.__class__.__name__}: '{e}'", 1, 'error')
 
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, fname_out))

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -15,7 +15,8 @@ import numpy as np
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.vertebrae.core import (
     get_z_and_disc_values_from_label, vertebral_detection, expand_labels,
-    crop_labels, label_vert, EmptyArrayError, MissingDiscsError)
+    crop_labels, label_vert)
+from spinalcordtoolbox.types import EmptyArrayError, MissingDiscsError
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -356,9 +356,9 @@ def main(argv: Sequence[str]):
                                 '-o', 'labeldisc_straight.nii.gz', '-x', 'label', '-v', '0'])
         try:
             label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
-        except MissingDiscsError:
-            printv(f"No disc labels found in straightened version of discfile {fname_disc}", 1, 'error')
-            sys.exit(1)
+        except MissingDiscsError as e:
+            printv(f"No disc labels found in straightened version of discfile {fname_disc}\n"
+                   f"    {e.__class__.__name__}: '{e}'", 1, 'error')
 
     else:
         printv('\nCreate label to identify disc...', verbose)

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -1,5 +1,5 @@
 """
-Coordinates and Centerline
+Custom object and error types.
 
 Copyright (c) 2013 Polytechnique Montreal <www.neuro.polymtl.ca>
 License: see the file LICENSE
@@ -559,3 +559,11 @@ class Centerline:
         plt.xlabel('z')
         plt.ylabel('y')
         plt.show()
+
+
+class EmptyArrayError(ValueError):
+    """Custom exception to distinguish between general SciPy ValueErrors."""
+
+
+class MissingDiscsError(ValueError):
+    """Custom exception to indicate that no disc labels were found."""

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -17,12 +17,9 @@ from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.metadata import get_file_label
 from spinalcordtoolbox.math import dilate, mutual_information
 from spinalcordtoolbox.centerline.core import get_centerline
+from spinalcordtoolbox.types import MissingDiscsError, EmptyArrayError
 
 logger = logging.getLogger(__name__)
-
-
-class MissingDiscsError(ValueError):
-    """Custom exception to indicate that no disc labels were found."""
 
 
 def label_vert(fname_seg, fname_label):
@@ -254,10 +251,6 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     discs = list(zip(list_disc_z, list_disc_value))
     label_segmentation(fname_seg, discs)
     label_discs(fname_seg, discs)
-
-
-class EmptyArrayError(ValueError):
-    """Custom exception to distinguish between general SciPy ValueErrors."""
 
 
 def center_of_mass(x):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR provides more intuitive feedback when `sct_deepseg_sc` produces an empty array. This avoids a more unintuitive error later on in the postprocessing function.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4197.