### PR TITLE
Remove `utils` star imports and ensure we are importing directly from submodules `{fs,sys,shell}`

### DIFF
--- a/spinalcordtoolbox/__init__.py
+++ b/spinalcordtoolbox/__init__.py
@@ -1,1 +1,0 @@
-from .utils import __version__, __sct_dir__, __data_dir__, __deepseg_dir__  # noqa: F401

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -19,7 +19,8 @@ import wquantiles
 
 from spinalcordtoolbox.template import get_slices_from_vertebral_levels, get_vertebral_level_from_slice
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import __version__, parse_num_list_inv
+from spinalcordtoolbox.utils.sys import __version__
+from spinalcordtoolbox.utils.shell import parse_num_list_inv
 
 
 class Metric:

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -13,9 +13,8 @@ import logging
 import textwrap
 import shutil
 
-import spinalcordtoolbox as sct
 from spinalcordtoolbox import download
-from spinalcordtoolbox.utils.sys import stylize
+from spinalcordtoolbox.utils.sys import stylize, __deepseg_dir__
 
 
 logger = logging.getLogger(__name__)
@@ -263,7 +262,7 @@ def folder(name_model):
     :param name: str: Name of model.
     :return: str: Folder to model
     """
-    return os.path.join(sct.__deepseg_dir__, name_model)
+    return os.path.join(__deepseg_dir__, name_model)
 
 
 def install_model(name_model):

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -15,7 +15,7 @@ import shutil
 
 import spinalcordtoolbox as sct
 from spinalcordtoolbox import download
-from spinalcordtoolbox.utils import stylize
+from spinalcordtoolbox.utils.sys import stylize
 
 
 logger = logging.getLogger(__name__)

--- a/spinalcordtoolbox/deepseg_/gm.py
+++ b/spinalcordtoolbox/deepseg_/gm.py
@@ -15,7 +15,8 @@ import os
 import nibabel as nib
 import numpy as np
 
-from spinalcordtoolbox import resampling, __data_dir__
+from spinalcordtoolbox import resampling
+from spinalcordtoolbox.utils.sys import __data_dir__
 from spinalcordtoolbox.deepseg_.onnx import onnx_inference
 
 # Models

--- a/spinalcordtoolbox/deepseg_/lesion.py
+++ b/spinalcordtoolbox/deepseg_/lesion.py
@@ -16,7 +16,8 @@ from spinalcordtoolbox.image import Image, add_suffix, zeros_like, empty_like
 from spinalcordtoolbox.deepseg_.onnx import onnx_inference
 from spinalcordtoolbox.deepseg_.sc import find_centerline, crop_image_around_centerline, uncrop_image, _normalize_data
 from spinalcordtoolbox import resampling
-from spinalcordtoolbox.utils import sct_dir_local_path, TempFolder
+from spinalcordtoolbox.utils.fs import TempFolder
+from spinalcordtoolbox.utils.sys import sct_dir_local_path
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -18,7 +18,8 @@ from spinalcordtoolbox.deepseg_.onnx import onnx_inference
 from spinalcordtoolbox.deepseg_.postprocessing import post_processing_volume_wise, keep_largest_object, fill_holes_2d
 from spinalcordtoolbox.image import Image, empty_like, change_type, zeros_like, add_suffix, concat_data, split_img_data
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
-from spinalcordtoolbox.utils import sct_dir_local_path, TempFolder
+from spinalcordtoolbox.utils.fs import TempFolder
+from spinalcordtoolbox.utils.sys import sct_dir_local_path
 from spinalcordtoolbox.types import EmptyArrayError
 
 # Thresholds to apply to binarize segmentations from the output of the 2D CNN. These thresholds were obtained by

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -17,9 +17,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from spinalcordtoolbox.utils import stylize
 from spinalcordtoolbox.utils.fs import tmp_create
-from spinalcordtoolbox.utils.sys import sct_progress_bar, __sct_dir__, __bin_dir__
+from spinalcordtoolbox.utils.sys import __bin_dir__, __sct_dir__, sct_progress_bar, stylize
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -26,7 +26,8 @@ import transforms3d.affines as affines
 from scipy.ndimage import map_coordinates
 
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import extract_fname, mv, run_proc, tmp_create
+from spinalcordtoolbox.utils.fs import extract_fname, mv, tmp_create
+from spinalcordtoolbox.utils.sys import run_proc
 
 
 logger = logging.getLogger(__name__)

--- a/spinalcordtoolbox/metadata.py
+++ b/spinalcordtoolbox/metadata.py
@@ -10,7 +10,7 @@ import os
 import re
 from operator import itemgetter
 
-from spinalcordtoolbox.utils import parse_num_list
+from spinalcordtoolbox.utils.shell import parse_num_list
 
 
 class InfoLabel(object):

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -15,7 +15,7 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.aggregate_slicewise import Metric
 from spinalcordtoolbox.centerline.core import get_centerline
 from spinalcordtoolbox.resampling import resample_nib
-from spinalcordtoolbox.utils import sct_progress_bar
+from spinalcordtoolbox.utils.sys import sct_progress_bar
 
 # NB: We use a threshold to check if an array is empty, instead of checking if it's exactly 0. This is because
 # resampling can change 0 -> ~0 (e.g. 1e-16). See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3402

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -25,7 +25,8 @@ from spinalcordtoolbox.math import laplacian
 from spinalcordtoolbox.registration.landmarks import register_landmarks
 from spinalcordtoolbox.registration import core
 from spinalcordtoolbox.scripts import sct_resample
-from spinalcordtoolbox.utils import sct_progress_bar, copy_helper, run_proc, tmp_create, sct_dir_local_path
+from spinalcordtoolbox.utils.fs import copy_helper, tmp_create
+from spinalcordtoolbox.utils.sys import run_proc, sct_dir_local_path, sct_progress_bar
 
 from spinalcordtoolbox.scripts import sct_image
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -28,7 +28,9 @@ import portalocker
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Slice, Axial, Sagittal
-from spinalcordtoolbox.utils import list2cmdline, __version__, copy, extract_fname, display_open
+from spinalcordtoolbox.utils.fs import copy, extract_fname
+from spinalcordtoolbox.utils.sys import __version__, list2cmdline
+from spinalcordtoolbox.utils.shell import display_open
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -49,9 +49,9 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
     dict_interp = {'nn': 0, 'linear': 1, 'spline': 2}
 
     # If input is an Image object, create nibabel object from it
-    if type(image) == nib.nifti1.Nifti1Image:
+    if isinstance(image, nib.nifti1.Nifti1Image):
         img = image
-    elif type(image) == Image:
+    elif isinstance(image, Image):
         img = nib.nifti1.Nifti1Image(image.data, image.hdr.get_best_affine(), image.hdr)
     else:
         raise TypeError(f'Invalid image type: {type(image)}')
@@ -107,9 +107,9 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
 
     # If reference is provided
     else:
-        if type(image_dest) == nib.nifti1.Nifti1Image:
+        if isinstance(image_dest, nib.nifti1.Nifti1Image):
             reference = image_dest
-        elif type(image_dest) == Image:
+        elif isinstance(image_dest, Image):
             reference = nib.nifti1.Nifti1Image(image_dest.data, image_dest.hdr.get_best_affine())
         else:
             raise TypeError(f'Invalid image type: {type(image_dest)}')
@@ -142,9 +142,10 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         img_r.header['sform_code'] = img.header['sform_code']
 
     # Convert back to proper type
-    if type(image) == nib.nifti1.Nifti1Image:
+    if isinstance(image, nib.nifti1.Nifti1Image):
         return img_r
-    elif type(image) == Image:
+    else:
+        assert isinstance(image, Image)  # already checked at the start of the function
         return Image(np.asanyarray(img_r.dataobj), hdr=img_r.header, orientation=image.orientation, dim=img_r.header.get_data_shape())
 
 

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -14,7 +14,7 @@ import nibabel as nib
 from nibabel.processing import resample_from_to
 
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import display_viewer_syntax
+from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -18,7 +18,7 @@ from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline
 from spinalcordtoolbox.types import Centerline
-from spinalcordtoolbox import __data_dir__
+from spinalcordtoolbox.utils.sys import __data_dir__
 from spinalcordtoolbox.scripts import sct_process_segmentation
 
 

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -12,8 +12,9 @@ import numpy as np
 import logging
 from typing import Sequence
 import pandas as pd
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
-from spinalcordtoolbox.utils.fs import get_absolute_path, extract_fname, printv
+from spinalcordtoolbox.utils.fs import extract_fname, get_absolute_path
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline
 from spinalcordtoolbox.types import Centerline

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -9,7 +9,8 @@ import sys
 import os
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.qmri.mt import compute_mtr
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -14,7 +14,8 @@ import os
 import json
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 from spinalcordtoolbox.qmri.mt import compute_mtsat
 from spinalcordtoolbox.image import Image, splitext
 

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -15,7 +15,8 @@ from typing import Sequence
 import numpy as np
 
 from spinalcordtoolbox.image import Image, empty_like, add_suffix
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, parse_num_list, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, parse_num_list
 
 
 # PARAMETERS

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -10,7 +10,8 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 import spinalcordtoolbox.image as image
 
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -16,7 +16,8 @@ import sys
 import os
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 from spinalcordtoolbox.image import add_suffix
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.deepseg_.gm import segment_file

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -13,8 +13,9 @@ import numpy as np
 import nibabel as nib
 from dipy.denoise.nlmeans import nlmeans
 
-from spinalcordtoolbox.utils import (SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_loglevel,
-                                     display_viewer_syntax)
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 
 
 # DEFAULT PARAMETERS

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -11,7 +11,8 @@ import sys
 import math
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 
 def main(argv: Sequence[str]):

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -8,7 +8,8 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -12,7 +12,8 @@ from typing import Sequence
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image, concat_data
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -8,7 +8,9 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -8,7 +8,9 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_loglevel
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -15,7 +15,8 @@ from dipy.data.fetcher import read_bvals_bvecs
 from matplotlib.lines import Line2D
 from matplotlib import cm
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 BZERO_THRESH = 0.0001  # b-zero threshold
 

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -8,7 +8,9 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_loglevel
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -10,7 +10,8 @@ import logging
 from typing import Sequence
 
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 from spinalcordtoolbox.flattening import flatten_sagittal
 
 logger = logging.getLogger(__name__)

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -11,7 +11,8 @@ from typing import Sequence
 import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 
 
 class Param:

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -22,9 +22,9 @@ import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import (SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, printv,
-                                     parse_num_list, set_loglevel)
-from spinalcordtoolbox.utils.shell import display_viewer_syntax
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.shell import (ActionCreateFolder, Metavar, SCTArgumentParser,
+                                           display_viewer_syntax, list_type, parse_num_list)
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -28,11 +28,11 @@ from spinalcordtoolbox.metrics_to_PAM50 import interpolate_metrics
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.image import add_suffix, splitext, Image
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, parse_num_list, display_open
-from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, __sct_dir__
 from spinalcordtoolbox.utils.fs import get_absolute_path
+from spinalcordtoolbox.utils.sys import __sct_dir__, init_sct, sct_progress_bar, set_loglevel
+from spinalcordtoolbox.utils.shell import (ActionCreateFolder, Metavar, SCTArgumentParser,
+                                           display_open, parse_num_list)
 from spinalcordtoolbox import __data_dir__
-from spinalcordtoolbox.utils import sct_progress_bar
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -32,7 +32,7 @@ from spinalcordtoolbox.utils.fs import get_absolute_path
 from spinalcordtoolbox.utils.sys import __sct_dir__, init_sct, sct_progress_bar, set_loglevel
 from spinalcordtoolbox.utils.shell import (ActionCreateFolder, Metavar, SCTArgumentParser,
                                            display_open, parse_num_list)
-from spinalcordtoolbox import __data_dir__
+from spinalcordtoolbox.utils.sys import __data_dir__
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -10,7 +10,8 @@ import sys
 from typing import Sequence
 
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import init_sct, set_loglevel, SCTArgumentParser, list2cmdline
+from spinalcordtoolbox.utils.sys import init_sct, list2cmdline, set_loglevel
+from spinalcordtoolbox.utils.shell import SCTArgumentParser
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -33,7 +33,7 @@ from spinalcordtoolbox.utils.fs import (copy, extract_fname, check_file_exist, r
 from spinalcordtoolbox.utils.shell import (SCTArgumentParser, ActionCreateFolder, Metavar, list_type,
                                            printv, display_viewer_syntax)
 from spinalcordtoolbox.utils.sys import set_loglevel, init_sct, run_proc
-from spinalcordtoolbox import __data_dir__
+from spinalcordtoolbox.utils.sys import __data_dir__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.scripts import sct_apply_transfo, sct_resample

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -10,7 +10,8 @@
 import sys
 from typing import Sequence
 
-from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
+from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 import spinalcordtoolbox.resampling
 
 

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -14,7 +14,7 @@
 import pytest
 import sys
 
-from spinalcordtoolbox import __sct_dir__
+from spinalcordtoolbox.utils.sys import __sct_dir__
 
 if __name__ == "__main__":
     # Treat `sct_testing` as an alias to `pytest`. If no arguments are passed,

--- a/spinalcordtoolbox/scripts/sct_version.py
+++ b/spinalcordtoolbox/scripts/sct_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from spinalcordtoolbox import __version__
+from spinalcordtoolbox.utils.sys import __version__
 
 
 def main():

--- a/spinalcordtoolbox/utils/__init__.py
+++ b/spinalcordtoolbox/utils/__init__.py
@@ -1,4 +1,0 @@
-from .fs import *  # noqa: F401, F403
-from .sys import *  # noqa: F401, F403
-from .sys import __version__, __sct_dir__, __data_dir__, __deepseg_dir__  # noqa: F401
-from .shell import *  # noqa: F401, F403

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -28,7 +28,8 @@ import nibabel as nib
 from scipy.ndimage import center_of_mass
 
 from spinalcordtoolbox.image import Image, zeros_like
-from spinalcordtoolbox.utils import run_proc, TempFolder, __data_dir__
+from spinalcordtoolbox.utils.fs import TempFolder
+from spinalcordtoolbox.utils.sys import __data_dir__, run_proc
 from spinalcordtoolbox.flattening import flatten_sagittal
 
 logger = logging.getLogger(__name__)

--- a/testing/api/test_aggregate_slicewise.py
+++ b/testing/api/test_aggregate_slicewise.py
@@ -7,7 +7,7 @@ import numpy as np
 import nibabel as nib
 import pandas as pd
 
-from spinalcordtoolbox import __version__
+from spinalcordtoolbox.utils.sys import __version__
 from spinalcordtoolbox import aggregate_slicewise
 from spinalcordtoolbox.process_seg import Metric
 from spinalcordtoolbox.image import Image

--- a/testing/api/test_centerline.py
+++ b/testing/api/test_centerline.py
@@ -10,7 +10,7 @@ import nibabel as nib
 from spinalcordtoolbox.centerline.curve_fitting import bspline
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, find_and_sort_coord
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import sct_test_path, init_sct, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, sct_test_path, set_loglevel
 
 # Set logger to "DEBUG"
 init_sct()

--- a/testing/api/test_deepseg_lesion.py
+++ b/testing/api/test_deepseg_lesion.py
@@ -7,7 +7,7 @@ import nibabel as nib
 
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.deepseg_.lesion as deepseg_lesion
-from spinalcordtoolbox.utils import __sct_dir__
+from spinalcordtoolbox.utils.sys import __sct_dir__
 
 
 def test_model_file_exists():

--- a/testing/api/test_deepseg_sc.py
+++ b/testing/api/test_deepseg_sc.py
@@ -6,7 +6,7 @@ import nibabel as nib
 
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.deepseg_.sc as deepseg_sc
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 from .test_centerline import dummy_centerline
 

--- a/testing/api/test_gui.py
+++ b/testing/api/test_gui.py
@@ -6,7 +6,7 @@ import unittest
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.gui import base, centerline, sagittal
 from spinalcordtoolbox.gui.base import InvalidActionWarning
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 
 logging.basicConfig(level=logging.DEBUG)

--- a/testing/api/test_image.py
+++ b/testing/api/test_image.py
@@ -9,7 +9,7 @@ import nibabel
 import nibabel.orientations
 
 import spinalcordtoolbox.image as msct_image
-from spinalcordtoolbox.utils import tmp_create
+from spinalcordtoolbox.utils.fs import tmp_create
 
 
 @pytest.fixture(scope="session")

--- a/testing/api/test_labels.py
+++ b/testing/api/test_labels.py
@@ -7,7 +7,7 @@ import pytest
 
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.types import Coordinate
 from .test_image import fake_3dimage, fake_3dimage2
 

--- a/testing/api/test_labels.py
+++ b/testing/api/test_labels.py
@@ -151,8 +151,8 @@ def test_compute_mse_label_warning(caplog):
 
     sct_labels.compute_mean_squared_error(src, ref)
     # Cannot use f-string in assert, I needed to create a variable before
-    string_form_inp = f'Label mismatch: Labels [{src.data[0,0,0]}] present in input image but missing from reference image.'
-    string_form_ref = f'Label mismatch: Labels [{ref.data[0,0,0]}] present in reference image but missing from input image.'
+    string_form_inp = f'Label mismatch: Labels [{src.data[0, 0, 0]}] present in input image but missing from reference image.'
+    string_form_ref = f'Label mismatch: Labels [{ref.data[0, 0, 0]}] present in reference image but missing from input image.'
     assert string_form_inp in caplog.text
     assert string_form_ref in caplog.text
 

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -5,7 +5,7 @@ import pytest
 
 import multiprocessing
 
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 import spinalcordtoolbox.reports.qc as qc
 
 

--- a/testing/api/test_qmri.py
+++ b/testing/api/test_qmri.py
@@ -6,7 +6,7 @@ import pytest
 
 from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import init_sct, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 
 
 # Set logger to "DEBUG"

--- a/testing/api/test_register.py
+++ b/testing/api/test_register.py
@@ -10,7 +10,7 @@ from spinalcordtoolbox.scripts.sct_register_to_template import Param
 from spinalcordtoolbox.registration.core import register
 from spinalcordtoolbox.registration.algorithms import (Paramreg, register_step_ants_registration, register_step_label,
                                                        register_step_ants_slice_regularized_registration)
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 

--- a/testing/api/test_reports.py
+++ b/testing/api/test_reports.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 import spinalcordtoolbox.reports.qc as qc
 import spinalcordtoolbox.reports.slice as qcslice
 

--- a/testing/api/test_straightening.py
+++ b/testing/api/test_straightening.py
@@ -1,7 +1,7 @@
 # pytest unit tests for spinalcordtoolbox.straightening
 
 from spinalcordtoolbox.straightening import SpinalCordStraightener
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 VERBOSE = 0  # Set to 2 to save images, 0 otherwise
 

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -23,7 +23,7 @@ def test_sct_argument_parser(capsys):
 
     # Check that new defaults are set properly
     parser3 = shell.SCTArgumentParser()
-    assert parser3.prog == "test_utils"
+    assert parser3.prog == "test_utils_shell"
     assert parser3.formatter_class == shell.SmartFormatter
     assert parser3.add_help is False
 
@@ -36,7 +36,7 @@ def test_sct_argument_parser(capsys):
 
     # Check help message is still output when above error is thrown
     captured = capsys.readouterr()
-    assert "usage: test_utils" in captured.err
+    assert "usage: test_utils_shell" in captured.err
 
     # Ensure no error is thrown when help is explicitly called
     with pytest.raises(SystemExit) as e:

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -4,27 +4,27 @@ import os
 import pytest
 from stat import S_IEXEC
 
-from spinalcordtoolbox import utils
+from spinalcordtoolbox.utils import shell
 
 
 def test_parse_num_list_inv():
-    assert utils.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
-    assert utils.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'
-    assert utils.parse_num_list_inv([]) == ''
+    assert shell.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
+    assert shell.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'
+    assert shell.parse_num_list_inv([]) == ''
 
 
 def test_sct_argument_parser(capsys):
     """Test extra argparse functionality added by SCTArgumentParser subclass."""
     # Check that new defaults can still be overridden (setting add_help via args AND kwargs)
-    parser1 = utils.SCTArgumentParser(None, None, None, None, [], utils.SmartFormatter, '-', None, None, 'error', True)
+    parser1 = shell.SCTArgumentParser(None, None, None, None, [], shell.SmartFormatter, '-', None, None, 'error', True)
     assert parser1.add_help is True
-    parser2 = utils.SCTArgumentParser(add_help=True)
+    parser2 = shell.SCTArgumentParser(add_help=True)
     assert parser2.add_help is True
 
     # Check that new defaults are set properly
-    parser3 = utils.SCTArgumentParser()
+    parser3 = shell.SCTArgumentParser()
     assert parser3.prog == "test_utils"
-    assert parser3.formatter_class == utils.SmartFormatter
+    assert parser3.formatter_class == shell.SmartFormatter
     assert parser3.add_help is False
 
     # Check that error is thrown when required argument isn't passed
@@ -45,7 +45,7 @@ def test_sct_argument_parser(capsys):
 
 
 @pytest.fixture()
-def temporary_viewers(supported_viewers=utils.SUPPORTED_VIEWERS):
+def temporary_viewers(supported_viewers=shell.SUPPORTED_VIEWERS):
     """Set up and teardown viewer files to satisfy check_exe() check within the scope of the test."""
     for viewer in supported_viewers:
         open(viewer, 'a').close()
@@ -59,7 +59,7 @@ def temporary_viewers(supported_viewers=utils.SUPPORTED_VIEWERS):
 
 def test_display_viewer_syntax(temporary_viewers):
     """Test that sample input produces the required syntax string output."""
-    syntax_strings = utils.display_viewer_syntax(
+    syntax_strings = shell.display_viewer_syntax(
         files=["test_img.nii.gz", "test_img_2.nii.gz", "test_seg.nii.gz", "test_img_3.nii.gz"],
         im_types=['anat', 'anat', 'seg', 'anat'],
         minmax=['', '0,1', '0.25,0.75', ''],

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -8,7 +8,8 @@ import pickle
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import sct_test_path, extract_fname
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_analyze_lesion, sct_label_utils
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_compute_mtsat.py
+++ b/testing/cli/test_cli_sct_compute_mtsat.py
@@ -5,7 +5,7 @@ import pytest
 import nibabel
 import numpy as np
 
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 from spinalcordtoolbox.scripts import sct_compute_mtsat
 

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 
 from spinalcordtoolbox.scripts import sct_deepseg_sc
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.image import Image
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_dmri_denoise_patch2self.py
+++ b/testing/cli/test_cli_sct_dmri_denoise_patch2self.py
@@ -3,7 +3,7 @@
 import pytest
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.image import Image, add_suffix
 from spinalcordtoolbox.scripts import (sct_dmri_concat_b0_and_dwi,
                                        sct_dmri_denoise_patch2self,

--- a/testing/cli/test_cli_sct_dmri_display_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_display_bvecs.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 from spinalcordtoolbox.scripts import sct_dmri_display_bvecs
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 

--- a/testing/cli/test_cli_sct_image.py
+++ b/testing/cli/test_cli_sct_image.py
@@ -7,7 +7,8 @@ import pytest
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import extract_fname, sct_test_path
+from spinalcordtoolbox.utils.fs import extract_fname
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_image, sct_crop_image
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_label_utils.py
+++ b/testing/cli/test_cli_sct_label_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_label_utils, sct_create_mask
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -7,7 +7,7 @@ import pytest
 
 from spinalcordtoolbox.image import Image, compute_dice
 from spinalcordtoolbox.labels import check_missing_label
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 import spinalcordtoolbox.scripts.sct_label_vertebrae as sct_label_vertebrae
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_maths
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -8,7 +8,7 @@ import nibabel
 import csv
 
 from spinalcordtoolbox.scripts import sct_process_segmentation
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -6,7 +6,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.image import Image, compute_dice
-from spinalcordtoolbox.utils import run_proc, sct_test_path
+from spinalcordtoolbox.utils.sys import run_proc, sct_test_path
 from spinalcordtoolbox.scripts import sct_propseg
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import sct_test_path, sct_dir_local_path
+from spinalcordtoolbox.utils.sys import sct_dir_local_path, sct_test_path
 from spinalcordtoolbox.scripts import sct_register_multimodal, sct_create_mask
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from spinalcordtoolbox.image import Image, compute_dice
-from spinalcordtoolbox import __sct_dir__
+from spinalcordtoolbox.utils.sys import __sct_dir__
 from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_register_to_template, sct_apply_transfo
 

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -10,7 +10,7 @@ import pytest
 
 from spinalcordtoolbox.image import Image, compute_dice
 from spinalcordtoolbox import __sct_dir__
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_register_to_template, sct_apply_transfo
 
 logger = logging.getLogger(__name__)

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -9,7 +9,7 @@ import warnings
 from torch.serialization import SourceChangeWarning
 
 import spinalcordtoolbox as sct
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils.sys import sct_test_path
 import spinalcordtoolbox.deepseg.models
 
 from spinalcordtoolbox.scripts import sct_deepseg


### PR DESCRIPTION
This PR changes all imports from the `utils` package to instead import from the submodule where they are defined: either `utils.fs`, or `utils.sys`, or `utils.shell`. This allows us to get rid of the star-imports in `utils/__init__.py` (actually, the whole file).

Fixes #3845.

For the morbidly curious, I automated this with a hacky script, then visually inspected the diff. The command line was:
```bash
./fix_utils.py $(ag --py -l --ignore __init__.py 'utils import')
```
and the script itself was:
<details><summary><code>fix_utils.py</code></summary><p>

```python3
#!/usr/bin/env python3
import re
import sys
import textwrap

lookup = {
    "Tee": "fs",
    "TempFolder": "fs",
    "cache_save": "fs",
    "cache_signature": "fs",
    "cache_valid": "fs",
    "check_file_exist": "fs",
    "copy": "fs",
    "copy_helper": "fs",
    "extract_fname": "fs",
    "get_absolute_path": "fs",
    "mv": "fs",
    "rmtree": "fs",
    "tmp_create": "fs",
    "ANSIColors16": "sys",
    "__bin_dir__": "sys",
    "__data_dir__": "sys",
    "__get_commit": "sys",
    "__get_git_origin": "sys",
    "__sct_dir__": "sys",
    "__version__": "sys",
    "init_sct": "sys",
    "list2cmdline": "sys",
    "printv": "sys",
    "run_proc": "sys",
    "sct_dir_local_path": "sys",
    "sct_progress_bar": "sys",
    "sct_test_path": "sys",
    "send_email": "sys",
    "set_loglevel": "sys",
    "stylize": "sys",
    "removesuffix": "sys",
    "ActionCreateFolder": "shell",
    "SCTArgumentParser": "shell",
    "Metavar": "shell",
    "display_open": "shell",
    "display_viewer_syntax": "shell",
    "get_interpolation": "shell",
    "list_type": "shell",
    "parse_num_list": "shell",
    "parse_num_list_inv": "shell",
}

import_re = re.compile(
    r"""
    ^from \s+ spinalcordtoolbox\.utils(?:\.(fs|sys|shell))? \s+ import \s+
    ( (?:
        \( [^)]* \)
    |
        \\ \n
    |
        [^(\n\\]
    )* )\n
