### PR TITLE
Temporary fix for dependency issue with dipy 1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy!=1.6.*,!=1.7.*
+# dipy 1.8.x causes conflicts, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319#issuecomment-1864670675
+dipy!=1.6.*,!=1.7.*, !=1.8.*
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description
This PR temporarily resolves a dependency conflict that makes the current version of SCT crash when installing. To temporarily solve the problem, I restricted the use of dipy 1.8.x.

## Linked issues
#4319 