### PR TITLE
Avoid onnxruntime 1.16.0 but allow onnxruntime >=1.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ nilearn
 numpy<1.24
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
-# Temporarily pinned to <1.16 due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
-onnxruntime>=1.7.0,<1.16
+# Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
+onnxruntime>=1.7.0,!=1.16.0
 pandas
 portalocker
 psutil


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Given that SCT v6.1 hasn't been released yet, I quickly checked in on #4225, and found [the following comment](https://github.com/microsoft/onnxruntime/issues/17631#issuecomment-1761262812):

> 1.16.1 was released with the below fix commit.
> [`1c245e6`](https://github.com/microsoft/onnxruntime/commit/1c245e6775201fec7a1d269a71deb0f3af6f7bea)

If true, then we can remove the `<1.16.0` limitation and replace it with `!=1.16.0`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4225.
