### PR TITLE
Replace `matrix.os` with `runner.os` to more robustly detect Win OSs in GHA workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -78,11 +78,11 @@ jobs:
         echo "0.0" > spinalcordtoolbox/version.txt
 
     - name: Install SCT from release branch (Unix)
-      if: matrix.os != 'windows-2022'
+      if: runner.os != 'Windows'
       run: ./install_sct -yc
 
     - name: Install SCT from release branch (Windows)
-      if: matrix.os == 'windows-2022'
+      if: runner.os == 'Windows'
       shell: cmd
       run: install_sct.bat
 

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -36,11 +36,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install SCT (Unix)
-        if: matrix.os != 'windows-2022'
+        if: runner.os != 'Windows'
         run: ./install_sct -y
 
       - name: Install SCT (Windows)
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         shell: cmd
         run: install_sct.bat
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This commit is a tiny follow-up fix for PR #4402. In that PR, we relegated the `create-release.yml` workflow to only run on cron jobs. And, because we no longer run the workflow on PRs, we were able to expand the OSs suite without worrying about incurring additional costs. So, `windows-2019` was added back in addition to `windows-2022`.

However, in order to determine which installer to use (win vs. unix), we currently check the exact runner name ("windows-2022"). So, windows-2019 wasn't detected as a Windows runner, and the workflow failed for today's cron job.

To fix this, we can use an alternative syntax that is more general ("Windows") suggested by the official docs: https://docs.github.com/en/actions/learn-github-actions/variables#detecting-the-operating-system

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A.
