### PR TITLE
Switch to using mean magnitude for moco QC

### DIFF
--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -423,7 +423,11 @@ def moco_wrapper(param):
                 files_warp_Y.append(fname_warp_crop_Y)
 
                 # Calculating the slice-wise average moco estimate to provide a QC file
-                moco_param.append([np.mean(np.ravel(im_warp_XYZ[0].data)), np.mean(np.ravel(im_warp_XYZ[1].data))])
+                # We're at a fixed time point, and we have a list of (X, Y) translation vectors, one for each Z slice
+                # This is the average of the translation lengths
+                X = im_warp_XYZ[0].data
+                Y = im_warp_XYZ[1].data
+                moco_param.append([np.mean(np.sqrt(X*X + Y*Y))])
 
             # These two lines allow to generate one file instead of two, containing X, Y and Z moco parameters
             # im_warp = [Image(fname) for fname in files_warp]
@@ -442,7 +446,7 @@ def moco_wrapper(param):
             # Writing a TSV file with the slicewise average estimate of the moco parameters. Useful for QC
             with open(file_moco_params_csv, 'wt', newline='') as out_file:
                 tsv_writer = csv.writer(out_file, delimiter='\t')
-                tsv_writer.writerow(['X', 'Y'])
+                tsv_writer.writerow(['mean(sqrt(X*X+Y*Y))'])
                 for mocop in moco_param:
                     tsv_writer.writerow([mocop[0], mocop[1]])
 


### PR DESCRIPTION
The purpose of this QC file is to identify the amount of motion in each volume (that is, at each time point), so that motion-related fluctuation in the signal can be corrected for.

Having the average of the signed X and Y values is not useful for this, because a lot of left-right motion (or front-back motion) could mostly cancel out, and look the same as not having much motion at all. This is potentially confusing, and prone to misuse.

In contrast, the mean magnitude is only small when there is not much total motion, and it is scale-invariant with the number of Z slices.

Note: the formula for magnitude, $\sqrt{X^2+Y^2}$, only makes sense when $X$ and $Y$ have the same units (that is, millimeters, not voxels). So, I considered whether we should also use the voxel dimensions in the calculation, and concluded that we shouldn't:
- I ran the `sct_fmri_moco` command from [our tutorial](https://spinalcordtoolbox.com/user_section/tutorials/processing-fmri-data.html) to get a baseline file `moco_params.tsv`.
- I rescaled the input image and mask from (1mm, 1mm, 3mm) to (2mm, 2mm, 6mm) and ran the command again. This was the same number of voxels, just different metadata. All the numbers in the resulting file `moco_params.tsv` approximately doubled. Which means that the coordinates are in physical units, not integer array coordinates.
- I also rescaled a single axis, from (1mm, 1mm, 3mm) to (2mm, 1mm, 3mm) and ran the command again. This time, the numbers in `moco_params.tsv` were very different, basically unrelated. Which further confirms that ANTS registration takes into account physical units, I guess.

Fixes #4344.