### PR TITLE
Replace assertions with more appropriate errors

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -90,7 +90,8 @@ def func_map(data, mask, map_clusters):
     :return: nd-array: matrix of all beta
     """
     # Check number of labels and map_clusters
-    assert mask.shape[-1] == len(map_clusters)
+    if mask.shape[-1] != len(map_clusters):
+        raise ValueError(f"Expected {mask.shape[-1]} clusters, but got {len(map_clusters)} clusters")
 
     # Iterate across all labels (excluding the first one) and generate cluster labels. Examples of input/output:
     #   [[0], [0], [0], [1], [2], [0]] --> [0, 0, 0, 1, 2, 0]

--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -112,7 +112,8 @@ def get_centerline(im_seg, param=ParamCenterline(), verbose=1, remove_temp_files
     # creation that is used for the other methods.
     if param.algo_fitting == 'optic':
         from spinalcordtoolbox.centerline import optic
-        assert param.contrast is not None
+        if param.contrast is None:
+            raise ValueError("Missing param.contrast")
         im_centerline = optic.detect_centerline(im_seg, param.contrast, remove_temp_files)
         x_centerline_fit, y_centerline_fit, z_centerline = find_and_sort_coord(im_centerline)
         # Compute derivatives using polynomial fit

--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -34,7 +34,8 @@ def main():
     pkg_dir = os.path.dirname(package_init_file)
 
     script = os.path.join(pkg_dir, "scripts", "{}.py".format(command))
-    assert os.path.exists(script)
+    if not os.path.exists(script):
+        raise FileNotFoundError(script)
 
     cmd = [sys.executable, script] + sys.argv[1:]
 

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -280,7 +280,8 @@ def install_model(name_model):
         download.install_data(model_urls, folder(name_model))
     # Dict of lists, with each list corresponding to a different model seed for ensembling
     else:
-        assert isinstance(url_field, dict), "Invalid url field in MODELS"
+        if not isinstance(url_field, dict):
+            raise ValueError("Invalid url field in MODELS")
         for seed_name, model_urls in url_field.items():
             logger.info(f"\nInstalling '{seed_name}'...")
             download.install_data(model_urls, folder(os.path.join(name_model, seed_name)), keep=True)

--- a/spinalcordtoolbox/deepseg_/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_/postprocessing.py
@@ -159,7 +159,7 @@ def keep_largest_object(z_slice_bin, x_cOm, y_cOm):
     :return: z_slice: int 2d-array: Processed 2d segmentation
     """
     if z_slice_bin.dtype != np.dtype('int'):
-        raise ValueError(f"Wrong dtype: {z_slice_bin.dtype}")
+        raise ValueError(f"Expected array of type int but got '{z_slice_bin.dtype}' instead.")
     # Find number of closed objects using skimage "label"
     labeled_obj, num_obj = label(z_slice_bin)
     # If more than one object is found, keep the largest one
@@ -186,5 +186,5 @@ def fill_holes_2d(z_slice):
     :return: int 2d-array: Output segmentation with holes filled
     """
     if z_slice.dtype != np.dtype('int'):
-        raise ValueError(f"Wrong dtype: {z_slice.dtype}")
+        raise ValueError(f"Expected array of type int but got '{z_slice.dtype}' instead.")
     return binary_fill_holes(z_slice, structure=np.ones((3, 3))).astype(int)

--- a/spinalcordtoolbox/deepseg_/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_/postprocessing.py
@@ -158,7 +158,8 @@ def keep_largest_object(z_slice_bin, x_cOm, y_cOm):
     :param y_cOm: int: Y center of mass of the segmentation for the previous 2d slice
     :return: z_slice: int 2d-array: Processed 2d segmentation
     """
-    assert z_slice_bin.dtype == np.dtype('int')
+    if z_slice_bin.dtype != np.dtype('int'):
+        raise ValueError(f"Wrong dtype: {z_slice_bin.dtype}")
     # Find number of closed objects using skimage "label"
     labeled_obj, num_obj = label(z_slice_bin)
     # If more than one object is found, keep the largest one
