### PR TITLE
Address test warnings by pinning `pyqt5-sip<12.13.0` and updating `setup.cfg` ignore entries (`pkg_resources`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,8 @@ psutil
 # Additionally, for versions between 5.12-5.14, the only release to have Python 3.9 wheels is 5.12.3. So, we pin it.
 # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3367#issuecomment-1533181462
 pyqt5==5.12.3
+# PyQt5-sip should be updated when PyQt5 is updated: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4354
+pyqt5-sip<12.13.0
 pytest
 pytest-cov
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,6 @@ filterwarnings =
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
     # This warning is for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
-    # These warnings are due to a deprecation for a call that is still used by many upstream packages. In our case:
-    # - matplotlib: https://github.com/matplotlib/matplotlib/issues/25244
-    # - google_auth: https://github.com/googleapis/google-cloud-python/issues/11184#issuecomment-1564488281
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    ignore:Deprecated call to \`pkg_resources.declare_namespace\('.*'\)\`.*:DeprecationWarning
 
 [flake8]
 max-line-length = 179

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,7 @@ filterwarnings =
     # The following are upstream dependencies that have DeprecationWarnings for THEIR dependencies.
     # We can't do much about these besides alert the upstream packages + upgrade where possible.
     # NB: Pystrum/VoxelMorph aren't well-maintained, but torch is. We should see if we can upgrade.
-    ignore::DeprecationWarning:pystrum.*:
-    ignore::DeprecationWarning:voxelmorph.*:
-    ignore::DeprecationWarning:torch.*:
+    ignore:.*inspect.getargspec.*:DeprecationWarning:voxelmorph.*:
     ignore:.*scipy.ndimage.*:DeprecationWarning:monai.*:
     ignore:.*scipy.ndimage.*:DeprecationWarning:batchgenerators.*:
     ignore:.*scipy.ndimage.*:DeprecationWarning:nnunetv2.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,9 @@ filterwarnings =
     # These warnings are for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
     ignore:.*is non-interactive, and thus cannot be shown:UserWarning:
+    # This is a warning we ourselves generate, and needs discussion
+    # Revisit as part of: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4357
+    ignore:.*with additional arguments is discouraged:UserWarning:
 
 [flake8]
 max-line-length = 179

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,9 @@ filterwarnings =
     ignore::DeprecationWarning:pystrum.*:
     ignore::DeprecationWarning:voxelmorph.*:
     ignore::DeprecationWarning:torch.*:
-    ignore::DeprecationWarning:monai.*:
-    ignore::DeprecationWarning:batchgenerators.*:
-    ignore::DeprecationWarning:nnunetv2.*:
+    ignore:.*scipy.ndimage.*:DeprecationWarning:monai.*:
+    ignore:.*scipy.ndimage.*:DeprecationWarning:batchgenerators.*:
+    ignore:.*scipy.ndimage.*:DeprecationWarning:nnunetv2.:
     # NB: This UserWarning is also an upstream issue, this time with the PyTorch version of the VoxelMorph network.
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ filterwarnings =
     ignore:.*inspect.getargspec.*:DeprecationWarning:voxelmorph.*:
     ignore:.*scipy.ndimage.*:DeprecationWarning:monai.*:
     ignore:.*scipy.ndimage.*:DeprecationWarning:batchgenerators.*:
-    ignore:.*scipy.ndimage.*:DeprecationWarning:nnunetv2.:
+    ignore:.*scipy.ndimage.*:DeprecationWarning:nnunetv2.*:
     # NB: This UserWarning is also an upstream issue, this time with the PyTorch version of the VoxelMorph network.
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,9 @@ filterwarnings =
     ignore::DeprecationWarning:pystrum.*:
     ignore::DeprecationWarning:voxelmorph.*:
     ignore::DeprecationWarning:torch.*:
+    ignore::DeprecationWarning:monai.*:
+    ignore::DeprecationWarning:batchgenerators.*:
+    ignore::DeprecationWarning:nnunetv2.*:
     # NB: This UserWarning is also an upstream issue, this time with the PyTorch version of the VoxelMorph network.
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,9 @@ filterwarnings =
     #     I'm not sure if we can do much here, but it will only become an issue if and when we upgrade torch.
     # Source: test_sct_register_multimodal_mto_image_data --> `algorithms.py :: vxm.networks.VxmDense()`
     ignore:.*in an upcoming release, it will be required to pass the indexing argument.*:UserWarning:torch.*:
+    # This warning is due to a deprecation for a call that is still used by many upstream packages. In our case:
+    # - wandb: https://github.com/wandb/wandb/issues/6711
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # This warning is for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,9 @@ filterwarnings =
     # This warning is due to a deprecation for a call that is still used by many upstream packages. In our case:
     # - wandb: https://github.com/wandb/wandb/issues/6711
     ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    # This warning is for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
+    # These warnings are for non-GUI backends on headless machines (i.e. CI), so it's safe to ignore.
     ignore:Matplotlib is currently using agg.*:UserWarning:
+    ignore:.*is non-interactive, and thus cannot be shown:UserWarning:
 
 [flake8]
 max-line-length = 179

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -57,6 +57,7 @@ def resolve_module(framework_name):
         'scikit-image': ('skimage', False),
         'scikit-learn': ('sklearn', False),
         'pyqt5': ('PyQt5.QtCore', False),  # Importing Qt instead PyQt5 to be able to catch this issue #2523
+        'pyqt5-sip': ('PyQt5.sip', False),
         'pyyaml': ('yaml', False),
         'futures': ("concurrent.futures", False),
         'opencv': ('cv2', False),


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a small PR to revisit the warnings caught by our test suite:

- pyqt5-sip: See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4354
- pkg_resources deprecation --> ~~fixed upstream~~ Not true! `wandb` still uses `pkg_resources`

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4354.