### PR TITLE
`sct_run_batch` - add note that `~` should not be used in paths passed using the `-script-args` arg

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -133,8 +133,9 @@ def get_parser():
                              'For example \'sct_run_batch -path-data data/ -script process_data.sh '
                              '-script-args "ARG1 ARG2"\'.\n'
                              'The arguments are retrieved by a script as \'${2}\', \'${3}\', etc.\n'
-                             'Note that \'${1}\' is reserved for the subject folder name, which is retrieved '
-                             'automatically.')
+                             'Note: \'${1}\' is reserved for the subject folder name, which is retrieved '
+                             'automatically.\n'
+                             'Note: Do not use \'~\' in the path. Use \'${HOME}\' instead.')
     parser.add_argument('-email-to',
                         help='Optional email address where sct_run_batch can send an alert on completion of the '
                         'batch processing.')


### PR DESCRIPTION
This PR is just a very minor clarification of the `sct_run_batch` `-script-args` arg.

@naga-karthik encountered errors when using `"~"`, `"${HOME}"` fixed the issues. The reason is that the quotation marks in `"~"` prevent tilde expansion.