@@ -184,5 +185,6 @@ def fill_holes_2d(z_slice):
     :param z_slice: int 2d-array: Input 2D segmentation.
     :return: int 2d-array: Output segmentation with holes filled
     """
-    assert z_slice.dtype == np.dtype('int')
+    if z_slice.dtype != np.dtype('int'):
+        raise ValueError(f"Wrong dtype: {z_slice.dtype}")
     return binary_fill_holes(z_slice, structure=np.ones((3, 3))).astype(int)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -823,11 +823,12 @@ def compute_dice(image1, image2, mode='3d', label=1, zboundaries=False):
     dice = 0.0  # default value of dice is 0
 
     # check if images are in the same coordinate system
-    assert image1.data.shape == image2.data.shape, (
-        f"\n\nERROR: the data ({image1.absolutepath} and {image2.absolutepath}) don't have the same size."
-        f"\nPlease use  \"sct_register_multimodal -i im1.nii.gz -d im2.nii.gz -identity 1\"  "
-        f"to put the input images in the same space"
-    )
+    if image1.data.shape != image2.data.shape:
+        raise ValueError(
+            f"\n\nERROR: the data ({image1.absolutepath} and {image2.absolutepath}) don't have the same size."
+            f"\nPlease use  \"sct_register_multimodal -i im1.nii.gz -d im2.nii.gz -identity 1\"  "
+            f"to put the input images in the same space"
+        )
 
     # if necessary, change orientation of images to RPI and compute segmentation boundaries
     if mode == '2d-slices' or (mode == '3d' and zboundaries):
@@ -1818,7 +1819,8 @@ def generate_stitched_qc_images(ims_in: Sequence[Image], im_out: Image) -> Tuple
     im_concat = concat_data(im_concat_list, dim=2)     # Concatenate the input images and spacer images together
 
     # We assume that the [x,y] dimensions match for both of the two QC images
-    assert im_concat.data.shape[0:2] == im_out.data.shape[0:2]
+    if im_concat.data.shape[0:2] != im_out.data.shape[0:2]:
+        raise ValueError("Mismatched image dimensions: {im_concat.data.shape[0:2]} != {im_out.data.shape[0:2]}")
 
     # However, we can't assume that the [z] dimensions match, because concatenating and stitching produce very
     # different results (lengthwise). So, we pad the smaller image to make the dimensions match.

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1818,7 +1818,7 @@ def generate_stitched_qc_images(ims_in: Sequence[Image], im_out: Image) -> Tuple
 
     # We assume that the [x,y] dimensions match for both of the two QC images
     if im_concat.data.shape[0:2] != im_out.data.shape[0:2]:
-        raise ValueError("Mismatched image dimensions: {im_concat.data.shape[0:2]} != {im_out.data.shape[0:2]}")
+        raise ValueError(f"Mismatched image dimensions: {im_concat.data.shape[0:2]} != {im_out.data.shape[0:2]}")
 
     # However, we can't assume that the [z] dimensions match, because concatenating and stitching produce very
     # different results (lengthwise). So, we pad the smaller image to make the dimensions match.

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -296,7 +296,7 @@ def concatenate_along_last_dimension(data):
 
     # Case 3: 2D/5D/etc. images --> Not supported
     else:
-        raise ValueError(f"Can only process 3D/4D images, but received images with ndim = {ndims - {3,4}}")
+        raise ValueError(f"Can only process 3D/4D images, but received images with ndim = {ndims - {3, 4}}")
 
     return np.concatenate(data, axis=-1)
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -188,7 +188,8 @@ def smooth(data, sigmas):
     :param sigmas: Kernel SD in voxel
     :return:
     """
-    assert len(data.shape) == len(sigmas)
+    if len(data.shape) != len(sigmas):
+        raise ValueError(f"Expected {len(data.shape)} sigmas, but got {len(sigmas)}")
     return gaussian_filter(data.astype(float), sigmas, order=0, truncate=4.0)
 
 
@@ -196,7 +197,8 @@ def laplacian(data, sigmas):
     """
     Apply Laplacian filter
     """
-    assert len(data.shape) == len(sigmas)
+    if len(data.shape) != len(sigmas):
+        raise ValueError(f"Expected {len(data.shape)} sigmas, but got {len(sigmas)}")
     return gaussian_laplace(data.astype(float), sigmas)
 
 

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -245,7 +245,8 @@ class Slice(object):
                   containing the slices and matrix of the transformed 3D MRI
                   to output containing the slices
         """
-        assert len(set([x.data.shape for x in self._images])) == 1, "Volumes don't have the same size"
+        if len(set([x.data.shape for x in self._images])) != 1:
+            raise ValueError("Volumes don't have the same size")
 
         matrices = list()
         # Retrieve the L-R center of the slice for each row (i.e. in the S-I direction).
@@ -427,7 +428,8 @@ class Sagittal(Slice):
         :return: index: [int] * n_SI
         """
         image = self._images[img_idx].copy()
-        assert image.orientation == 'SAL'
+        if image.orientation != 'SAL':
+            raise ValueError(f"Image orientation should be SAL, but got: {image.orientation}")
         # If mask is empty, raise error
         if np.argwhere(image.data).shape[0] == 0:
             raise ValueError("Label/segmentation image is empty. Can't retrieve RL slice indices.")

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -274,7 +274,8 @@ class ComputeDistances:
         nx1, ny1, nz1, nt1, px1, py1, pz1, pt1 = self.im1.dim
         nx2, ny2, nz2, nt2, px2, py2, pz2, pt2 = self.im2.dim
 
