### PR TITLE
For `-normalize-PAM50` option, replace `FileNotFoundError` with `parser.error` so that the argparse help gets displayed

### DIFF
--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -391,7 +391,7 @@ def main(argv: Sequence[str]):
                        f"not be displayed. To use vertebral level information, you may need to run "
                        f"`sct_warp_template` to generate the appropriate level file in your working directory.")
         if normalize_pam50:
-            raise FileNotFoundError("The vertebral level file must exist to use -normalize-PAM50.")
+            parser.error("Option '-normalize-PAM50' requires option '-vertfile'.")
         fname_vert_level = None  # Discard the default '-vertfile', so that we don't attempt to find vertebral levels
         if levels:
             raise FileNotFoundError("The vertebral level file must exist to use `-vert` to group by vertebral level.")

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -125,7 +125,7 @@ def test_sct_process_segmentation_check_normalize_PAM50_missing_perslice(tmp_pat
 def test_sct_process_segmentation_check_normalize_PAM50_missing_vertfile(tmp_path):
     """ Run sct_process_segmentation with -normalize PAM50 when missing -vertfile"""
     filename = str(tmp_path / 'tmp_file_out.csv')
-    with pytest.raises(FileNotFoundError) as e:
+    with pytest.raises(SystemExit) as e:
         sct_process_segmentation.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-normalize-PAM50', '1',
                                             '-perslice', '1', '-o', filename])
         assert e.value.code == 2


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This minor PR replaces FileNotFoundError by parser.error when `-normalize-PAM50` is provided without the required option `-vertfile`.

`master` branch:

```console
$ cd dcm-zurich/derivatives/labels/sub-250791
$ sct_process_segmentation -i /anat/sub-250791_acq-axial_T2w_label-SC_mask-manual.nii.gz -normalize-PAM50 1
...
Vertebral level file ./label/template/PAM50_levels.nii.gz does not exist. Vert level information will not be displayed. To use vertebral level information, you may need to run `sct_warp_template` to generate the appropriate level file in your working directory.
Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_process_segmentation.py", line 528, in <module>
    main(sys.argv[1:])
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_process_segmentation.py", line 394, in main
    raise FileNotFoundError("The vertebral level file must exist to use -normalize-PAM50.")
FileNotFoundError: The vertebral level file must exist to use -normalize-PAM50.
```

this PR:

```console
$ cd dcm-zurich/derivatives/labels/sub-250791
$ sct_process_segmentation -i /anat/sub-250791_acq-axial_T2w_label-SC_mask-manual.nii.gz -normalize-PAM50 1
...
sct_process_segmentation: error: Option '-normalize-PAM50' requires option '-vertfile'
```

The error message with parser.error is clearer and the arg handling is now in line with handling of flags `-normalize-PAM50` and `-perslice 1` ([L413-L414](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/spinalcordtoolbox/scripts/sct_process_segmentation.py#L413-L414)).



