### PR TITLE
Switch matmul syntax (`*` -> `@`) to follow-up previous `np.matrix` -> `np.array` change

### DIFF
--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -862,8 +862,8 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
         # display rotations
         if verbose == 2 and not angle_src_dest[iz] == 0 and not rot_method == 'hog':
             # compute new coordinates
-            coord_src_rot = coord_src[iz] * R
-            coord_dest_rot = coord_dest[iz] * R.T
+            coord_src_rot = coord_src[iz] @ R
+            coord_dest_rot = coord_dest[iz] @ R.T
             # generate figure
             plt.figure(figsize=(9, 9))
             # plt.ion()  # enables interactive mode (allows keyboard interruption)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This change is necessary is to accommodate the previous change of the `R` array from an `np.matrix` object to an `np.array` object. (See #4091, specifically https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/dee9e9fa90dedf44d6c7819d835996dd3abdd5ef.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

This fixes the error in #4266, but does not address @jqmcginnis's failed registration, so we shouldn't close the issue quite yet.