### PR TITLE
Update GitHub Actions versions (Debian 9->11, CentOS 7->9, WSL 2022->2019) to fix CI failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,10 +152,6 @@ jobs:
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
         # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
         run: |  
-          echo "deb http://archive.debian.org/debian/ stretch main non-free contrib" > /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian/ stretch main non-free contrib" >> /etc/apt/sources.list
-          echo "deb http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
-          echo "deb-src http://archive.debian.org/debian-security/ stretch/updates main non-free contrib" >> /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v4
       - name: Install SCT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,14 +139,14 @@ jobs:
         run: |
           ./.ci.sh -t
 
-  debian-9:
-    name: Debian 9
+  debian-11:
+    name: Debian 11
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
-    container: debian:9
+    container: debian:11
     steps:
       - name: Dependencies
         # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
@@ -170,6 +170,10 @@ jobs:
 
   centos-8:
     name: CentOS Stream 8
+    # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
+    #if: ${{ env.NIGHTLY }}
+    # in the meantime, copy-paste this:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     # Stream8 has a 2024 EOL, while CentOS 8 has a 2021 EOL
     # See: https://blog.centos.org/2020/12/future-is-centos-stream/
@@ -189,14 +193,10 @@ jobs:
         run: |
           ./.ci.sh -t
 
-  centos-7:
-    name: CentOS 7
-    # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
-    #if: ${{ env.NIGHTLY }}
-    # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+  centos-9:
+    name: CentOS Stream 9
     runs-on: ubuntu-20.04
-    container: centos:7
+    container: quay.io/centos/centos:stream9
     steps:
       - name: Dependencies
         run: |  # NB: mesa-libGL is needed for PyQT testing (https://stackoverflow.com/a/65408967/7584115)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -289,7 +289,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: windows-2022
+    runs-on: windows-2019
     defaults:
       run:
         shell: wsl-bash {0} # https://github.com/marketplace/actions/setup-wsl#default-shell
@@ -343,7 +343,7 @@ jobs:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    runs-on: windows-2022
+    runs-on: windows-2019
     defaults:
       run:
         shell: wsl-bash {0} # https://github.com/marketplace/actions/setup-wsl#default-shell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,7 +200,7 @@ jobs:
     steps:
       - name: Dependencies
         run: |  # NB: mesa-libGL is needed for PyQT testing (https://stackoverflow.com/a/65408967/7584115)
-          yum install -y gcc git curl mesa-libGL
+          yum install -y gcc git mesa-libGL
       - uses: actions/checkout@v4
       - name: Install SCT
         run: |


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a sister PR to #4353. In that PR, the versions for Node.js actions and runner OSs were updated across the board. However, doing so caused some failures that weren't discovered until after the PR was merged.

So, this PR addresses the issue by:

- Replacing EOL (or near-EOL) OSs with modern counterparts.
- Promoting CentOS 9 to "PR testing" and sunsetting CentOS 8 to "nightly testing"
  - I'll have to update the branch protection rules to ensure the right version is "Required" on PRs, too. 
- Downgrading the WSL runner temporarily.
  - This isn't a long-term fix, but given the complexity of debugging a failing runner that hangs without further feedback, I figure we can revert the change for now, at least until [`windows-2025` forces us to upgrade](https://github.com/actions/runner-images/discussions/7840#discussioncomment-6342593). 

This time, I _did_ test the changes by manually running the full test suite against this branch: https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/8147776646

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4382.