### PR TITLE
Color installed datasets for `sct_download_data -h`

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -414,7 +414,6 @@ def is_installed(dataset_name, custom_paths):
     lines_to_remove = []
     for line in custom_paths:
         custom_folder, name = line[:-1].split(",")
-        print("DEBUG", custom_folder,name, dataset_name)
         if os.path.exists(custom_folder):
             if name == dataset_name:
                 return True
@@ -443,7 +442,7 @@ def list_datasets():
     table = f"{'DATASET NAME':<30s}{'TYPE':<20s}\n"
     table += f"{'-' * 50}\n"
     sorted_datasets = sorted(DATASET_DICT,
-                            key=lambda k: DATASET_DICT[k]['download_type'])
+                             key=lambda k: DATASET_DICT[k]['download_type'])
 
     # Read record of custom pathways once, in case it is needed.
     custom_paths = None
@@ -458,8 +457,6 @@ def list_datasets():
         download_type = DATASET_DICT[dataset_name]['download_type']
         table += f"{dataset_status}{download_type:<20s}\n"
 
-    if custom_paths:
-        print(len(custom_paths))
     table += '\nLegend: {} | {}\n\n'.format(
             stylize("installed", color[True]),
             stylize("not installed", color[False]))

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -382,14 +382,15 @@ def list_datasets():
     color = {True: 'LightGreen', False: 'LightRed'}
     table = f"{'DATASET NAME':<30s}{'TYPE':<20s}\n"
     table += f"{'-' * 50}\n"
-    sortedDatasets = sorted(DATASET_DICT,
-                            key=lambda k: DATASET_DICT[k]['download_type'])
-    for dataset_name in sortedDatasets:
+    sorted_datasets = sorted(DATASET_DICT,
+                             key=lambda k: DATASET_DICT[k]['download_type'] + k)
+    for dataset_name in sorted_datasets:
         download_type = DATASET_DICT[dataset_name]['download_type']
         dataset_status = dataset_name.ljust(30)
         if download_type != "Binaries":
             path_dataset = DATASET_DICT[dataset_name]['default_location']
-            installed = os.path.exists(path_dataset)
+            installed = (os.path.exists(path_dataset)
+                         and len(os.listdir(path_dataset)) > 0)
             dataset_status = stylize(dataset_status, color[installed])
         table += f"{dataset_status}{download_type:<20s}\n"
 

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -17,6 +17,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
+from spinalcordtoolbox.utils import stylize
 from spinalcordtoolbox.utils.fs import tmp_create
 from spinalcordtoolbox.utils.sys import sct_progress_bar, __sct_dir__, __bin_dir__
 
@@ -375,13 +376,23 @@ def install_named_dataset(dataset_name, dest_folder=None, keep=False):
 
 def list_datasets():
     """
-    :returns: A table containing listing the downloadable datasets
+    :returns: A table listing the downloadable datasets
     :rtype: str
     """
+    color = {True: 'LightGreen', False: 'LightRed'}
     table = f"{'DATASET NAME':<30s}{'TYPE':<20s}\n"
     table += f"{'-' * 50}\n"
-    sortedDatasets = sorted(DATASET_DICT, key=lambda k: DATASET_DICT[k]['download_type'])
+    sortedDatasets = sorted(DATASET_DICT,
+                            key=lambda k: DATASET_DICT[k]['download_type'])
     for dataset_name in sortedDatasets:
+        path_dataset = DATASET_DICT[dataset_name]['default_location']
+        installed = os.path.exists(path_dataset)
+        dataset_status = stylize(dataset_name.ljust(30), color[installed])
         download_type = DATASET_DICT[dataset_name]['download_type']
-        table += f"{dataset_name:<30s}{download_type:<20s}\n"
+        table += f"{dataset_status}{download_type:<20s}\n"
+
+    table += '\nLegend: {} | {}\n\n'.format(
+            stylize("installed", color[True]),
+            stylize("not installed", color[False]))
+
     return table

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -357,23 +357,6 @@ def install_data(url, dest_folder, keep=False):
     shutil.rmtree(extraction_folder)
 
 
