### PR TITLE
Mitigate scaling issues (`0.999`) in both `sct_deepseg` and `sct_label_vertebrae`

### DIFF
--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -30,7 +30,7 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
         :param options: A dictionary containing optional configuration settings, as specified by the
             ivadomed.inference.segment_volume function.
 
-        :return: list, list: List of nibabel objects containing the soft segmentation(s), one per prediction class, \
+        :return: list, list: List of Image objects containing the soft segmentation(s), one per prediction class, \
             List of target suffix associated with each prediction
     """
     if not isinstance(model_paths, list):
@@ -78,7 +78,8 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
     # The 'targets' should be identical for each model, so just take the first
     target_lst = target_lsts[0]
 
-    # Convert the output Nifti1Images into SCT images
+    # Convert the output Nifti1Images into SCT images, to avoid scaling issues
+    # (see https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4346)
     im_lst = [Image(np.asanyarray(nii.dataobj), hdr=nii.header) for nii in nii_lst]
 
     return im_lst, target_lst

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -12,6 +12,8 @@ from ivadomed import inference as imed_inference
 import nibabel as nib
 import numpy as np
 
+from spinalcordtoolbox.image import Image
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,4 +78,7 @@ def segment_and_average_volumes(model_paths, input_filenames, options):
     # The 'targets' should be identical for each model, so just take the first
     target_lst = target_lsts[0]
 
-    return nii_lst, target_lst
+    # Convert the output Nifti1Images into SCT images
+    im_lst = [Image(np.asanyarray(nii.dataobj), hdr=nii.header) for nii in nii_lst]
+
+    return im_lst, target_lst

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -210,7 +210,7 @@ def main(argv: Sequence[str]):
         options = {**vars(arguments), "fname_prior": fname_prior}
         # NB: For single models, the averaging will have no effect.
         #     For model ensembles, this will average the output of the ensemble into a single set of outputs.
-        nii_lst, target_lst = inference.segment_and_average_volumes(path_models, input_filenames, options=options)
+        im_lst, target_lst = inference.segment_and_average_volumes(path_models, input_filenames, options=options)
 
         # Delete intermediate outputs
         if fname_prior and os.path.isfile(fname_prior) and arguments.r:
@@ -219,7 +219,7 @@ def main(argv: Sequence[str]):
 
         output_filenames = []
         # Save output seg
-        for nii_seg, target in zip(nii_lst, target_lst):
+        for im_seg, target in zip(im_lst, target_lst):
             if 'o' in options and options['o'] is not None:
                 # To support if the user adds the extension or not
                 extension = ".nii.gz" if ".nii.gz" in options['o'] else ".nii" if ".nii" in options['o'] else ""
@@ -236,7 +236,7 @@ def main(argv: Sequence[str]):
             if not (path_out == '' or os.path.exists(path_out)):
                 os.makedirs(path_out)
 
-            nib.save(nii_seg, fname_seg)
+            im_seg.save(fname_seg)
             output_filenames.append(fname_seg)
 
         # Use the result of the current model as additional input of the next model

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -17,8 +17,6 @@ import sys
 import logging
 from typing import Sequence
 
-import nibabel as nib
-
 from spinalcordtoolbox.deepseg import models, inference
 from spinalcordtoolbox.image import splitext
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -309,10 +309,12 @@ def crop_labels(im_labeled_seg, im_seg):
     modifying on the labeled segmentation in-place.
 
     :param Image im_labeled_seg: labeled segmentation
-    :param Image im_seg: segmentation (with values in [0, 1])
+    :param Image im_seg: segmentation (can be softseg or binary)
     :return: None
     """
-    im_labeled_seg.data *= im_seg.data
+    boolean_mask = (im_seg.data != 0)    # Nonzero -> True | Zero -> False
+    im_labeled_seg.data *= boolean_mask  # Keep only voxels that were nonzero in the segmentation image
+    # Note: NumPy will cast the bool type to the integer type, with False and True converted to 0 and 1 respectively.
 
 
 def expand_labels(im_labeled_seg):


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3232#issuecomment-1883229811, I ran into a two-pronged bug:

1. `sct_deepseg` uses `nib.save()` rather than `Image.save()`, meaning that it was susceptible to the float/int scaling issues (1.0 -> 0.999) as previously documented in #3232.
2. When using a poorly-scaled segmentation with `sct_label_vertebrae`, the multiplication part of the "clean labels" step would then transfer the scaling issues to the integer labels themselves.

This PR fixes both issues by:

- Working with `spinalcordtoolbox.image.Image` objects in `sct_deepseg` (since `Image.save()` contains a mitigation for the scaling issues.)
- Converting the segmentation to a boolean mask before multiplying it with the label image.

Note: I'm not sure whether it's worth writing a test for this, given that the scaling behavior is something that is unique to `nibabel`. Once the `nib.save()` function is removed from usage, there's practically no chance that this behavior will come up again.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially fixes <!-- don't auto-close --> #3232. (Should this be closed? Or should we keep it open until we replace all existing usages of `nib.save()` with `Image.save()`?)
