### PR TITLE
Migrate old ReadTheDocs settings to `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,18 +8,26 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
+      # This python version needs to be compatible with SCT, see setup.py
       python: "3.9"
-
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: documentation/source/conf.py
-  fail_on_warning: true
 
 python:
   install:
     - requirements: requirements.txt
-    - method: pip
-      path: .
+    # Install SCT itself
+    - path: .
       extra_requirements:
         - docs
+# This file is just a duplicate of the .[docs] requirements specified
+# in the previous point (see setup.py), so it's not necessary:
 #    - requirements: documentation/source/requirements.txt
+
+# The build happens in the documentation/source/ directory
+sphinx:
+  configuration: documentation/source/conf.py
+  fail_on_warning: true
+
+# Other formats to produce, in addition to html
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
Fixes #4205.

Main changes:
- Cosmetic: renamed `.readthedocs.yml` to `.yaml` extension, to match the ReadTheDocs interface and docs.
- Cosmetic: added some explanatory comments.
- Functional: re-enabled pdf and epub builds (ignored options from the [project settings](https://readthedocs.org/dashboard/spinalcordtoolbox/advanced/)).