""",
    re.MULTILINE | re.VERBOSE,
)

import_re_no_capture = re.compile(
    r"""
    ^from \s+ spinalcordtoolbox\.utils(?:\.(?:fs|sys|shell))? \s+ import \s+
    (?: (?:
        \( [^)]* \)
    |
        \\ \n
    |
        [^(\n\\]
    )* )\n
""",
    re.MULTILINE | re.VERBOSE,
)

for filename in sys.argv[1:]:
    orig = open(filename).read()
    imported = set()
    for m in import_re.finditer(orig):
        mod, names = m.groups()
        names = "".join(c for c in names if c not in "() \n\\")
        imported.update(names.split(","))
    todo = {
        "fs": [],
        "sys": [],
        "shell": [],
    }
    for name in sorted(imported):
        todo[lookup[name]].append(name)
    imp_lines = []
    for mod, names in todo.items():
        if names:
            prefix = f"from spinalcordtoolbox.utils.{mod} import "
            one_line = prefix + ", ".join(names)
            if len(one_line) <= 100:
                imp_lines.append(one_line)
            else:
                prefix = prefix + "("
                width = 100 - len(prefix)
                for line in textwrap.wrap(
                    ", ".join(names) + ")", width=width, break_long_words=False
                ):
                    imp_lines.append(f"{prefix}{line}")
                    prefix = " " * len(prefix)
    parts = import_re_no_capture.split(orig)
    parts.insert(1, "".join(line + "\n" for line in imp_lines))
    modd = "".join(parts)
    with open(filename, "w") as f:
        f.write(modd)
```
</details>

(I used a previous iteration of the script, and some manual fixing, to generate the `lookup` dictionary.)