-def record_custom_folders(dest_folder, dataset_name):
-    """
-    Record custom output folder to track installation status.
-    """
-    custom_paths = os.path.join(__sct_dir__, "data", ".custom_paths")
-    custom_path = dest_folder + "," + dataset_name + "\n"
-    if (os.path.exists(custom_paths)):
-        with open(custom_paths, 'r') as file:
-            lines = file.readlines()
-        if custom_path not in lines:
-            with open(custom_paths, 'a') as file:
-                file.write(custom_path)
-    else:
-        with open(custom_paths, 'w') as file:
-            file.write(custom_path)
-
-
 def install_named_dataset(dataset_name, dest_folder=None, keep=False):
     """
     A light wrapper for the 'install_data' function to allow downstream consumers to download
@@ -385,52 +368,10 @@ def install_named_dataset(dataset_name, dest_folder=None, keep=False):
                          f"{sorted(list(DATASET_DICT.keys()), key=str.casefold)}")
 
     urls = DATASET_DICT[dataset_name]["mirrors"]
-
-    custom = True
     if dest_folder is None:
-        custom = False
         dest_folder = DATASET_DICT[dataset_name]["default_location"]
 
     install_data(urls, dest_folder, keep)
-
-    if custom is True:
-        record_custom_folders(dest_folder, dataset_name)
-
-
-def is_installed(dataset_name, custom_paths):
-    """
-    :return: bool: Checks whether a dataset is installed
-    """
-    # Check for installation at default location
-    path_default = DATASET_DICT[dataset_name]['default_location']
-    if os.path.exists(path_default):
-        return True
-
-    if custom_paths is None:
-        return False
-
-    # Check if a custom installation pathway has been recorded,
-    # and whether it still exists.
-    lines_to_remove = []
-    for line in custom_paths:
-        custom_folder, name = line[:-1].split(",")
-        if os.path.exists(custom_folder):
-            if name == dataset_name:
-                return True
-        else:
-            lines_to_remove.append(line)
-
-    # If a recorded custom pathway no longer exists,
-    # remove it from the record.
-    if len(lines_to_remove):
-        for line in lines_to_remove:
-            custom_paths.remove(line)
-        custom_paths_file = os.path.join(__sct_dir__, "data", ".custom_paths")
-        with open(custom_paths_file, 'w') as file:
-            for line in custom_paths:
-                file.write(line)
-
-    return False
 
 
 def list_datasets():
@@ -441,23 +382,18 @@ def list_datasets():
     color = {True: 'LightGreen', False: 'LightRed'}
     table = f"{'DATASET NAME':<30s}{'TYPE':<20s}\n"
     table += f"{'-' * 50}\n"
-    sorted_datasets = sorted(DATASET_DICT,
-                             key=lambda k: DATASET_DICT[k]['download_type'])
-
-    # Read record of custom pathways once, in case it is needed.
-    custom_paths = None
-    custom_paths_file = os.path.join(__sct_dir__, "data", ".custom_paths")
-    if os.path.exists(custom_paths_file):
-        with open(custom_paths_file, 'r') as file:
-            custom_paths = file.readlines()
-
-    for dataset_name in sorted_datasets:
-        installed = is_installed(dataset_name, custom_paths)
-        dataset_status = stylize(dataset_name.ljust(30), color[installed])
+    sortedDatasets = sorted(DATASET_DICT,
+                            key=lambda k: DATASET_DICT[k]['download_type'])
+    for dataset_name in sortedDatasets:
         download_type = DATASET_DICT[dataset_name]['download_type']
+        dataset_status = dataset_name.ljust(30)
+        if download_type != "Binaries":
+            path_dataset = DATASET_DICT[dataset_name]['default_location']
+            installed = os.path.exists(path_dataset)
+            dataset_status = stylize(dataset_status, color[installed])
         table += f"{dataset_status}{download_type:<20s}\n"
 
-    table += '\nLegend: {} | {}\n\n'.format(
+    table += '\nLegend: {} | {} (in the $SCT_DIR/data folder)\n\n'.format(
             stylize("installed", color[True]),
             stylize("not installed", color[False]))
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
In PR #4255 it was suggested that the table appended to the argparse help for `sct_download_data` could be colored to indicate whether a dataset was installed.

I have made a simple attempt to check for the existence of each dataset at its default location.

However, this is insufficient if a user has installed to a custom location.

Perhaps calling [`download.py::install_named_dataset()`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/23776c374fa183308043f3d95f0017e0e63b51a3/spinalcordtoolbox/download.py#L359C16-L359C16) with a custom `dest_folder` parameter could create or add to a new file that will record custom install paths. This file would be created in a standard location and could then be referenced to accurately reflect whether each dataset has been installed.

<details>
<summary>Image</summary>

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/103092293/c24d780e-2bc7-4b55-b071-ab42a8ace6a8)

</details>

## Linked issues
#4007 
#4255
