### PR TITLE
Ensure that point label files are correctly interpolated during template warping

### DIFF
--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -128,11 +128,9 @@ def get_interp(file_label):
     # default interp
     interp = 'linear'
     # Nearest Neighbours interp
-    if any(substring in file_label for substring in [
-        '_level.nii.gz', '_levels.nii.gz', '_csf.nii.gz', '_CSF.nii.gz', '_cord.nii.gz'
-    ]):
+    if any(substring in file_label for substring in ['_levels.', '_csf.', '_cord.']):
         interp = 'nn'
-    elif any(substring in file_label for substring in ['_label', '_midpoint']):
+    elif any(substring in file_label for substring in ['_label_', '_midpoint.']):
         interp = 'label'
     # output
     return interp

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -31,15 +31,13 @@ class Param:
         # self.warp_template = 1
         self.warp_atlas = 1
         self.warp_histo = 0
-        # list of files for which nn interpolation should be used. Default = linear.
-        self.list_labels_nn = ['_level.nii.gz', '_levels.nii.gz', '_csf.nii.gz', '_CSF.nii.gz', '_cord.nii.gz']
         self.verbose = 1  # verbose
         self.path_qc = None
 
 
 class WarpTemplate:
     def __init__(self, fname_src, fname_transfo, warp_atlas, folder_out, path_template,
-                 folder_template, folder_atlas, file_info_label, list_labels_nn,
+                 folder_template, folder_atlas, file_info_label,
                  verbose, warp_histo, folder_histo):
 
         # Initialization
@@ -53,7 +51,6 @@ class WarpTemplate:
         self.folder_atlas = folder_atlas
         self.folder_histo = folder_histo
         self.file_info_label = file_info_label
-        self.list_labels_nn = list_labels_nn
         self.verbose = verbose
 
         # printv(arguments)
@@ -72,22 +69,22 @@ class WarpTemplate:
         # Warp template objects
         printv('\nWARP TEMPLATE:', self.verbose)
         warp_label(self.path_template, self.folder_template, self.file_info_label, self.fname_src,
-                   self.fname_transfo, self.folder_out, self.list_labels_nn, self.verbose)
+                   self.fname_transfo, self.folder_out, self.verbose)
 
         # Warp atlas
         if self.warp_atlas == 1:
             printv('\nWARP ATLAS OF WHITE MATTER TRACTS:', self.verbose)
             warp_label(self.path_template, self.folder_atlas, self.file_info_label, self.fname_src,
-                       self.fname_transfo, self.folder_out, self.list_labels_nn, self.verbose)
+                       self.fname_transfo, self.folder_out, self.verbose)
 
         # Warp histology atlas
         if self.warp_histo == 1:
             printv('\nWARP HISTOLOGY ATLAS:', self.verbose)
             warp_label(self.path_template, self.folder_histo, self.file_info_label, self.fname_src,
-                       self.fname_transfo, self.folder_out, self.list_labels_nn, self.verbose)
+                       self.fname_transfo, self.folder_out, self.verbose)
 
 
-def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, path_out, list_labels_nn, verbose):
+def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, path_out, verbose):
     """
     Warp label files according to info_label.txt file
     :param path_label:
@@ -96,7 +93,6 @@ def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, p
     :param fname_src:
     :param fname_transfo:
     :param path_out:
-    :param list_labels_nn:
     :param verbose:
     :return:
     """
@@ -120,7 +116,7 @@ def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, p
                                     '-d', fname_src,
                                     '-w', fname_transfo,
                                     '-o', os.path.join(path_out, folder_label, template_label_file[i]),
-                                    '-x', get_interp(template_label_file[i], list_labels_nn),
+                                    '-x', get_interp(template_label_file[i]),
                                     '-v', '0'])
         # Copy list.txt
         copy(os.path.join(path_label, folder_label, file_label), os.path.join(path_out, folder_label))
@@ -128,11 +124,13 @@ def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, p
 
 # Get interpolation method
 # ==========================================================================================
-def get_interp(file_label, list_labels_nn):
+def get_interp(file_label):
     # default interp
     interp = 'linear'
     # Nearest Neighbours interp
