### PR TITLE
Fix broken link

### DIFF
--- a/documentation/source/user_section/tutorials/registration-to-template/lumbar-registration/template-registration.rst
+++ b/documentation/source/user_section/tutorials/registration-to-template/lumbar-registration/template-registration.rst
@@ -23,7 +23,7 @@ To apply the registration algorithm, the following command is used:
       Label max provided: 60
       Label max from template: 21   
 
-   In that case, you should update it by following `these instructions <before-starting-lumbar-registration>`_.
+   In that case, you should update it by following :ref:`these instructions <before-starting-lumbar-registration>`.
 
 :Input arguments:
    - ``-i`` : Input image.


### PR DESCRIPTION
See this page for the correct syntax:

https://www.sphinx-doc.org/en/master/usage/referencing.html#role-ref

Sorry for introducing this broken link in [my earlier suggestion](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4250#discussion_r1374998121)!