### PR TITLE
Add `manual-correction` to `download.py` to make downloading easier for the SCT Course

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -52,7 +52,14 @@ DATASET_DICT = {
             "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20231020.zip",
         ],
         "default_location": os.path.join(__sct_dir__, "data", "sct_course_data"),
-        "download_type": "Datasets",
+        "download_type": "SCT Course Files",
+    },
+    "manual-correction": {
+        "mirrors": [
+            "https://github.com/spinalcordtoolbox/manual-correction/archive/refs/tags/r20231101.zip",
+        ],
+        "default_location": os.path.join(__sct_dir__, "data", "manual-correction"),
+        "download_type": "SCT Course Files",
     },
     "PAM50": {
         "mirrors": [


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Right now, the manual correction scripts exist outside of the SCT repo, for reasons outlined in:

- https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3353

However, this makes accessing the manual correction script difficult (requiring either a `git clone` or a `wget`/`curl` call).

So, similarly to https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4271, we make use of `sct_download_data` as a download manager, to ease the process of downloading a URL + unzipping it to the correct folder.

Additionally, I've re-added the separate "Course" download category, which should signal to users that manual correction is intended to be used within the context of the SCT course.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://docs.google.com/presentation/d/1t40Fd0fS0SwWR5FU_GWKEvHkB9d96LVddLQW6L3QAx0/edit?disco=AAAA_SxrQH8.