### PR TITLE
Fix distorted registration due to straightening bug in `get_closest_to_absolute`

### DIFF
--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -384,9 +384,9 @@ class SpinalCordStraightener(object):
             for index in range(centerline.number_of_points):
                 disc_label = centerline.l_points[index]
                 relative_position = centerline.dist_points_rel[index]
-                idx_closest = centerline_straight.get_closest_to_absolute_position(disc_label, relative_position,
-                                                                                   backup_index=index,
-                                                                                   backup_centerline=centerline_straight)
+                idx_closest = centerline_straight.get_closest_index(disc_label, relative_position,
+                                                                    backup_index=index,
+                                                                    backup_centerline=centerline_straight)
                 if idx_closest is not None:
                     lookup_curved2straight[index] = idx_closest
                 else:
@@ -408,9 +408,9 @@ class SpinalCordStraightener(object):
             for index in range(centerline_straight.number_of_points):
                 disc_label = centerline_straight.l_points[index]
                 relative_position = centerline_straight.dist_points_rel[index]
-                idx_closest = centerline.get_closest_to_absolute_position(disc_label, relative_position,
-                                                                          backup_index=index,
-                                                                          backup_centerline=centerline_straight)
+                idx_closest = centerline.get_closest_index(disc_label, relative_position,
+                                                           backup_index=index,
+                                                           backup_centerline=centerline_straight)
                 if idx_closest is not None:
                     lookup_straight2curved[index] = idx_closest
         for p in range(0, len(lookup_straight2curved) // 2):

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -386,7 +386,7 @@ class SpinalCordStraightener(object):
                 relative_position = centerline.dist_points_rel[index]
                 idx_closest = centerline_straight.get_closest_index(disc_label, relative_position,
                                                                     backup_index=index,
-                                                                    backup_centerline=centerline_straight)
+                                                                    backup_centerline=centerline)
                 if idx_closest is not None:
                     lookup_curved2straight[index] = idx_closest
                 else:

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -459,7 +459,7 @@ class Centerline:
         elif vertebral_level == 0:  # level == 0 --> above the C1 vertebral level
             vertebral_index = -1    # so, ensure index is always outside C1 index
         else:
-            raise ValueError(f"vertebral_index must be a level string (C1, C2, C3...) or 0, but got {vertebral_level}.")
+            raise ValueError(f"vertebral_level must be a level string (C1, C2, C3...) or 0, but got {vertebral_level}.")
 
         # If the vertebral level is within the centerline, compute the closest index using relative position
         if self.list_labels.index(self.first_label) <= vertebral_index < self.list_labels.index(self.last_label):

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -500,9 +500,6 @@ class Centerline:
         :backup_index: the index of the desired slice, in the 'backup_centerline' space.
         :backup_centerline: an alternate centerline that contains both 'reference_level' and the 'backup_index'
         """
-        if backup_index >= backup_centerline.number_of_points:
-            return None
-
         # Get the slice index of the reference vertebral level within the backup centerline
         backup_index_reference = backup_centerline.index_disc[reference_level]
 

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -470,7 +470,8 @@ class Centerline:
         else:
             if vertebral_index < self.list_labels.index(self.first_label):
                 label = self.first_label
-            elif vertebral_index >= self.list_labels.index(self.last_label):
+            else:
+                assert vertebral_index >= self.list_labels.index(self.last_label)
                 label = self.last_label
             closest_centerline_level = self.regions_labels[label]
             closest_index = self.get_closest_to_absolute_position(closest_centerline_level,


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

#4085 describes a registration issue where the top of the registered template image appears buggy/incorrect. The investigation in that issue is long and complex, but the root cause and its fix are quite simple!

- We pass the the wrong `centerline` object to the `backup_centerline` parameter of the `get_closest_index` function. (065afabf9f2ded39861af7d628bcfd851f817a59)

This bug was also the _actual_ cause of https://github.com/neuropoly/template/issues/60, meaning that we can remove the workaround from #4192.

> **Note**: During my investigation, I made two refactoring commits related to #4075, which helped make the `get_closest_index` functions easier to understand. While not strictly necessary for this PR, I think they'll help with future maintainability, and should hopefully make this PR easier to understand and review.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4085. 
Fixes https://github.com/neuropoly/template/issues/60.
Reverts #4192.
