### PR TITLE
Fix broken pip installer by forcing it to detect macOS 11 as `11.0` and not `10.16`

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -621,7 +621,10 @@ fi
 (
   # We use "--ignore-installed" to preserve the version of `certifi` installed into the conda
   # env, which prevents https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3609
-  python/envs/venv_sct/bin/pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
+  # We use 'SYSTEM_VERSION_COMPAT=0' to tell pip to report macOS 11 instead of macOS 10.16
+  # This is necessary in order to install 'macosx_11_0' wheels. See also:
+  # https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4352
+  SYSTEM_VERSION_COMPAT=0 python/envs/venv_sct/bin/pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
   print info "Installing spinalcordtoolbox..." &&
   python/envs/venv_sct/bin/pip install -e .
 ) ||


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This was a really weird bug to investigate!! General background info references:

- https://eclecticlight.co/2020/07/21/big-sur-is-both-10-16-and-11-0-its-official/
- https://github.com/pypa/packaging/issues/497#issuecomment-1012665274
- https://github.com/pypa/pipenv/issues/4564#issuecomment-829199591

Specific to `onnxruntime`:

- https://github.com/microsoft/onnxruntime/issues/17166
- https://github.com/microsoft/onnxruntime/issues/19371

The above issue has only become relevant for SCT because one of its dependencies, `onnxruntime` switched to wheels that specify `macosx_11_0` in the wheel's name instead of the previous `macosx_10_15`. So, we need the compatibility fix to install the newest `onnxruntime` wheels, at least until `pip` fixes this upstream by vendoring a newer version of `packaging`:

- https://github.com/pypa/pip/issues/11715

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4352.
