### PR TITLE
Fix path splitting when space (`' '`) is present in `isct_spine_detect` model path

### DIFF
--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -78,7 +78,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # Run detection
     logger.info('Run C2-C3 detector...')
     os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
-    cmd_detection = (['isct_spine_detect', '-ctype=dpdt', path_model, 'data_midSlice', 'data_midSlice_pred'])
+    cmd_detection = ['isct_spine_detect', '-ctype=dpdt', path_model, 'data_midSlice', 'data_midSlice_pred']
     # The command below will fail, but we don't care because it will output an image (prediction), which we
     # will use later on.
     s, o = run_proc(cmd_detection, verbose=0, is_sct_binary=True, raise_exception=False)

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -78,8 +78,9 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # Run detection
     logger.info('Run C2-C3 detector...')
     os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
-    cmd_detection = 'isct_spine_detect -ctype=dpdt "%s" "%s" "%s"' % \
-                    (path_model, 'data_midSlice', 'data_midSlice_pred')
+    # passing arguments for run_proc which is consistent with others like sct_apply_transfo, sct_straighten_spinalcord, etc.
+    # No need to split string of arguments into lists. White space problem if exists in the path of the environment/folder is solved. 
+    cmd_detection = (['isct_spine_detect', '-ctype=dpdt', path_model, 'data_midSlice', 'data_midSlice_pred'])
     # The command below will fail, but we don't care because it will output an image (prediction), which we
     # will use later on.
     s, o = run_proc(cmd_detection, verbose=0, is_sct_binary=True, raise_exception=False)

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -78,8 +78,6 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # Run detection
     logger.info('Run C2-C3 detector...')
     os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
-    # passing arguments for run_proc which is consistent with others like sct_apply_transfo, sct_straighten_spinalcord, etc.
-    # No need to split string of arguments into lists. White space problem if exists in the path of the environment/folder is solved. 
     cmd_detection = (['isct_spine_detect', '-ctype=dpdt', path_model, 'data_midSlice', 'data_midSlice_pred'])
     # The command below will fail, but we don't care because it will output an image (prediction), which we
     # will use later on.


### PR DESCRIPTION
Hi SCT Group, 

I was trying to use SCT in 3D Slicer environment. Installation works perfect.  
 
https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/5b9f2451f40f5e45a3c04d2a9826f34b452d19e8/spinalcordtoolbox/vertebrae/detect_c2c3.py#L85C13-L85C13

during https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/5b9f2451f40f5e45a3c04d2a9826f34b452d19e8/spinalcordtoolbox/utils/sys.py#L333C6-L333C6 

it tries to split cmd in couple of argument lists.

The problem for me is Slicer 5.6.1 has a space in between.
(example)
" 'C:\\Users\\admin\\AppData\\Local\\slicer.org\\Slicer 5.6.1\\lib\\Python\\Lib\\site-packages\\bin\\isct_spine_detect -ctype=dpdt "C:\\Users\\admin\\AppData\\Local\\slicer.org\\Slicer 5.6.1\\lib\\Python\\Lib\\site-packages\\data\\c2c3_disc_models\\t1_model" "data_midSlice" "data_midSlice_pred" " 

it will split environment path like this (C:\\Users\\admin\\AppData\\Local\\slicer.org\\Slicer) ;  which is wrong. 

first split I expect is something like this 

C:\\Users\\admin\\AppData\\Local\\slicer.org\\Slicer 5.6.1\\lib\\Python\\Lib\\site-packages\\bin\\isct_spine_detect

Therefore refactoring cmd_detection here 
https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/5b9f2451f40f5e45a3c04d2a9826f34b452d19e8/spinalcordtoolbox/vertebrae/detect_c2c3.py#L81 as a lists before passing to run_proc.

with above changes in code solved the issues. 

Raj
