### PR TITLE
Temporarily pin `onnxruntime` to <1.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,8 @@ nilearn
 numpy<1.24
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
-onnxruntime>=1.7.0
+# Temporarily pinned to <1.16 due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
+onnxruntime>=1.7.0,<1.16
 pandas
 portalocker
 psutil


### PR DESCRIPTION
Due to https://github.com/microsoft/onnxruntime/issues/17631, version 1.16.0 is causing CI to fail on master. We can change the pin to `!=1.16.0` (or to however many versions are buggy) once upstream releases a fix.

Part of #4225.