### PR TITLE
Update model releases (`lumbar_seg`, `t2star_sc`) to fix output suffix (`_seg-manual` -> `_seg`)

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -30,7 +30,7 @@ MODELS = {
     "t2star_sc": {
         "url": [
             "https://github.com/ivadomed/t2star_sc/releases/download/r20231004/r20231004_t2star_sc.zip",
-            "https://osf.io/425db/download",
+            "https://osf.io/8nk5w/download",
         ],
         "description": "Cord segmentation model on T2*-weighted contrast.",
         "contrasts": ["t2star"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -30,7 +30,7 @@ MODELS = {
     "t2star_sc": {
         "url": [
             "https://github.com/ivadomed/t2star_sc/releases/download/r20231004/r20231004_t2star_sc.zip",
-            "https://osf.io/dj726/download",
+            "https://osf.io/425db/download",
         ],
         "description": "Cord segmentation model on T2*-weighted contrast.",
         "contrasts": ["t2star"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -122,7 +122,7 @@ MODELS = {
     },
     "model_seg_epfl_t2w_lumbar_sc": {
         "url": [
-            "https://github.com/ivadomed/lumbar_seg_EPFL/releases/download/r20220411/model_seg_epfl_t2w_lumbar_sc.zip"
+            "https://github.com/ivadomed/lumbar_seg_EPFL/releases/download/r20231004/model_seg_epfl_t2w_lumbar_sc.zip"
         ],
         "description": "Lumbar SC segmentation on T2w contrast with 3D UNet",
         "contrasts": ["t2"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 MODELS = {
     "t2star_sc": {
         "url": [
-            "https://github.com/ivadomed/t2star_sc/releases/download/r20200622/r20200622_t2star_sc.zip",
-            "https://osf.io/v9hs8/download?version=5",
+            "https://github.com/ivadomed/t2star_sc/releases/download/r20231004/r20231004_t2star_sc.zip",
+            "https://osf.io/dj726/download",
         ],
         "description": "Cord segmentation model on T2*-weighted contrast.",
         "contrasts": ["t2star"],


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR updates the model links so that they point to newly-created releases that change the `target-suffix` key in the `config.json` files to `_seg` (instead of the incorrect `_seg-manual`):

- https://github.com/ivadomed/lumbar_seg_EPFL/releases/edit/r20231004
- https://github.com/ivadomed/t2star_sc/releases/tag/r20231004

This is necessary so that we can write a tutorial for lumbar registration, and have the suffix be appropriate for the tutorial.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3278.
