### PR TITLE
Remove unused `Image.verbose` attribute

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -274,8 +274,6 @@ class Image(object):
         if absolutepath is not None:
             self._path = os.path.abspath(absolutepath)
 
-        self.verbose = verbose
-
         # Case 1: load an image from file
         if isinstance(param, str):
             try:


### PR DESCRIPTION
A tiny tiny PR, but I noticed it once and it bothered me: the attribute `Image.verbose` is saved in `__init__`, but is never actually read anywhere. Instead, the pattern is that individual methods of `Image` which can be chatty accept a `verbose` parameter.

(To be sure that no one at all uses `Image.verbose`, I searched all python files for the string `.verbose`. All instances are either: `self.verbose` in another class, `param.verbose` in various scripts, `SpinalCordStraightener.verbose`, `Transform.verbose`, or `ImageCropper.verbose`.)