### PR TITLE
Document Rosetta 2 as a requirement for installation on Apple silicon (M1, M2, M3)

### DIFF
--- a/documentation/source/user_section/installation/mac.rst
+++ b/documentation/source/user_section/installation/mac.rst
@@ -13,6 +13,16 @@ Supported Operating Systems
 * MacOS >= 10.13
 
 
+Mac computers with Apple silicon
+--------------------------------
+
+If your computer uses Apple silicon (M1, M2, M3, etc.), you need to make sure `Rosetta 2 <https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2>`__ is installed before installing or running SCT. To do this, you can open a Terminal and run:
+
+.. code:: sh
+
+    softwareupdate --install-rosetta
+
+
 Gnu Compiler Collection (gcc)
 -----------------------------
 
@@ -23,7 +33,7 @@ You need to have ``gcc`` installed. Check to see if ``gcc`` is installed by open
     gcc --version
 
 
-If it isn't installed, we recommend installing `Homebrew <https://brew.sh/>`_ and then run:
+If it isn't installed, we recommend installing `Homebrew <https://brew.sh/>`__ and then run:
 
 .. code:: sh
 
@@ -37,7 +47,7 @@ Installation Options
 Option 1: Install from Package (recommended)
 --------------------------------------------
 
-The simplest way to install SCT is to do it via a stable release. First, navigate to the `latest release <https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases>`_, then download the install script for SCT (``install_sct-<version>_macos.sh``). Major changes to each release are listed in the :doc:`/dev_section/CHANGES`.
+The simplest way to install SCT is to do it via a stable release. First, navigate to the `latest release <https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases>`__, then download the install script for SCT (``install_sct-<version>_macos.sh``). Major changes to each release are listed in the :doc:`/dev_section/CHANGES`.
 
 Once you have downloaded SCT, open a new Terminal in the location of the downloaded script, then launch the installer the ``bash`` command. For example, if the script was downloaded to `Downloads/`, then you would run:
 
@@ -124,7 +134,7 @@ Procedure:
 Option 4: Install with Docker
 -----------------------------
 
-`Docker <https://www.docker.com/what-container>`_ is a portable (Linux, macOS, Windows) container platform.
+`Docker <https://www.docker.com/what-container>`__ is a portable (Linux, macOS, Windows) container platform.
 
 In the context of SCT, it can be used:
 
@@ -136,7 +146,7 @@ In the context of SCT, it can be used:
 Basic Installation (No GUI)
 ***************************
 
-First, `install Docker Desktop <https://docs.docker.com/desktop/install/mac-install/>`_. Then, follow the examples below to create an OS-specific SCT installation.
+First, `install Docker Desktop <https://docs.docker.com/desktop/install/mac-install/>`__. Then, follow the examples below to create an OS-specific SCT installation.
 
 
 Docker Image: Ubuntu
@@ -192,7 +202,7 @@ First, save your Docker image if you haven't already done so:
 
 Create an X11 server for handling display:
 
-1. Install `XQuartz X11 <https://www.xquartz.org/>`_ server.
+1. Install `XQuartz X11 <https://www.xquartz.org/>`__ server.
 2. Check ‘Allow connections from network clients option in XQuartz\` settings. (Run XQuartz; in the top-of-screen menu bar, choose "XQuartz", then "Preferences..."; the relevant option is under the "Security" tab.)
 3. Quit and restart XQuartz.
 4. In the XQuartz "xterm" window, run the command:

--- a/install_sct
+++ b/install_sct
@@ -183,6 +183,28 @@ function check_requirements() {
   if [[ ! ( $(command -v curl) || $(command -v wget) ) ]]; then
     die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
   fi
+  # check rosetta
+  if [[ "$OS" == "osx" ]]; then
+    if ! arch -x86_64 true >/dev/null 2>&1; then
+      print warning "WARNING: not running an x86_64 architecture."
+      while [[ ! "$ROSETTA_INSTALL" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+        ROSETTA_INSTALL="no"
+        if [ -z "$NONINTERACTIVE" ]; then
+          print question "Do you want to install \"Rosetta 2\" now? [y]es/[n]o:"
+          read -r ROSETTA_INSTALL
+        fi
+      done
+      if [[ "$ROSETTA_INSTALL" =~ ^[Yy](es)? ]]; then
+        softwareupdate --install-rosetta
+        # check if we can now run x86_64 executables
+        if ! arch -x86_64 true >/dev/null 2>&1; then
+          die "ERROR: still cannot run x86_64 executables. Please contact SCT team for assistance."
+        fi
+      else
+        die "Please install \"Rosetta 2\" by running \"softwareupdate --install-rosetta\" and restart SCT installation."
+      fi
+    fi
+  fi
   # check gcc
   if ! gcc --version > /dev/null 2>&1; then
     print warning "WARNING: \"gcc\" is not installed."


### PR DESCRIPTION
[Rosetta 2](https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2) is needed to translate `x86_64` executables (which we rely on) so they can run on the `arm64` architecture of Apple silicon chips. This PR documents this requirement on the [Mac installation page for SCT](https://spinalcordtoolbox.com/user_section/installation/mac.html) and in the SCT installer, which:
* detects whether the computer is running macOS;
* if so, it tries to run a builtin command (`true`) while requesting the `x86_64` architecture;
* if this fails, it offers to install Rosetta 2.

The new code mirrors the check for `gcc` which appears right below in the installer.

The test uses the `arch` command, which has different functionality on Linux than on macOS; see [the linux manual page for `arch`](https://www.man7.org/linux/man-pages/man1/arch.1.html) and [an old macOS manual page for `arch`](https://www.unix.com/man-page/osx/1/arch/). I checked on a recent M2 laptop, and the `arch` command now also recognizes `arm64`, `arm64e`, and `x86_64h` as architecture names, but otherwise seems to still work the same way.

Fixes #4342.