### PR TITLE
Raise exception if sform/qform don't match during registation

### DIFF
--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -406,12 +406,16 @@ def main(argv: Sequence[str]):
 
     # copy files to temporary folder
     printv('\nCopying input data to tmp folder and convert to nii...', verbose)
-    Image(fname_data).save(os.path.join(path_tmp, ftmp_data))
-    Image(fname_seg).save(os.path.join(path_tmp, ftmp_seg))
-    Image(fname_landmarks).save(os.path.join(path_tmp, ftmp_label))
-    Image(fname_template).save(os.path.join(path_tmp, ftmp_template))
-    Image(fname_template_seg).save(os.path.join(path_tmp, ftmp_template_seg))
-    Image(fname_template_labeling).save(os.path.join(path_tmp, ftmp_template_label))
+    try:
+        Image(fname_data, check_sform=True).save(os.path.join(path_tmp, ftmp_data))
+        Image(fname_seg, check_sform=True).save(os.path.join(path_tmp, ftmp_seg))
+        Image(fname_landmarks, check_sform=True).save(os.path.join(path_tmp, ftmp_label))
+        Image(fname_template, check_sform=True).save(os.path.join(path_tmp, ftmp_template))
+        Image(fname_template_seg, check_sform=True).save(os.path.join(path_tmp, ftmp_template_seg))
+        Image(fname_template_labeling, check_sform=True).save(os.path.join(path_tmp, ftmp_template_label))
+    except ValueError as e:
+        printv("\nImages could not be saved to temporary folder. Aborting registration.\n"
+               f"    {e.__class__.__name__}: '{e}'", 1, 'error')
 
     # go to tmp folder
     curdir = os.getcwd()

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -111,3 +111,17 @@ def test_sct_register_to_template_dice_coefficient_against_groundtruth(fname_gt,
     im_template_seg = Image(fname_gt)
     dice_anat2template = compute_dice(im_seg_reg, im_template_seg, mode='3d', zboundaries=True)
     assert dice_anat2template > dice_threshold
+
+
+def test_sct_register_to_template_mismatched_xforms(tmp_path, capsys):
+    fname_mismatch = str(tmp_path / "t2_mismatched.nii.gz")
+    im_in = Image(sct_test_path('t2', 't2.nii.gz'))
+    qform = im_in.header.get_qform()
+    qform[1, 3] += 10
+    im_in.header.set_qform(qform)
+    im_in.save(fname_mismatch)
+    with pytest.raises(SystemExit):
+        sct_register_to_template.main(argv=['-i', fname_mismatch,
+                                            '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                            '-l', sct_test_path('t2', 'labels.nii.gz')])
+    assert "Image sform does not match qform" in capsys.readouterr().out


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR adds a test to cover the situation described in #4184 (mismatched qform/sform in input anat image). The command in the test should fail to raise an exception on `master`, but 626dd733b419c2ac3870a836c58bf02509f1aa5e should cause the test to pass.

There is more work that could be done (e.g. papering over the mismatch ourselves in `sct_register_to_template`), but I think for now, I want to leave that for #3283, as discussed in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4184#issuecomment-1670042547.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4184.