-        assert np.isclose(px1, px2) and np.isclose(py1, py2) and np.isclose(px1, py1)
+        if not (np.isclose(px1, px2) and np.isclose(py1, py2) and np.isclose(px1, py1)):
+            raise ValueError("Resolutions are not close enough")
         self.dim_pix = py1
 
         if self.param.thinning:
@@ -308,7 +309,8 @@ class ComputeDistances:
         nx1, ny1, nz1, nt1, px1, py1, pz1, pt1 = self.im1.dim
         nx2, ny2, nz2, nt2, px2, py2, pz2, pt2 = self.im2.dim
         # assert np.round(pz1, 5) == np.round(pz2, 5) and np.round(py1, 5) == np.round(py2, 5)
-        assert nx1 == nx2
+        if nx1 != nx2:
+            raise ValueError(f"Mismatched image dimensions: {nx1} != {nx2}")
         self.dim_pix = py1
 
         if self.param.thinning:

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -274,8 +274,10 @@ class ComputeDistances:
         nx1, ny1, nz1, nt1, px1, py1, pz1, pt1 = self.im1.dim
         nx2, ny2, nz2, nt2, px2, py2, pz2, pt2 = self.im2.dim
 
-        if not (np.isclose(px1, px2) and np.isclose(py1, py2) and np.isclose(px1, py1)):
-            raise ValueError("Resolutions are not close enough")
+        if not all(np.isclose(px1, py1) and np.isclose(px2, py2)):
+            raise ValueError(f"2D resolutions must both be isotropic, but got '{(px1, py1)}' and '{(px2, py2)}' instead.")
+        if not all(np.isclose(px1, px2) and np.isclose(py1, py2)):
+            raise ValueError(f"2D resolutions must be close to one another, but got '{(px1, py1)}' and '{(px2, py2)}' instead.")
         self.dim_pix = py1
 
         if self.param.thinning:

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -274,7 +274,7 @@ def main(argv: Sequence[str]):
     # Arguments are sorted alphabetically (not according to the usage order)
     if arguments.concat is not None:
         dim = arguments.concat
-        assert dim in DIM_LIST
+        assert dim in DIM_LIST  # Enforced by add_argument(..., choices=...)
         dim = DIM_LIST.index(dim)
         im_out = [concat_data(im_in_list, dim)]
 
@@ -382,7 +382,7 @@ def main(argv: Sequence[str]):
 
     elif arguments.split is not None:
         dim = arguments.split
-        assert dim in DIM_LIST
+        assert dim in DIM_LIST  # Enforced by add_argument(..., choices=...)
         dim = DIM_LIST.index(dim)
         im_out = split_data(im_in, dim)
 
@@ -566,7 +566,8 @@ def multicomponent_split(im):
     :return:
     """
     data = im.data
-    assert len(data.shape) == 5
+    if len(data.shape) != 5:
+        raise ValueError(f"Wrong number of dimensions: {len(data.shape)}")
     data_out = []
     for i in range(data.shape[-1]):
         dat_out = data[:, :, :, :, i]

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -567,7 +567,7 @@ def multicomponent_split(im):
     """
     data = im.data
     if len(data.shape) != 5:
-        raise ValueError(f"Wrong number of dimensions: {len(data.shape)}")
+        raise ValueError(f"Expected 5D image but got '{len(data.shape)}' dimensions instead.")
     data_out = []
     for i in range(data.shape[-1]):
         dat_out = data[:, :, :, :, i]

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -201,7 +201,8 @@ def main(argv: Sequence[str]):
     rm_tmp = arguments.r
 
     # check if list of input files and warping fields have same length
-    assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"
+    if len(list_fname_src) != len(list_fname_warp):
+        parser.error("lists of files are not of the same length")
 
     # merge src images to destination image
     merge_images(list_fname_src, fname_dest, list_fname_warp, fname_out, interp, rm_tmp)

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -316,7 +316,8 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
                              stdout=open(log_file, 'w'),
                              stderr=subprocess.STDOUT)
 
-        assert res.returncode == 0, 'Processing of subject {} failed'.format(subject)
+        if res.returncode != 0:
+            raise ValueError(f"Processing of subject {subject} failed")
     except Exception as e:
         process_completed = 'res' in locals()
         res = res if process_completed else SimpleNamespace(returncode=-1)


### PR DESCRIPTION
This PR replaces most instances of `assert` in SCT with `raise`.

Apart from unit tests, assertions are meant for internal invariants, and are not even guaranteed to be run (for example, if python is run with `-O`).

For bad script arguments, calling `parser.error` is better. For bad function arguments, usually raising `ValueError` or `TypeError` is better.