### PR TITLE
Fix detection of PSIR images for QC resampling to avoid unnecessary thresholding

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1877,7 +1877,9 @@ def check_image_kind(img):
             return 'seg'
         elif binary_percentage > 0.95:
             return 'softseg'
-    elif is_whole_only and zero_most_common and zero_percentage > 0.50:
+        else:  # binary_percentage <= 0.95
+            pass  # may be 'seg-labeled' or 'anat'
+    if is_whole_only and zero_most_common and zero_percentage > 0.50:
         return 'seg-labeled'
     else:
         return 'anat'

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1850,12 +1850,12 @@ def generate_stitched_qc_images(ims_in: Sequence[Image], im_out: Image) -> Tuple
 
 def check_image_kind(img):
     """
-    Identify the image as one of 4 image types:
+    Identify the image as one of 4 image types (represented as one of 4 strings):
 
         - 'seg': Binary segmentation (0/1)
         - 'softseg': Nonbinary segmentation in the range [0, 1], where 0 and 1 are the majority of values
-        - 'labeled_seg': Nonbinary, whole values (0, 1, 2...) where 0 is the majority of values
-        - 'im': Any other image where 0 is not the majority of values.
+        - 'seg-labeled': Nonbinary, whole values (0, 1, 2...) where 0 is the majority of values
+        - 'anat': Any other image
 
     Useful for determining A) which colormap should be applied to an image, or
                            B) which interpolation can be safely used on a given image


### PR DESCRIPTION
## Description

The primary goal of this PR is to avoid treating PSIR anat images as labeled segmentation images when resampling for QC reports. Segmentations are thresholded after resampling to ensure that their background remains transparent. But, PSIR images can have positive _and_ negative values, so thresholding will make half the image dark:

Before (thresholded as seg image):

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/8dab332b-0b3d-4216-a6d0-a1014b408a85)

After (no thresholding as anat image):

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/c1c255e7-9160-4174-946f-fab0b634bb76)

> Note: There is less of a risk of the inverse issue where label images treated as anat images, since `sct_qc -p sct_label_vertebrae` doesn't perform resampling. (Though, `check_image_kind` is also used for picking the colormap to use for `fsleyes` commands, so we do still need to consider labeled segmentations.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4389.