### PR TITLE
Pull upstream `ivadomed` changes that let us upgrade previously-pinned versions of `dipy`/`numpy`/`nibabel`

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Check for broken links
       run: | 
         touch valid_urls.txt redirected_urls.txt invalid_urls.txt
-        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \( \! -name 'CHANGES.md' \) | 
+        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
+          \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) | 
           xargs grep -Eo "\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]" | 
           sed 's/:/;/' | 
           xargs -n 1 -P 8 ./.github/workflows/check-url.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy!=1.6.*,!=1.7.*
+dipy!=1.6.*,!=1.7.*,<1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
-ivadomed @ git+https://github.com/ivadomed/ivadomed@master # append_to_freeze
+ivadomed
 matplotlib
 monai[nibabel]
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-# dipy 1.8 and above cause conflicts, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319#issuecomment-1864670675
-dipy<1.6
+dipy!=1.6.*,!=1.7.*
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dipy<1.6
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
-ivadomed
+ivadomed @ git+https://github.com/ivadomed/ivadomed@master # append_to_freeze
 matplotlib
 monai[nibabel]
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,7 @@ msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
 nnunetv2
-# This pin is due to an incompatibility with pystrum==0.2, which is installed via voxelmorph -> neurite -> pystrum
-# See also: https://github.com/adalca/pystrum/issues/9
-# If pystrum is updated to 0.3, then we should replace this version pinning with `pystrum>=0.3`
-numpy<1.24
+numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
@@ -38,6 +35,9 @@ psutil
 pyqt5==5.12.3
 # PyQt5-sip should be updated when PyQt5 is updated: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4354
 pyqt5-sip<12.13.0
+# pystrum==0.2 is incompatible with newer versions of numpy (installed via voxelmorph -> neurite -> pystrum)
+# See also: https://github.com/adalca/pystrum/issues/9
+pystrum>=0.3
 pytest
 pytest-cov
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ filterwarnings =
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
     # This warning is due to a deprecation for a call that is still used by many upstream packages. In our case:
-    # - wandb: https://github.com/wandb/wandb/issues/6711
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    # - monai: https://github.com/Project-MONAI/MONAI/issues/7559
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning:monai.*:
     # These warnings are for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
     ignore:.*is non-interactive, and thus cannot be shown:UserWarning:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ filterwarnings =
     #    seriously, but are time-consuming to debug. These should definitely be explored in future issues.
     #    1a. This is the most frequent error. Happens in at least 5 separate LOCs.
     ignore:invalid value encountered in divide.*:RuntimeWarning:
+    ignore:invalid value encountered in scalar divide.*:RuntimeWarning:
     #    1b. This is the second-most frequent error. Happens in at least 2 separate LOCs.
     ignore:invalid value encountered in double_scalars.*:RuntimeWarning:
     #    1c. This happens once: `test_cli_register_to_template` --> `compute_pca()` --> `coordsrc.mean(0)`

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,9 @@ filterwarnings =
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
+    # This warning is due to a deprecation for a call that is still used by many upstream packages. In our case:
+    # - wandb: https://github.com/wandb/wandb/issues/6711
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # These warnings are for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
     ignore:.*is non-interactive, and thus cannot be shown:UserWarning:

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,10 @@ filterwarnings =
     # This is a warning we ourselves generate, and needs discussion
     # Revisit as part of: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4357
     ignore:.*with additional arguments is discouraged:UserWarning:
+    # NB: `pandas` is being held to <2.0.0 by ivadomed, but numpy is free to upgrade, resulting in several upstream
+    # deprecation warnings by mixing an out-of-date pandas with an up-to-date numpy.
+    ignore:np.find_common_type is deprecated:DeprecationWarning:pandas.*:
+    ignore:NumPy will stop allowing conversion:DeprecationWarning:pandas.*:
 
 [flake8]
 max-line-length = 179

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,6 @@ filterwarnings =
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
-    # This warning is due to a deprecation for a call that is still used by many upstream packages. In our case:
-    # - wandb: https://github.com/wandb/wandb/issues/6711
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # These warnings are for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
     ignore:.*is non-interactive, and thus cannot be shown:UserWarning:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,9 @@ filterwarnings =
     # deprecation warnings by mixing an out-of-date pandas with an up-to-date numpy.
     ignore:np.find_common_type is deprecated:DeprecationWarning:pandas.*:
     ignore:NumPy will stop allowing conversion:DeprecationWarning:pandas.*:
+    # MONAI/nnUNet warnings: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4404
+    ignore:Detected old nnU-Net plans format:UserWarning:nnunetv2.*:
+    ignore:.*Our suggested max number of worker.*:UserWarning:torch.*:
 
 [flake8]
 max-line-length = 179

