### PR TITLE
Disable PDF and EPUB documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,8 +26,3 @@ python:
 sphinx:
   configuration: documentation/source/conf.py
   fail_on_warning: true
-
-# Other formats to produce, in addition to html
-formats:
-  - pdf
-  - epub


### PR DESCRIPTION
They are failing badly on master, and are not useful.

Fixes #4260.