### PR TITLE
Pin to `dipy<1.6` until conflicts with `dipy>=1.8` can be resolved

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
 #     stable releases. We do this because `pip freeze` will not capture options (e.g. --extra-index-url) or
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
-# Avoid method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-# dipy 1.8.x causes conflicts, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319#issuecomment-1864670675
-dipy!=1.6.*,!=1.7.*, !=1.8.*
+# Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
+# dipy 1.8 and above cause conflicts, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4319#issuecomment-1864670675
+dipy<1.6
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`dipy==1.8` and above cause conflicts with SCT's venv due to ivadomed. More details here: https://github.com/ivadomed/ivadomed/pull/1308

So, for now, we need to pin `dipy<1.6` to avoid breakage every time a new version of `dipy` is released. But, once https://github.com/ivadomed/ivadomed/pull/1308 is merged and a new version of ivadomed is released, we can switch this pin to `dipy!=1.6.*,!=1.7.*` and allow 1.8/1.9/etc.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4397.