--- a/spinalcordtoolbox/deepseg_/onnx.py
+++ b/spinalcordtoolbox/deepseg_/onnx.py
@@ -6,6 +6,7 @@ License: see the file LICENSE
 """
 
 import onnxruntime as ort
+import numpy as np
 
 
 def onnx_inference(model_path, input_data):
@@ -18,5 +19,6 @@ def onnx_inference(model_path, input_data):
 
     ort_sess = ort.InferenceSession(model_path, sess_options=sess_options)
     preds = ort_sess.run(output_names=["predictions"], input_feed={"input_1": input_data})
+    preds = [np.nan_to_num(arr) for arr in preds]
 
     return preds

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -88,11 +88,11 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
             # Compute the angle about AP axis between the centerline and the normal vector to the slice
             v0 = [tangent_vect[0], tangent_vect[2]]
             v1 = [0, 1]
-            angle_AP_rad = np.math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
+            angle_AP_rad = math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
             # Compute the angle about RL axis between the centerline and the normal vector to the slice
             v0 = [tangent_vect[1], tangent_vect[2]]
             v1 = [0, 1]
-            angle_RL_rad = np.math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
+            angle_RL_rad = math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
             # Apply affine transformation to account for the angle between the centerline and the normal to the patch
             tform = transform.AffineTransform(scale=(np.cos(angle_RL_rad), np.cos(angle_AP_rad)))
             # Convert to float64, to avoid problems in image indexation causing issues when applying transform.warp

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -196,28 +196,25 @@ class AnalyzeLesion:
             copy(os.path.join(self.tmp_dir, file_), os.path.join(self.path_ofolder, file_))
 
     def pack_measures(self):
-        writer = pd.ExcelWriter(self.excel_name, engine='xlsxwriter')
-        self.measure_pd.to_excel(writer, sheet_name='measures', index=False, engine='xlsxwriter')
+        with pd.ExcelWriter(self.excel_name, engine='xlsxwriter') as writer:
+            self.measure_pd.to_excel(writer, sheet_name='measures', index=False, engine='xlsxwriter')
 
-        # Add the total column and row
-        if self.path_template is not None:
-            for sheet_name in self.distrib_matrix_dct:
-                if '#' in sheet_name:
-                    df = self.distrib_matrix_dct[sheet_name].copy()
-                    df = df.append(df.sum(numeric_only=True, axis=0), ignore_index=True)
-                    df['total'] = df.sum(numeric_only=True, axis=1)
-                    df.iloc[-1, df.columns.get_loc('vert')] = 'total'
-                    df.to_excel(writer, sheet_name=sheet_name, index=False, engine='xlsxwriter')
-                else:
-                    self.distrib_matrix_dct[sheet_name].to_excel(writer, sheet_name=sheet_name, index=False, engine='xlsxwriter')
+            # Add the total column and row
+            if self.path_template is not None:
+                for sheet_name in self.distrib_matrix_dct:
+                    if '#' in sheet_name:
+                        df = self.distrib_matrix_dct[sheet_name].copy()
+                        df = df.append(df.sum(numeric_only=True, axis=0), ignore_index=True)
+                        df['total'] = df.sum(numeric_only=True, axis=1)
+                        df.iloc[-1, df.columns.get_loc('vert')] = 'total'
+                        df.to_excel(writer, sheet_name=sheet_name, index=False, engine='xlsxwriter')
+                    else:
+                        self.distrib_matrix_dct[sheet_name].to_excel(writer, sheet_name=sheet_name, index=False, engine='xlsxwriter')
 
-        # Save pickle
-        self.distrib_matrix_dct['measures'] = self.measure_pd
-        with open(self.pickle_name, 'wb') as handle:
-            pickle.dump(self.distrib_matrix_dct, handle)
-
-        # Save Excel
-        writer.close()
+            # Save pickle
+            self.distrib_matrix_dct['measures'] = self.measure_pd
+            with open(self.pickle_name, 'wb') as handle:
+                pickle.dump(self.distrib_matrix_dct, handle)
 
     def show_total_results(self):
         """

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -217,7 +217,7 @@ class AnalyzeLesion:
             pickle.dump(self.distrib_matrix_dct, handle)
 
         # Save Excel
-        writer.save()
+        writer.close()
 
     def show_total_results(self):
         """

--- a/testing/api/test_deepseg_sc.py
+++ b/testing/api/test_deepseg_sc.py
@@ -75,7 +75,7 @@ def test_uncrop_image():
     input_shape = (100, 100, 100)
     crop_size = 20
     data_crop = np.random.randint(0, 2, size=(crop_size, crop_size, input_shape[2]))
-    data_in = np.random.randint(0, 1000, size=input_shape)
+    data_in = np.random.randint(0, 1000, size=input_shape, dtype=np.uint32)
 
     x_crop_lst = list(np.random.randint(0, input_shape[0] - crop_size, input_shape[2]))
     y_crop_lst = list(np.random.randint(0, input_shape[1] - crop_size, input_shape[2]))

--- a/testing/api/test_qmri.py
+++ b/testing/api/test_qmri.py
@@ -20,7 +20,7 @@ def make_sct_image(data):
     data: scalar
     """
     affine = np.eye(4)
-    nii = nibabel.nifti1.Nifti1Image(np.array([data, data]), affine)
+    nii = nibabel.nifti1.Nifti1Image(np.array([data, data], dtype=np.uint32), affine)
     img = Image(np.asanyarray(nii.dataobj), hdr=nii.header, orientation="LPI", dim=nii.header.get_data_shape())
     return img
 

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -110,6 +110,7 @@ def test_sct_label_vertebrae_initial_disc_zero(capsys, tmp_path):
     assert 'Missing label or zero label for initial disc.' in capsys.readouterr().out
 
 
+@pytest.mark.skip("Test doesn't work as intended: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4405")
 def test_sct_label_vertebrae_initial_disc_too_low(capsys, tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'),


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Upstream ivadomed changes: https://github.com/ivadomed/ivadomed/pull/1308

The upstream changes enabled a cascade of version upgrades (compared to `master`):

- Explicit dependency upgrades (`requirements.txt`):
  - `nibabel`: `3.2.2` -> `5.2.1`
  - `dipy`: `1.5.0` -> `1.8.0`
  - `numpy`: `1.23.5` -> `1.26.4`
- Second-order dependency upgrades (held back by previous packages):
  - `pandas`: `1.4.4` -> `1.5.3`
  - `pyparsing`: `2.4.7` -> `3.1.2`

Given that we've been held back on these versions for so long, some additional changes are needed to address upstream deprecation warnings and errors, mainly due to `numpy`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4319.
Mostly addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4408, but doesn't address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4408#issuecomment-2007396098.