### PR TITLE
Avoid `dipy` versions 1.6.0 + 1.7.0 that contain a `method=restore` bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 #     stable releases. We do this because `pip freeze` will not capture options (e.g. --extra-index-url) or
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
-dipy
+# Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
+dipy<1.6.0,>1.7.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy<1.6.0,>1.7.0
+dipy!=1.6.*,!=1.7.*
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`sct_dmri_compute_dti` fails on `sct_example_data` images when using `-method restore`:

```
sct_dmri_compute_dti -i dmri.nii.gz -bval bvals.txt -bvec bvecs.txt -method restore
```

I dug into this on the `dipy` side of things, and found that the issue only exists for `dipy==1.6.0,1.7.0`, and has already been fixed upstream. `dipy==1.8.0` is releasing soon, so to avoid freezing a buggy version for SCT v6.1, we skip these two versions in our requirements.txt.

Note: We have an existing test for this. The reason that our test suite didn't catch this is because `dipy` chunks the processing, and the test image is smaller than a single chunk, but the bug only occurs when there are >1 chunks. I'm not quite sure how to test for this given our available testing data? But maybe given that this is a one-off issue with an upstream library, we don't necessarily need to test for this.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4209.