### PR TITLE
Set `minmax=False` to prevent cropping during angle correction, avoiding slice number mismatches

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -495,7 +495,8 @@ class AnalyzeLesion:
         nx, ny, nz, nt, px, py, pz, pt = im_seg.dim
 
         # fit centerline, smooth it and return the first derivative (in physical space)
-        _, arr_ctl, arr_ctl_der, _ = get_centerline(im_seg, param=ParamCenterline(), verbose=1)
+        # We set minmax=False to prevent cropping and ensure that `self.angles[iz]` covers all z slices of `im_seg`
+        _, arr_ctl, arr_ctl_der, _ = get_centerline(im_seg, param=ParamCenterline(minmax=False), verbose=1)
         x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = arr_ctl_der
 
         self.angles = np.full_like(np.empty(nz), np.nan, dtype=np.double)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In `sct_analyze_lesion` we perform angle correction [using the centerline derivative](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/365651dbd7d31b909b7ec85844b0e6492a4649ca/spinalcordtoolbox/scripts/sct_analyze_lesion.py#L504C1-L504C1) (via the `get_centerline` function). The `get_centerline` function [crops the centerline by default](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/365651dbd7d31b909b7ec85844b0e6492a4649ca/spinalcordtoolbox/centerline/core.py#L137-L141), due to the parameter `minmax` [being `True` by default](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/365651dbd7d31b909b7ec85844b0e6492a4649ca/spinalcordtoolbox/centerline/core.py#L21).

Cropping has the following knock-on effects:

- The `arr_ctl_der` array's dimensions no longer match the number of z slices in the image.
- Thus, when we iterate over `arr_ctl_der` using `range`, the 0-based indexes (`0, 1, 2...`) will (most likely) no longer match the slice numbers occupied by the centerline.
- This means that when we [compute `self.angles`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/365651dbd7d31b909b7ec85844b0e6492a4649ca/spinalcordtoolbox/scripts/sct_analyze_lesion.py#L510), the indexes (`iz`) are not slice numbers either!
- So, when we [fetch `self.angles` later on](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/365651dbd7d31b909b7ec85844b0e6492a4649ca/spinalcordtoolbox/scripts/sct_analyze_lesion.py#L312) (using `zz`), the values are mismatched (and the results are wrong).

By setting `minmax=False`, we prevent the cropping (and thus the resulting mismatch).

> [!NOTE]
> `mixmax=False` actually used to be the default behavior, introduced in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2147.
>
> But, this default was changed in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2154, and thus this bug was introduced.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4315.
