### PR TITLE
Apply missing B1 correction to `r1map` and `a` calculations to fix MTsat bug

### DIFF
--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -8,6 +8,7 @@ License: see the file LICENSE
 """
 
 import logging
+
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -102,7 +103,7 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
         # compute R1
         logger.info("Compute T1 map...")
         r1map = 0.5 * np.multiply(np.multiply(nii_b1map.data, nii_b1map.data), np.true_divide((fa_t1_rad / tr_t1) * nii_t1.data - (fa_pd_rad / tr_pd) * nii_pd.data,
-                                     nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad))
+                                                                                              nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad))
         # remove nans and clip unrelistic values
         r1map = np.nan_to_num(r1map)
         ind_unrealistic = np.where(r1map < r1_threshold)
@@ -119,10 +120,10 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
 
     # Compute A
     logger.info("Compute A...")
-    a = np.divide((tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) * \
-        np.true_divide(np.multiply(nii_pd.data, nii_t1.data, dtype=float),
-                       tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data), \
-                       nii_b1map.data)
+    a = np.divide((tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) *
+                  np.true_divide(np.multiply(nii_pd.data, nii_t1.data, dtype=float),
+                                 tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data),
+                  nii_b1map.data)
 
     # Compute MTsat
     logger.info("Compute MTsat...")

--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -102,8 +102,12 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
     if nii_t1map is None:
         # compute R1
         logger.info("Compute T1 map...")
-        r1map = 0.5 * np.multiply(np.multiply(nii_b1map.data, nii_b1map.data), np.true_divide((fa_t1_rad / tr_t1) * nii_t1.data - (fa_pd_rad / tr_pd) * nii_pd.data,
-                                                                                              nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad))
+        r1map = 0.5 * np.true_divide((fa_t1_rad / tr_t1) * nii_t1.data - (fa_pd_rad / tr_pd) * nii_pd.data,
+                                     nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad)
+        # apply B1 correction if available
+        if nii_b1map is not None:
+            b1_squared = np.multiply(nii_b1map.data, nii_b1map.data)
+            r1map = np.multiply(r1map, b1_squared)
         # remove nans and clip unrelistic values
         r1map = np.nan_to_num(r1map)
         ind_unrealistic = np.where(r1map < r1_threshold)
@@ -120,10 +124,12 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
 
     # Compute A
     logger.info("Compute A...")
-    a = np.divide((tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) *
-                  np.true_divide(np.multiply(nii_pd.data, nii_t1.data, dtype=float),
-                                 tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data),
-                  nii_b1map.data)
+    a = (tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) * \
+        np.true_divide(np.multiply(nii_pd.data, nii_t1.data, dtype=float),
+                       tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data)
+    # apply B1 correction if available
+    if nii_b1map is not None:
+        a = np.divide(a, nii_b1map.data)
 
     # Compute MTsat
     logger.info("Compute MTsat...")

--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -101,8 +101,8 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
     if nii_t1map is None:
         # compute R1
         logger.info("Compute T1 map...")
-        r1map = 0.5 * np.true_divide((fa_t1_rad / tr_t1) * nii_t1.data - (fa_pd_rad / tr_pd) * nii_pd.data,
-                                     nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad)
+        r1map = 0.5 * np.multiply(np.multiply(nii_b1map.data, nii_b1map.data), np.true_divide((fa_t1_rad / tr_t1) * nii_t1.data - (fa_pd_rad / tr_pd) * nii_pd.data,
+                                     nii_pd.data / fa_pd_rad - nii_t1.data / fa_t1_rad))
         # remove nans and clip unrelistic values
         r1map = np.nan_to_num(r1map)
         ind_unrealistic = np.where(r1map < r1_threshold)
@@ -119,9 +119,10 @@ def compute_mtsat(nii_mt, nii_pd, nii_t1,
 
     # Compute A
     logger.info("Compute A...")
-    a = (tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) * \
+    a = np.divide((tr_pd * fa_t1_rad / fa_pd_rad - tr_t1 * fa_pd_rad / fa_t1_rad) * \
         np.true_divide(np.multiply(nii_pd.data, nii_t1.data, dtype=float),
-                       tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data)
+                       tr_pd * fa_t1_rad * nii_t1.data - tr_t1 * fa_pd_rad * nii_pd.data), \
+                       nii_b1map.data)
 
     # Compute MTsat
     logger.info("Compute MTsat...")


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/geek-tips/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The MTsat equations in SCT were inherited from qMRLab. I've just discovered that the initial implementation of the B1 correction of MTsat in qMRLab was missing corrections for the PDw and T1w excitation flip angles, which for large B1 errors causes substantial differences in the T1 and MTsat maps. Other softwares have these B1 corrections ([QUIT](https://github.com/spinicist/QUIT/blob/5af31041a2194c81306826a729e6729f4d806f3d/Source/MT/MTSatModel.cpp#L12-L20), hMRI [R1](https://github.com/hMRI-group/hMRI-toolbox/blob/894a38be696e42a769765c313022f0bf1acafe64/hmri_calc_R1.m#L41-L47) and [A](https://github.com/hMRI-group/hMRI-toolbox/blob/894a38be696e42a769765c313022f0bf1acafe64/hmri_calc_A.m#L41-L47)). 

This PR seeks to fix this bug, and is designed closest to the QUIT implementation (with the B1 multiplications factored out of the main calculations, instead of multiplying each FA by B1).

Here's a before/after fix using SCT for a ultra high field mouse brain dataset that has sever B1 inhomogeneity.

# MTsat map
## Before
<img width="1293" alt="Screenshot 2023-11-22 at 1 29 13 PM" src="https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/1421029/c799825f-77f3-4c47-8dfe-f056db7542e8">

##After
<img width="1293" alt="Screenshot 2023-11-22 at 1 30 57 PM" src="https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/1421029/486baebd-7b56-4a79-b35f-4a4bae3c383d">

# T1 map
## Before
<img width="1293" alt="Screenshot 2023-11-22 at 1 29 38 PM" src="https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/1421029/d6600b70-50eb-48ae-b0b6-9357093a6866">

## After
<img width="1293" alt="Screenshot 2023-11-22 at 1 31 20 PM" src="https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/1421029/96cf5de4-0ec6-4f5e-a234-3fb1291a7998">



## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

https://github.com/qMRLab/qMRLab/pull/497
