### PR TITLE
Fix `ValueError` by passing a tuple to `color=` instead of a numpy array

### DIFF
--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -132,7 +132,7 @@ def main(argv: Sequence[str]):
         # skip b=0
         if unique_bval < BZERO_THRESH:
             continue
-        shell_colors[unique_bval] = list(next(colors))
+        shell_colors[unique_bval] = tuple(next(colors))
 
     # Get total number of directions
     n_dir = len(x)

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -132,7 +132,7 @@ def main(argv: Sequence[str]):
         # skip b=0
         if unique_bval < BZERO_THRESH:
             continue
-        shell_colors[unique_bval] = next(colors)
+        shell_colors[unique_bval] = list(next(colors))
 
     # Get total number of directions
     n_dir = len(x)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Previously, we would create a dict of [1,4] numpy arrays representing RGB colors + A (transparency) for each unique bval. Due to a recent matplotlib update, though, using a numpy array causes an unexpected ValueError. (https://github.com/matplotlib/matplotlib/issues/26821)

> This error is what's causing the current CI failures across recent PRs.

Since a tuple of size [4] results in the exact same functionality, we can bypass the error by storing tuple-based colors instead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4220.
