### PR TITLE
Use the same Python version as SCT for linting

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       run: pip install flake8
     # Note: flake8 picks up project-wide configuration options from 'setup.cfg' in SCT's root directory


### PR DESCRIPTION
This is the easiest way to make sure that developers' commit hooks generate the same warnings/errors as what runs in CI. Otherwise, we get annoyances like in #4294.
