### PR TITLE
Raise error if `sct_run_batch` config file has wrong suffix

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -347,8 +347,10 @@ def main(argv: Sequence[str]):
             _, ext = os.path.splitext(arguments.config)
             if ext == '.json':
                 config = json.load(conf)
-            if ext == '.yml' or ext == '.yaml':
+            elif ext == '.yml' or ext == '.yaml':
                 config = yaml.load(conf, Loader=yaml.Loader)
+            else:
+                raise ValueError('Unrecognized configuration file type: {}'.format(ext))
 
         # Warn people if they're overriding their config file
         if len(argv) > 2:


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

When working with the `sct_run_batch` script, I incorrectly defined the suffix of the config file to `.sh`. The error raised by the `sct_run_batch` script was not very specific. Thus, I added an error raise if the config file is not YML or JSON.

`master` branch:

```
$ sct_run_batch -config config.sh

--
Spinal Cord Toolbox (git-master-d6aeaef52466129b5f24a56fa250403839bd0166)

sct_run_batch -config config.sh
--

configuring
Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_run_batch.py", line 597, in <module>
    main(sys.argv[1:])
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_run_batch.py", line 359, in main
    config_keys = set(config.keys())
UnboundLocalError: local variable 'config' referenced before assignment
```

`jv/raise_error_if_sct_run_batch_config_has_wrong_suffix` branch:

```
$ sct_run_batch -config config.sh

--
Spinal Cord Toolbox (git-master-d6aeaef52466129b5f24a56fa250403839bd0166*)

sct_run_batch -config config.sh
--

configuring
Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_run_batch.py", line 599, in <module>
    main(sys.argv[1:])
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_run_batch.py", line 353, in main
    raise ValueError('Unrecognized configuration file type: {}'.format(ext))
ValueError: Unrecognized configuration file type: .sh
```




