### PR TITLE
Fix `-p sct_label_vertebrae` QC report when providing TotalSegmentator labels

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -187,12 +187,11 @@ class QcImage:
 
     def label_vertebrae(self, mask, ax):
         """Draw vertebrae areas, then add text showing the vertebrae names"""
-        from matplotlib import colors
         img = np.rint(np.ma.masked_where(mask < 1, mask))
         labels = np.unique(img[np.where(~img.mask)]).astype(int)  # get available labels
         color_list = self._assign_label_colors_by_groups(labels)
         ax.imshow(img,
-                  cmap=colors.ListedColormap(color_list),
+                  cmap=color.ListedColormap(color_list),
                   interpolation=self.interpolation,
                   alpha=1,
                   aspect=float(self.aspect_mask))
@@ -209,12 +208,12 @@ class QcImage:
                     index = int(val)
                     if index in self._labels_regions.values():
                         # NB: We need to subtract `min` to convert the label value into an index for the color list
-                        color = color_list[index - labels.min()]
+                        label_color = color_list[index - labels.min()]
                         y, x = center_of_mass(np.where(data == val, data, 0))
                         # Draw text with a shadow
                         x += data.shape[1] / 25
                         label = list(self._labels_regions.keys())[list(self._labels_regions.values()).index(index)]
-                        label_text = ax.text(x, y, label, color=color, clip_on=True)
+                        label_text = ax.text(x, y, label, color=label_color, clip_on=True)
                         label_text.set_path_effects([path_effects.Stroke(linewidth=2, foreground='black'),
                                                      path_effects.Normal()])
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -12,6 +12,7 @@ import logging
 import datetime
 from string import Template
 from typing import Callable, List, Tuple, Union
+import itertools as it
 
 import numpy as np
 import skimage
@@ -85,9 +86,9 @@ class QcImage:
 
         # Handle the usual case: A single continuous group (likely vertebral labels)
         if len(label_groups) == 1:
-            n_colors = labels.max() - labels.min() + 1        # get label range from min label and max label
-            q, r = divmod(n_colors, len(self._labels_color))  # repeat the base list of colors to cover label range
-            color_list = (q * self._labels_color) + self._labels_color[:r]
+            # repeat high-contrast colors until we have enough to cover the range of labels
+            n_colors = labels.max() - labels.min() + 1
+            color_list = list(it.islice(it.cycle(self._labels_color), n_colors))
 
         # Handle the edge case: Multiple continuous groups
         else:

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -69,7 +69,7 @@ class QcImage:
             - Normal vertebral labels:  [2, 3, 4, 5, 6, ...]
             - Edge case, TotalSegmentator labels: [31, 32, 33, 200, 201, 217, 218, 219]
 
-        We assume that the subgroups of labesl (1: [31, 32, 33, ...], 2: [200, 201], 3: [217, 218, 219, ...])
+        We assume that the subgroups of labels (1: [31, 32, 33, ...], 2: [200, 201], 3: [217, 218, 219, ...])
         should each be assigned their own distinct colormap, as to group them semantically.
         """
         # Arrange colormaps for max contrast between colormaps, and max contrast between colors in colormaps

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -57,7 +57,7 @@ class QcImage:
         "#ff0000",  # Red         ( 5.25:1)
         "#50ff30",  # Green       (15.68:1)
         "#F749FD",  # Magenta     ( 7.32:1)
-    ] * 15
+    ]
     _seg_colormap = ["#4d0000", "#ff0000"]
     _ctl_colormap = ["#ff000099", '#ffff00']
 
@@ -143,8 +143,11 @@ class QcImage:
         from matplotlib import colors
         img = np.rint(np.ma.masked_where(mask < 1, mask))
         labels = np.unique(img[np.where(~img.mask)]).astype(int)  # get available labels
+        n_colors_needed = labels.max() - labels.min() + 1         # get label range from min label and max label
+        q, r = divmod(n_colors_needed, len(self._labels_color))   # repeat the base list of colors to cover label range
+        color_list = (q * self._labels_color) + self._labels_color[:r]
         ax.imshow(img,
-                  cmap=colors.ListedColormap(self._labels_color[labels.min():labels.max()+1]),  # get color from min label and max label
+                  cmap=colors.ListedColormap(color_list),
                   interpolation=self.interpolation,
                   alpha=1,
                   aspect=float(self.aspect_mask))
@@ -157,7 +160,8 @@ class QcImage:
                 a.append(val)
                 index = int(val)
                 if index in self._labels_regions.values():
-                    color = self._labels_color[index]
+                    # NB: We need to subtract `min` to convert the label value into an index for the color list
+                    color = color_list[index - labels.min()]
                     y, x = center_of_mass(np.where(data == val, data, 0))
                     # Draw text with a shadow
                     x += data.shape[1] / 25

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -70,7 +70,7 @@ class QcImage:
             - Edge case, TotalSegmentator labels: [31, 32, 33, 200, 201, 217, 218, 219]
 
         We assume that the subgroups of labesl (1: [31, 32, 33, ...], 2: [200, 201], 3: [217, 218, 219, ...])
-        should each be assigned their own distinct colormap, as to
+        should each be assigned their own distinct colormap, as to group them semantically.
         """
         # Arrange colormaps for max contrast between colormaps, and max contrast between colors in colormaps
         distinct_colormaps = ['Blues', 'Reds', 'Greens', 'Oranges', 'Purples']

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -47,10 +47,12 @@ def get_parser():
                         help='Plane of the output QC. Only relevant for -p sct_deepseg_lesion.',
                         choices=('axial', 'sagittal'),
                         required=False)