-    if any(substring in file_label for substring in list_labels_nn):
+    if any(substring in file_label for substring in [
+        '_level.nii.gz', '_levels.nii.gz', '_csf.nii.gz', '_CSF.nii.gz', '_cord.nii.gz'
+    ]):
         interp = 'nn'
     elif any(substring in file_label for substring in ['_label', '_midpoint']):
         interp = 'label'
@@ -272,11 +270,10 @@ def main(argv: Sequence[str]):
     folder_atlas = param.folder_atlas
     folder_histo = param.folder_histo
     file_info_label = param.file_info_label
-    list_labels_nn = param.list_labels_nn
 
     # call main function
     w = WarpTemplate(fname_src, fname_transfo, warp_atlas, folder_out, path_template,
-                     folder_template, folder_atlas, file_info_label, list_labels_nn,
+                     folder_template, folder_atlas, file_info_label,
                      verbose, warp_histo, folder_histo)
 
     path_template = os.path.join(w.folder_out, w.folder_template)

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -128,6 +128,7 @@ def get_interp(file_label):
     # default interp
     interp = 'linear'
     # Nearest Neighbours interp
+    # For safety and consistency, ensure strings are bracketed by `_` or `.` on both sides
     if any(substring in file_label for substring in ['_levels.', '_csf.', '_cord.']):
         interp = 'nn'
     elif any(substring in file_label for substring in ['_label_', '_midpoint.']):

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -134,6 +134,8 @@ def get_interp(file_label, list_labels_nn):
     # Nearest Neighbours interp
     if any(substring in file_label for substring in list_labels_nn):
         interp = 'nn'
+    elif any(substring in file_label for substring in ['_label', '_midpoint']):
+        interp = 'label'
     # output
     return interp
 

--- a/testing/cli/test_cli_sct_warp_template.py
+++ b/testing/cli/test_cli_sct_warp_template.py
@@ -3,7 +3,8 @@
 import pytest
 import logging
 
-from spinalcordtoolbox.scripts import sct_warp_template
+from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.scripts import sct_warp_template, sct_register_to_template
 
 logger = logging.getLogger(__name__)
 
@@ -23,3 +24,26 @@ def test_sct_warp_template_warp_full_PAM50():
     sct_warp_template.main(argv=['-d', 'mt/mt1.nii.gz', '-w', 'mt/warp_template2mt.nii.gz',
                                  '-a', '1', '-histo', '1',
                                  '-qc', 'testing-qc'])
+
+
+@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
+def test_sct_warp_template_point_labels(tmp_path):
+    """Warp the full PAM50 template, then test whether point labels are preserved."""
+    # Register the cropped T2 image to the full PAM50 template
+    sct_register_to_template.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz',
+                                        '-ldisc', 't2/labels.nii.gz', '-ref', 'subject',
+                                        '-ofolder', str(tmp_path)])
+
+    # Warp the PAM50 template to the cropped T2 image space
+    path_out = tmp_path/"PAM50_warped"
+    sct_warp_template.main(argv=['-d', 't2/t2.nii.gz', '-w', str(tmp_path/'warp_template2anat.nii.gz'),
+                                 '-a', '0',  # -a is '1' by default, but save time since not needed for point labels
+                                 '-qc', 'testing-qc', '-ofolder', str(path_out)])
+
+    # Ensure that point labels were preserved
+    point_label_files = ['PAM50_label_discPosterior.nii.gz', 'PAM50_spinal_midpoint.nii.gz',
+                         'PAM50_label_body.nii.gz', 'PAM50_label_disc.nii.gz']
+    for label in point_label_files:
+        coords = Image(str(path_out/'template'/label)).getNonZeroCoordinates()
+        assert coords  # Ensure no labels were lost during warping
+        assert all(c.value == int(c.value) for c in coords)  # Ensure point labels are equivalent to integers


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, either `linear` or `nn` interpolation is used when warping template files (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4280#issuecomment-1789177326). But, neither interpolation method is appropriate for label files _(`nn` may result in lost labels, while `linear` results in the label values themselves not being preserved (int `3.0` -> float `1.0234674`))_. This is why `sct_apply_transfo` has a specific interpolation setting called `label`, so we should use it here.

I've written a test that will fail for the current interpolation, but will pass when interpolation is switched to `label`, to demonstrate that my changes fix the issue.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4280.