### PR TITLE
Fix straightening error during registration if 3+ labels are supplied and topmost disc label is not C1

### DIFF
--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -345,7 +345,6 @@ class Centerline:
                         Must be on of self.labels_regions
         """
         self.discs_levels = discs_levels
-        self.label_reference = label_reference
 
         # special case for C2, which might not be present because it is difficult to identify
         is_C2_here = False
@@ -394,15 +393,14 @@ class Centerline:
         for i in range(self.number_of_points - 1):
             progress_length[i + 1] = progress_length[i] + self.progressive_length[i]
 
-        self.label_reference = label_reference
-        if self.label_reference not in self.index_disc:
+        if label_reference not in self.index_disc:
             upper = 31
             label_reference = ''
             for label in self.index_disc:
                 if self.labels_regions[label] < upper:
                     label_reference = label
                     upper = self.labels_regions[label]
-            self.label_reference = label_reference
+        self.label_reference = label_reference
 
         self.distance_from_C1label = {}
         progress_length_reference = progress_length[self.index_disc[self.label_reference]]

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -388,13 +388,18 @@ class Centerline:
         self.first_label = self.list_labels[index_first_label]
         self.last_label = self.list_labels[index_last_label]
 
+        index_disc_inv.append([0, 'bottom'])
+        index_disc_inv.sort(key=itemgetter(0))
+
+        progress_length = zeros(self.number_of_points)
+        for i in range(self.number_of_points - 1):
+            progress_length[i + 1] = progress_length[i] + self.progressive_length[i]
+
         # If the reference label (default 'C1' - 1) is not present in the disc labels, then use the uppermost label
         if label_reference not in self.index_disc.keys():
             label_reference = self.regions_labels[self.first_label]  # int label -> str label
         self.label_reference = label_reference
 
-        # Add a special label to handle points below the bottommost label
-        index_disc_inv.append([0, 'bottom'])
         # Add a special label to handle points above the uppermost label
         # (NB: We only do this if the reference label is not 'C1'. If the reference label *is* 'C1', then we
         #  want to leave the points above C1 as their default value ('0'), since there is further logic that
@@ -406,23 +411,16 @@ class Centerline:
             # Then, assign it to the last point in the cord
             index_disc_inv.append([self.number_of_points, above_label_reference])
 
-        # Sort the discs according to index
-        index_disc_inv.sort(key=itemgetter(0))
+        self.distance_from_C1label = {}
+        progress_length_reference = progress_length[self.index_disc[self.label_reference]]
+        for disc, i in self.index_disc.items():
+            self.distance_from_C1label[disc] = progress_length_reference - progress_length[i]
 
         # Use the disc indexes to label the points according to the vertebral level they belong to
         for i in range(1, len(index_disc_inv)):
             disc = index_disc_inv[i][1]
             for j in range(index_disc_inv[i - 1][0], index_disc_inv[i][0]):
                 self.l_points[j] = disc
-
-        progress_length = zeros(self.number_of_points)
-        for i in range(self.number_of_points - 1):
-            progress_length[i + 1] = progress_length[i] + self.progressive_length[i]
-
-        self.distance_from_C1label = {}
-        progress_length_reference = progress_length[self.index_disc[self.label_reference]]
-        for disc, i in self.index_disc.items():
-            self.distance_from_C1label[disc] = progress_length_reference - progress_length[i]
 
         for i in range(self.number_of_points):
             self.dist_points[i] = progress_length_reference - progress_length[i]

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -393,13 +393,12 @@ class Centerline:
         for i in range(self.number_of_points - 1):
             progress_length[i + 1] = progress_length[i] + self.progressive_length[i]
 
-        if label_reference not in self.index_disc:
-            upper = 31
-            label_reference = ''
-            for label in self.index_disc:
-                if self.labels_regions[label] < upper:
-                    label_reference = label
-                    upper = self.labels_regions[label]
+        # If the reference label (default 'C1' - 1) is not present in the disc labels, then find the
+        # uppermost label ('C2' - 2, 'C3' - 3, etc.) that _is_ present in the disc label.
+        if label_reference not in self.index_disc.keys():
+            # Convert the present disc labels to integers, then take the minimum value.
+            label_min_int = min(self.labels_regions[label] for label in self.index_disc.keys())
+            label_reference = self.regions_labels[label_min_int]  # int label -> str label
         self.label_reference = label_reference
 
         self.distance_from_C1label = {}

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -393,8 +393,27 @@ class Centerline:
             label_reference = self.regions_labels[self.first_label]  # int label -> str label
         self.label_reference = label_reference
 
+        # Add a special label to handle points below the bottommost label
         index_disc_inv.append([0, 'bottom'])
+        # Add a special label to handle points above the uppermost label
+        # (NB: We only do this if the reference label is not 'C1'. If the reference label *is* 'C1', then we
+        #  want to leave the points above C1 as their default value ('0'), since there is further logic that
+        #  relies on the assumption that 0 == "above C1".)
+        if self.label_reference != 'C1':
+            # Get the label that theoretically would be above the reference label
+            label_reference_int = self.labels_regions[self.label_reference]       # str label -> int label
+            above_label_reference = self.regions_labels[label_reference_int - 1]  # int label -> str label
+            # Then, assign it to the last point in the cord
+            index_disc_inv.append([self.number_of_points, above_label_reference])
+
+        # Sort the discs according to index
         index_disc_inv.sort(key=itemgetter(0))
+
+        # Use the disc indexes to label the points according to the vertebral level they belong to
+        for i in range(1, len(index_disc_inv)):
+            disc = index_disc_inv[i][1]
+            for j in range(index_disc_inv[i - 1][0], index_disc_inv[i][0]):
+                self.l_points[j] = disc
 
         progress_length = zeros(self.number_of_points)
         for i in range(self.number_of_points - 1):
@@ -404,11 +423,6 @@ class Centerline:
         progress_length_reference = progress_length[self.index_disc[self.label_reference]]
         for disc, i in self.index_disc.items():
             self.distance_from_C1label[disc] = progress_length_reference - progress_length[i]
-
-        for i in range(1, len(index_disc_inv)):
-            disc = index_disc_inv[i][1]
-            for j in range(index_disc_inv[i - 1][0], index_disc_inv[i][0]):
-                self.l_points[j] = disc
 
         for i in range(self.number_of_points):
             self.dist_points[i] = progress_length_reference - progress_length[i]

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -381,10 +381,17 @@ class Centerline:
                 if index_last_label is None or index_label > index_last_label:
                     index_last_label = index_label
 
-        if index_first_label is not None:
-            self.first_label = self.list_labels[index_first_label]
-        if index_last_label is not None:
-            self.last_label = self.list_labels[index_last_label]
+        # Assign first/last labels once we guarantee that there even *are* valid labels
+        if index_last_label is None or index_last_label is None:
+            raise ValueError(f"None of the provided disc levels {[l[3] for l in discs_levels]} are present in the"
+                             f"list of expected disc levels: {list(self.list_labels)}.")
+        self.first_label = self.list_labels[index_first_label]
+        self.last_label = self.list_labels[index_last_label]
+
+        # If the reference label (default 'C1' - 1) is not present in the disc labels, then use the uppermost label
+        if label_reference not in self.index_disc.keys():
+            label_reference = self.regions_labels[self.first_label]  # int label -> str label
+        self.label_reference = label_reference
 
         index_disc_inv.append([0, 'bottom'])
         index_disc_inv.sort(key=itemgetter(0))
@@ -392,14 +399,6 @@ class Centerline:
         progress_length = zeros(self.number_of_points)
         for i in range(self.number_of_points - 1):
             progress_length[i + 1] = progress_length[i] + self.progressive_length[i]
-
-        # If the reference label (default 'C1' - 1) is not present in the disc labels, then find the
-        # uppermost label ('C2' - 2, 'C3' - 3, etc.) that _is_ present in the disc label.
-        if label_reference not in self.index_disc.keys():
-            # Convert the present disc labels to integers, then take the minimum value.
-            label_min_int = min(self.labels_regions[label] for label in self.index_disc.keys())
-            label_reference = self.regions_labels[label_min_int]  # int label -> str label
-        self.label_reference = label_reference
 
         self.distance_from_C1label = {}
         progress_length_reference = progress_length[self.index_disc[self.label_reference]]


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR handles a specific registration case from @jqmcginnis, where:

- The `-ldisc` argument is used with 3+ intervertebral disc labels.
- The topmost disc label is _not_ C1. In this case, it was `'C3'` (`3`).
- There are slices in the spinal cord segmentation that extend above the topmost disc label.

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/09f66388-1253-4db9-99d1-18c74e675673)

If these three conditions are met, then straightening will fail prior to registration.

The tl;dr for the failure is the following logic:

- When a centerline is fitted to the cord segmentation, then the points of the centerline get labeled with their corresponding vertebral level (inferred from the disc labels). Any points above the C1 intervertebral disc should be left as `0` (since there is no vertebral level above the C1 disc).
- Because of this logic, the rest of the code operates under the assumption that if a centerline point has the label `0`, it must be located "above the C1 disc"
- However, what actually happened was that _any_ points above the topmost disc label would get labeled with `0`, regardless of whether the topmost disc label was actually C1. 
- This breaks the assumption that "0 == above C1", causing a crash [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/52131da66f91ec2fd3d0f2d1fd707cebbdb7dfd6/spinalcordtoolbox/types.py#L459-L460).

This PR fixes the problem by ensuring that, if the topmost disc label is not C1, then points above the disc label will get labeled with the appropriate vertebrae, rather than `0`. This preserves the assumption that "0 == above C1", and allows straightening to occur without crashing.

(This PR also includes a small amount of refactoring to make the overall method's steps easier to understand and review.)

## Testing this PR

The link to the data was shared in the #bavaria_quebec channel on Slack, with the command being:

```
sct_register_to_template -i sub-m002886_ses-20171102_acq-ax_T2w.nii.gz -s sub-m002886_ses-20171102_seg-manual_T2w.nii.gz -ldisc sub-m002886_ses-20171102_acq-ax_vertfile.nii.gz -c t2 -ofolder out
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4329.