-    parser.add_argument('-exclude-label-text',
-                        help="If provided, text won't be drawn on top of labels. Only relevant for -p "
+    parser.add_argument('-text-labels',
+                        help="If set to 0, text won't be drawn on top of labels. Only relevant for -p "
                              "sct_label_vertebrae.",
-                        action="store_true",
+                        choices=(0, 1),
+                        default=1,
+                        type=int,
                         required=False)
     parser.add_argument('-qc',
                         metavar='QC',
@@ -104,7 +106,7 @@ def main(argv: Sequence[str]):
                 subject=arguments.qc_subject,
                 process=arguments.p,
                 fps=arguments.fps,
-                draw_text=(not arguments.exclude_label_text))
+                draw_text=bool(arguments.text_labels))
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -47,6 +47,11 @@ def get_parser():
                         help='Plane of the output QC. Only relevant for -p sct_deepseg_lesion.',
                         choices=('axial', 'sagittal'),
                         required=False)
+    parser.add_argument('-exclude-label-text',
+                        help="If provided, text won't be drawn on top of labels. Only relevant for -p "
+                             "sct_label_vertebrae.",
+                        action="store_true",
+                        required=False)
     parser.add_argument('-qc',
                         metavar='QC',
                         help='Path to save QC report. Default: ./qc',
@@ -98,7 +103,8 @@ def main(argv: Sequence[str]):
                 dataset=arguments.qc_dataset,
                 subject=arguments.qc_subject,
                 process=arguments.p,
-                fps=arguments.fps,)
+                fps=arguments.fps,
+                draw_text=(not arguments.exclude_label_text))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The existing QC report for `-p sct_label_vertebrae` assumes a single continuous set of labels with low values (e.g. `[2, 3, 4, 5, 6]`). However, if the provided labels go beyond 105, and/or  contain multiple distinct subsets of labels, then the generated color mapping will be incorrect, causing segmented labels to be seemingly merged together.

This PR provides two fixes: 

- A simple fix (to ensure that we properly assign a unique color to each label)
- A more complex fix (to try to visually distinguish the different label subgroups)

<details>
<summary> Comparison screenshots </summary>

Before:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/7bcb8bb2-ab1d-419a-b9d6-7b7447de6e36)

After (simple fix):

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/3e8728f2-ad80-434e-96dc-1ee2d33da236)

After (complex fix):

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/b97b4762-6235-4354-b342-8febd3d82347)

</details>

## Discussion

There was some back and forth in the original issue, but in short: My complex "automatic" approach won't necessarily result in our typical colormaps for the cord and vertebrae (red for cord, rainbow for vertebrae). 

But, I'm not sure how to parse whether we even _have_ vertebrae/cord labels unless we can confidently assume that specific values have semantic meaning (e.g. 200 = cord, 201 = CSF, etc.).

So, for now, I've kept my implementation general (i.e. unspecific to hardcoded label values), such that the code can more easily be ported to a future QC revamp (e.g. if `-p sct_label_vertebrae` becomes something like `-type labels`). But, my approach can definitely be revised!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4379.
