### PR TITLE
Add start date information to the logs

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -569,7 +569,7 @@ def main(argv: Sequence[str]):
     # Display timing
     duration = end - start
     timing_message = ('Started: {} | Ended: {} | Duration: {}\n'.format(
-        start.strftime('%Hh%Mm%Ss'),
+        start.strftime('%F %Hh%Mm%Ss'),
         end.strftime('%Hh%Mm%Ss'),
         (datetime.datetime.utcfromtimestamp(0) + duration).strftime('%Hh%Mm%Ss')))
     print(timing_message)


### PR DESCRIPTION
Fixes #4216, with only 3 extra characters :wink:

From the manual page for `strftime`, the added date information is:
```
       %F     Equivalent to %Y-%m-%d (the ISO 8601 date format). (C99)

       %Y     The  year  as a decimal number including the century.  (The %EY con‐
              version specification corresponds to the full alternative year  rep‐
              resentation.)  (Calculated from tm_year)

       %m     The month as a decimal number (range 01 to  12).   (Calculated  from
              tm_mon.)

       %d     The  day of the month as a decimal number (range 01 to 31).  (Calcu‐
              lated from tm_mday.)
```