### PR TITLE
Simplify lesion volume computation

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -99,7 +99,7 @@ def get_parser():
     return parser
 
 
-class AnalyzeLeion:
+class AnalyzeLesion:
     def __init__(self, fname_mask, fname_sc, fname_ref, path_template, path_ofolder, verbose):
         self.fname_mask = fname_mask
 
@@ -617,12 +617,12 @@ def main(argv: Sequence[str]):
         rm_tmp = True
 
     # create the Lesion constructor
-    lesion_obj = AnalyzeLeion(fname_mask=fname_mask,
-                              fname_sc=fname_sc,
-                              fname_ref=fname_ref,
-                              path_template=path_template,
-                              path_ofolder=path_results,
-                              verbose=verbose)
+    lesion_obj = AnalyzeLesion(fname_mask=fname_mask,
+                               fname_sc=fname_sc,
+                               fname_ref=fname_ref,
+                               path_template=path_template,
+                               path_ofolder=path_results,
+                               verbose=verbose)
 
     # run the analyze
     lesion_obj.analyze()

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -140,9 +140,6 @@ class AnalyzeLesion:
         # orientation of the input image
         self.orientation = None
 
-        # volume object
-        self.volumes = None
-
         # initialization of proportion measures, related to registrated atlas
         if self.path_template is not None:
             self.path_atlas = os.path.join(self.path_template, "atlas")
@@ -267,12 +264,9 @@ class AnalyzeLesion:
         """
         Measure the volume of the lesion
         """
-        for zz in range(im_data.shape[2]):
-            self.volumes[zz, idx - 1] = np.sum(im_data[:, :, zz]) * p_lst[0] * p_lst[1] * p_lst[2]
-
-        vol_tot_cur = np.sum(self.volumes[:, idx - 1])
-        self.measure_pd.loc[idx, 'volume [mm3]'] = vol_tot_cur
-        printv('  Volume : ' + str(np.round(vol_tot_cur, 2)) + ' mm^3', self.verbose, type='info')
+        volume = np.sum(im_data) * p_lst[0] * p_lst[1] * p_lst[2]
+        self.measure_pd.loc[idx, 'volume [mm3]'] = volume
+        printv(f'  Volume : {round(volume, 2)} mm^3', self.verbose, type='info')
 
     def _measure_axial_damage_ratio(self, im_data, p_lst, idx):
         """
@@ -458,8 +452,6 @@ class AnalyzeLesion:
                 img_cur_copy = img_cur.copy()
                 atlas_data_dct[tract_id] = img_cur_copy.data
                 del img_cur
-
-        self.volumes = np.zeros((im_lesion.dim[2], len(label_lst)))
 
         # iteration across each lesion to measure statistics
         for lesion_label in label_lst:


### PR DESCRIPTION
Fixes #4214.

The `self.volumes` array was only written, never read by anyone else, so there's no need to have it.

And once it's gone, there's no need to sum each slice first, then sum over the slices; we can just sum the whole array at once.