### PR TITLE
Update argparse descriptions to make it clear that the script can also be used to compute MCC

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
-# Compute maximum spinal cord compression using AP diameter or other morphometrics.
+# Compute maximum spinal cord compression (MSCC) or maximum canal compromise (MCC) using AP diameter or other
+# morphometrics.
 #
 # Copyright (c) 2023 Polytechnique Montreal <www.neuro.polymtl.ca>
 # License: see the file LICENSE

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -33,7 +33,9 @@ INDEX_COLUMNS = ['filename', 'compression_level', 'slice(I->S)']
 # ==========================================================================================
 def get_parser():
     parser = SCTArgumentParser(
-        description='Compute normalized morphometric measures to assess spinal cord compression.\n'
+        description='Compute normalized morphometric metrics to assess:'
+                    '\n\t- spinal cord compression using MSCC (maximum spinal cord compression)'
+                    '\n\t- spinal canal stenosis using MCC (maximum canal compromise)\n'
                     '\n'
                     'Metrics are normalized using the non-compressed levels above and below the compression site using '
                     'the following equation:\n'
@@ -64,7 +66,9 @@ def get_parser():
         '-i',
         metavar=Metavar.file,
         required=True,
-        help='Spinal cord segmentation mask to compute morphometrics. Example: sub-001_T2w_seg.nii.gz'
+        help='Spinal cord or spinal canal segmentation mask to compute morphometrics from. If spinal cord segmentation '
+             'is provided, MSCC is computed. If spinal canal segmentation is provided, MCC is computed. '
+             'Example: sub-001_T2w_seg.nii.gz'
              '\nNote: If no normalization is wanted (i.e., if the "-normalize-hc" flag is not specified),'
              ' metric ratio will take the average along the segmentation centerline.'
     )
@@ -98,7 +102,8 @@ def get_parser():
         metavar=Metavar.int,
         type=int,
         choices=[0, 1],
-        help='Set to 1 to normalize the metrics using a database of healthy controls. Set to 0 to not normalize.'
+        help='Set to 1 to normalize the metrics using a database of healthy controls. Set to 0 to not normalize. '
+             '\nNote: This flag is valid only if the spinal cord segmentation is provided by the flag "-i".',
     )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -104,7 +104,8 @@ def get_parser():
         type=int,
         choices=[0, 1],
         help='Set to 1 to normalize the metrics using a database of healthy controls. Set to 0 to not normalize. '
-             '\nNote: This flag is valid only if the spinal cord segmentation is provided by the flag "-i".',
+             '\nNote: This flag should not be set to 1 when computing the MCC (i.e. using spinal canal segmentation). '
+             'It should only be used when computing the MSCC (i.e. using spinal cord segmentation).'
     )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -65,7 +65,7 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help='Spinal cord segmentation mask to compute morphometrics. Example: sub-001_T2w_seg.nii.gz'
-             '\nNote: If no normalization is wanted (i.e., if the "-normalize" flag is not specified),'
+             '\nNote: If no normalization is wanted (i.e., if the "-normalize-hc" flag is not specified),'
              ' metric ratio will take the average along the segmentation centerline.'
     )
     mandatory.add_argument(
@@ -349,7 +349,7 @@ def get_centerline_object(img_seg, verbose):
 def get_slices_upper_lower_level_from_centerline(centerline, distance, extent, z_compressions, z_ref):
     """
     Get slices to average for the level above the highest compression and below the lowest compression from the centerline.
-    (If arg -normalize is not used; meaning no normalization)
+    (If arg -normalize-hc is not used; meaning no normalization)
     : param centerline: Centerline(): Spinal cord centerline object
     : param distance: float: distance (mm) from the compression from where to average healthy slices.
     : param extent: float: extent (mm) to average healthy slices.

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -53,7 +53,7 @@ def get_parser():
                     'with 100 consecutive patients. Radiology 2007;243(3):820-827.\n'
                     'doi.org/10.1148/radiol.2433060583\n'
                     '\n'
-                    'Reference for \'-normalize-hc\':\n'
+                    'Reference for the "-normalize-hc" flag:\n'
                     'Valošek J, Bédard S, Keřkovský M, Rohan T, Cohen-Adad J. A database of the healthy human spinal '
                     'cord morphometry in the PAM50 template space. NeuroLibre Reproducible Preprints 2023; 17.\n'
                     'doi.org/10.55458/neurolibre.00017'

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -68,8 +68,8 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help='Spinal cord or spinal canal segmentation mask to compute morphometrics from. If spinal cord segmentation '
-             'is provided, MSCC is computed. If spinal canal segmentation (spinal cord + CSF) is provided, MCC is computed. '
-             'Example: sub-001_T2w_seg.nii.gz'
+             'is provided, MSCC is computed. If spinal canal segmentation (spinal cord + CSF) is provided, MCC is '
+             'computed. Example: sub-001_T2w_seg.nii.gz'
              '\nNote: If no normalization is wanted (i.e., if the "-normalize-hc" flag is not specified),'
              ' metric ratio will take the average along the segmentation centerline.'
     )

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -68,7 +68,7 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help='Spinal cord or spinal canal segmentation mask to compute morphometrics from. If spinal cord segmentation '
-             'is provided, MSCC is computed. If spinal canal segmentation is provided, MCC is computed. '
+             'is provided, MSCC is computed. If spinal canal segmentation (spinal cord + CSF) is provided, MCC is computed. '
              'Example: sub-001_T2w_seg.nii.gz'
              '\nNote: If no normalization is wanted (i.e., if the "-normalize-hc" flag is not specified),'
              ' metric ratio will take the average along the segmentation centerline.'

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -83,7 +83,7 @@ def get_parser():
         help='NIfTI file that includes labels at the compression sites. '
              'Each compression site is denoted by a single voxel of value `1`.'
              ' Example: sub-001_T2w_compression_labels.nii.gz '
-             'Note: The input and the compression label file must be in the same voxel coordinate system '
+             '\nNote: The input and the compression label file must be in the same voxel coordinate system '
              'and must match the dimensions between each other.'
     )
     mandatory.add_argument(

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -73,7 +73,7 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help='Vertebral labeling file. Example: sub-001_T2w_seg_labeled.nii.gz'
-             'Note: The input and the vertebral labelling file must be in the same voxel coordinate system'
+             '\nNote: The input and the vertebral labelling file must be in the same voxel coordinate system'
              'and must match the dimensions between each other.'
     )
     mandatory.add_argument(


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
The `sct_compute_compression` function is meant to compute maximum spinal cord compression (MSCC) using the SC segmentation.
This PR updates the `sct_compute_compression` description to make clear that the function can also be used for maximum canal compromise (MCC) computation if spinal canal (aka CSF) segmentation is provided.
More context in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4330.

Currently, I have updated only the description (without changing any code). This assumes that users will read the description and will not provide spinal canal segmentation in combination with the `-normalize-hc` flag ([normative database](https://github.com/spinalcordtoolbox/PAM50-normalized-metrics) does not contain measures of the spinal canal). I made this clear by the following note:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/0ab10445492d456e0b907d494c01551814b286c0/spinalcordtoolbox/scripts/sct_compute_compression.py#L101-L106

## Linked issues
Resolves https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4330
