### PR TITLE
Clarify `sct_label_utils -disc` help

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -122,7 +122,10 @@ def get_parser():
     func_group.add_argument(
         '-disc',
         metavar=Metavar.file,
-        help="Create an image with regions labelized depending on values from reference"
+        help="Project disc labels onto the spinal cord segmentation to create a labeled segmentation. "
+             "Note: Unlike 'sct_label_vertebrae -discfile', this function does not involve cord straightening. "
+             "The disc labeling follows the convention: "
+             "https://spinalcordtoolbox.com/user_section/tutorials/vertebral-labeling/labeling-conventions.html"
     )
 
     func_group.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -131,7 +131,7 @@ def get_parser():
     func_group.add_argument(
         '-project-centerline',
         metavar=Metavar.file,
-        help="Project labels onto the spinal cord centerline"
+        help="Project disc labels onto the spinal cord centerline."
     )
 
     func_group.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -46,7 +46,7 @@ def get_parser():
         '-o',
         metavar=Metavar.file,
         default='labels.nii.gz',
-        help=("Output image. Note: Only some label utilities create an output image. Example: t2_labels.nii.gz")
+        help="Output image. Note: Only some label utilities create an output image. Example: t2_labels.nii.gz"
     )
 
     io_group.add_argument(


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR clarifies the `sct_label_utils -disc` help to make it clear that this flag is used to create a labeled segmentation from disc labels without cord straightening.

## Linked issues
Resolves: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4323
