### PR TITLE
Update `numpy` upper bound from `<1.24` to `<1.25`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,9 @@ matplotlib
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
-numpy
+# Currently, we pin dipy such that 1.5.0 gets installed. However, dipy 1.5.0 is incompatible with
+# numpy>=1.25.0. So, we have to pin numpy on their behalf.
+numpy<1.25
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@
 #     stable releases. We do this because `pip freeze` will not capture options (e.g. --extra-index-url) or
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
-# v1.5 and below are incompatible with newer versions of numpy
-# We also avoid v1.6 and v1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy>1.7.0
+# Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
+dipy!=1.6.*,!=1.7.*
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,7 @@ matplotlib
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
-# This pin is due to an incompatibility with pystrum==0.2, which is installed via voxelmorph -> neurite -> pystrum
-# See also: https://github.com/adalca/pystrum/issues/9
-# If pystrum is updated to 0.3, then we should replace this version pinning with `pystrum>=0.3`
-numpy<1.24
+numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 #     stable releases. We do this because `pip freeze` will not capture options (e.g. --extra-index-url) or
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
-# Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy!=1.6.*,!=1.7.*
+# v1.5 and below are incompatible with newer versions of numpy
+# We also avoid v1.6 and v1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
+dipy>1.7.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Previously, we pinned `numpy<1.24` due to an incompatibility with pystrum:

> ```bash
> # This pin is due to an incompatibility with pystrum==0.2, which is installed via voxelmorph -> neurite -> pystrum
> # See also: https://github.com/adalca/pystrum/issues/9
> ```

Pystrum has since been updated, so the `numpy<1.24` upper bound can be removed.

However, this runs into _another_ incompatibility, this time with `dipy`. (We're forced to avoid the newest versions of dipy due to an upstream bug https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328. And, the older version of dipy is incompatible with `numpy>=1.25`, hence the new upper bound.)

This will be relevant for PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4231, since the MONAI contrast-agnostic code uses a newer version of numpy. So, if we want to test those new additions, it would be good to have numpy unpinned.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Related to #4182.