### PR TITLE
Check whether the provided discfile is empty

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -353,7 +353,11 @@ def main(argv: Sequence[str]):
         printv('\nApply straightening to disc labels...', verbose)
         sct_apply_transfo.main(['-i', fname_disc, '-d', 'data_straightr.nii', '-w', 'warp_curve2straight.nii.gz',
                                 '-o', 'labeldisc_straight.nii.gz', '-x', 'label', '-v', '0'])
-        label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
+        try:
+            label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
+        except ValueError:
+            printv(f"No disc labels found in straightened version of discfile {fname_disc}", 1, 'error')
+            sys.exit(1)
 
     else:
         printv('\nCreate label to identify disc...', verbose)

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -15,7 +15,7 @@ import numpy as np
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.vertebrae.core import (
     get_z_and_disc_values_from_label, vertebral_detection, expand_labels,
-    crop_labels, label_vert, EmptyArrayError)
+    crop_labels, label_vert, EmptyArrayError, MissingDiscsError)
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
@@ -355,7 +355,7 @@ def main(argv: Sequence[str]):
                                 '-o', 'labeldisc_straight.nii.gz', '-x', 'label', '-v', '0'])
         try:
             label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
-        except ValueError:
+        except MissingDiscsError:
             printv(f"No disc labels found in straightened version of discfile {fname_disc}", 1, 'error')
             sys.exit(1)
 

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -31,6 +31,8 @@ def label_vert(fname_seg, fname_label):
     """
     # retrieve all labels
     coord_labels = Image(fname_label).change_orientation("RPI").getNonZeroCoordinates()
+    if not coord_labels:
+        raise ValueError(f'No disc labels present in file {fname_label}')
     # '-1' to use the convention "disc labelvalue=3 ==> disc C2/C3"
     discs = [(cl.z, cl.value - 1) for cl in reversed(coord_labels)]
     discs.sort(reverse=True)

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -21,6 +21,10 @@ from spinalcordtoolbox.centerline.core import get_centerline
 logger = logging.getLogger(__name__)
 
 
+class MissingDiscsError(ValueError):
+    """Custom exception to indicate that no disc labels were found."""
+
+
 def label_vert(fname_seg, fname_label):
     """
     Label segmentation using vertebral labeling information. No orientation expected.
@@ -32,7 +36,7 @@ def label_vert(fname_seg, fname_label):
     # retrieve all labels
     coord_labels = Image(fname_label).change_orientation("RPI").getNonZeroCoordinates()
     if not coord_labels:
-        raise ValueError(f'No disc labels present in file {fname_label}')
+        raise MissingDiscsError(f'No disc labels present in file {fname_label}')
     # '-1' to use the convention "disc labelvalue=3 ==> disc C2/C3"
     discs = [(cl.z, cl.value - 1) for cl in reversed(coord_labels)]
     discs.sort(reverse=True)
@@ -254,7 +258,6 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
 
 class EmptyArrayError(ValueError):
     """Custom exception to distinguish between general SciPy ValueErrors."""
-    pass
 
 
 def center_of_mass(x):


### PR DESCRIPTION
Or, conceivably, whether it was made empty by straightening. If/when that happens, the files generated by sct_label_vertebrae are empty and useless, so we should alert the user instead of silently failing.

Fixes #4174.

Manually tested using the reproduction steps from the issue:
```
$ sct_label_vertebrae -i t2.nii.gz -s t2_seg.nii.gz -discfile labels.nii.gz -c t2

--
Spinal Cord Toolbox (git-mgp/empty-discfile-c9dc5e173ffdc6a06d5092cf629308c6ef5c1a79*)

sct_label_vertebrae -i t2.nii.gz -s t2_seg.nii.gz -discfile labels.nii.gz -c t2
--

Creating temporary folder (/tmp/sct_2023-08-17_14-23-00_label-vertebrae_5wp4u5nc)

Copying input data to tmp folder...

Straighten spinal cord...
Reusing existing warping field which seems to be valid
cp /tmp/tmp.PjWfschWY3/straightening.cache straightening.cache
cp /tmp/tmp.PjWfschWY3/warp_curve2straight.nii.gz warp_curve2straight.nii.gz
cp /tmp/tmp.PjWfschWY3/warp_straight2curve.nii.gz warp_straight2curve.nii.gz
cp /tmp/tmp.PjWfschWY3/straight_ref.nii.gz straight_ref.nii.gz
/home/mguaypaq/neuropoly/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i data.nii -o data_straight.nii -t warp_curve2straight.nii.gz -r straight_ref.nii.gz -n 'BSpline[3]' # in /tmp/sct_2023-08-17_14-23-00_label-vertebrae_5wp4u5nc

Resample to 0.5mm isotropic...
load data...

Apply straightening to segmentation...
/home/mguaypaq/neuropoly/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i segmentation.nii -o segmentation_straight.nii -t warp_curve2straight.nii.gz -r data_straightr.nii -n Linear # in /tmp/sct_2023-08-17_14-23-00_label-vertebrae_5wp4u5nc
File /tmp/sct_2023-08-17_14-23-00_label-vertebrae_5wp4u5nc/segmentation_straight.nii already exists. Will overwrite it.

Apply straightening to disc labels...

Dilate labels before warping...
Creating temporary folder (/tmp/sct_2023-08-17_14-23-02_apply-transfo-3d-label_3wqyy26t)
/home/mguaypaq/neuropoly/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i /tmp/sct_2023-08-17_14-23-02_apply-transfo-3d-label_3wqyy26t/dilated_data.nii -o labeldisc_straight.nii.gz -t warp_curve2straight.nii.gz -r data_straightr.nii -n NearestNeighbor # in /tmp/sct_2023-08-17_14-23-00_label-vertebrae_5wp4u5nc

Take the center of mass of each registered dilated labels...
File labeldisc_straight.nii.gz already exists. Will overwrite it.
No disc labels found in straightened version of discfile /tmp/tmp.PjWfschWY3/labels.nii.gz
```