### PR TITLE
Reduce concurrent macOS runners on PRs from 6 to 2 (and remove push-to-master triggers)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
     needs: generate-requirements-freeze
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-14, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,9 +6,6 @@ on:
       milestone_title:
         description: 'Milestone title (this release)'
         required: true
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,9 +6,6 @@ on:
       milestone_title:
         description: 'Milestone title (this release)'
         required: true
-  pull_request:
-    branches:
-      - '*'
   schedule:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onschedule
     # > Scheduled workflows run on the latest commit on the default or base branch

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -62,7 +62,7 @@ jobs:
     needs: generate-requirements-freeze
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, macos-14, windows-2022]
+        os: [ubuntu-20.04, macos-12, windows-2022]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -27,7 +27,7 @@ jobs:
     name: Test batch_processing.sh
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12, macos-14, windows-2022 ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -2,10 +2,6 @@ name: Test batch_processing.sh
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - release
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ on:
 # - you cannot refer to the matrix parameters in a job's `if:`, so it is impossible to decide whether to run a job or not; it is possible to do so in a *step*'s `if:`. See https://github.community/t/conditional-matrices/17206/2.
 #   ideally we would have a build matrix with all the platforms covered
 #   ```
-#   if: ${{ !matrix.nightly || (github.event_name == 'schedule' || github.event_name == 'push') }}
+#   if: ${{ !matrix.nightly || (github.event_name == 'schedule') }}
 #   ```
 #   but it's not allowed; that second half is legal but `matrix.nightly` is not.
 # - there's no way to mix the docker-based platforms with the windows ones in the same build matrix anyway, because specifying `container:`, even with an empty/undefined string, tries blindly to use the docker scripts
@@ -49,7 +49,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: archlinux
     steps:
@@ -72,7 +72,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:sid
     steps:
@@ -95,7 +95,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:testing
     steps:
@@ -118,7 +118,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:10
     steps:
@@ -141,7 +141,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     container: debian:11
     steps:
@@ -166,7 +166,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     # Stream8 has a 2024 EOL, while CentOS 8 has a 2021 EOL
     # See: https://blog.centos.org/2020/12/future-is-centos-stream/
@@ -225,7 +225,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Dependencies
@@ -262,7 +262,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: macos-14
     steps:
       - name: Dependencies
@@ -285,7 +285,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: windows-2019
     defaults:
       run:
@@ -339,7 +339,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: windows-2019
     defaults:
       run:
@@ -431,7 +431,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: windows-2019
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -262,6 +262,10 @@ jobs:
 
   macos-14:
     name: macOS 14.0 (Sonoma)
+    # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
+    #if: ${{ env.NIGHTLY }}
+    # in the meantime, copy-paste this:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: macos-14
     steps:
       - name: Dependencies


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR solves the queuing issues we've faced due to the limit of 5 concurrent macOS runners.

Here, I've added the lowest-hanging-fruit suggestions from the issue description of https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4400. I've tried to preserve the highest-impact CI workflows (tests.yml, test-batch-processing.yml) while relegating the lower-impact CI workflows (create-release.yml, macos-14) to cron-only. I've also removed the trigger for merges/pushes to master. 

(See extended commit messages for further justification of each change.)

With these changes, we can now:

- Update PRs twice concurrently without running into queuing issues. (2x2 < 5)
- Merge and update PRs without running into queuing issues.

In the short term, this should allow us to quickly work through our backlog of approved PRs. (This need is also why I've mainly focused on uncontroversial, easy-to-review changes.) Long term, however, we may want to consider a more sophisticated approach to testing the create-release.yml workflow.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4400.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4374.
Maybe even addresses https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4034, since now that push-to-master triggers are gone, trains of PR merges are less of a hassle?
