### PR TITLE
Replace remaining usages of `nib.save()` with `Image.save()` to mitigate scaling issues

### DIFF
--- a/spinalcordtoolbox/deepseg_/gm.py
+++ b/spinalcordtoolbox/deepseg_/gm.py
@@ -18,6 +18,7 @@ import numpy as np
 from spinalcordtoolbox import resampling
 from spinalcordtoolbox.utils.sys import __data_dir__
 from spinalcordtoolbox.deepseg_.onnx import onnx_inference
+from spinalcordtoolbox.image import Image
 
 # Models
 # Tuple of (model, metadata)
@@ -275,5 +276,6 @@ def segment_file(input_filename, output_filename,
     if threshold is not None:
         res_data = threshold_predictions(res_data, 0.5)
 
-    nib.save(nii_resampled_original, output_filename)
+    img = Image(param=res_data, hdr=nii_resampled_original.header)
+    img.save(output_filename)
     return output_filename

--- a/spinalcordtoolbox/deepseg_/sc.py
+++ b/spinalcordtoolbox/deepseg_/sc.py
@@ -558,6 +558,6 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     im_seg_r_postproc.change_orientation(original_orientation)
 
     # copy q/sform from input image to output segmentation
-    im_seg.copy_qform_from_ref(im_image)
+    im_seg.copy_affine_from_ref(im_image)
 
     return im_seg_r_postproc, im_image_res, im_seg.change_orientation('RPI')

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -377,7 +377,7 @@ class Image(object):
         else:
             return deepcopy(self)
 
-    def copy_qform_from_ref(self, im_ref):
+    def copy_affine_from_ref(self, im_ref):
         """
         Copy qform and sform and associated codes from a reference Image object
 
@@ -1407,7 +1407,7 @@ def concat_warp2d(fname_list, fname_warp3d, fname_dest):
     # save new image
     im_dest = Image(fname_dest)
     im_warp3d = Image(warp3d)
-    im_warp3d.copy_qform_from_ref(im_dest)
+    im_warp3d.copy_affine_from_ref(im_dest)
 
     # set "intent" code to vector, to be interpreted as warping field
     im_warp3d.header.set_intent('vector', (), '')

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1399,7 +1399,7 @@ def concat_warp2d(fname_list, fname_warp3d, fname_dest):
 
     for iz, fname in enumerate(fname_list):
         img = Image(fname)
-        warp2d = np.asanyarray(img.data)
+        warp2d = img.data
         warp3d[:, :, iz, 0, 0] = warp2d[:, :, 0, 0, 0]
         warp3d[:, :, iz, 0, 1] = warp2d[:, :, 0, 0, 1]
         del warp2d

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1398,20 +1398,20 @@ def concat_warp2d(fname_list, fname_warp3d, fname_dest):
     warp3d = np.zeros([nx, ny, nz, 1, 3])
 
     for iz, fname in enumerate(fname_list):
-        img = nib.load(fname)
-        warp2d = np.asanyarray(img.dataobj)
+        img = Image(fname)
+        warp2d = np.asanyarray(img.data)
         warp3d[:, :, iz, 0, 0] = warp2d[:, :, 0, 0, 0]
         warp3d[:, :, iz, 0, 1] = warp2d[:, :, 0, 0, 1]
         del warp2d
 
     # save new image
-    im_dest = nib.load(fname_dest)
-    affine_dest = im_dest.affine
-    im_warp3d = nib.nifti1.Nifti1Image(warp3d, affine_dest)
+    im_dest = Image(fname_dest)
+    im_warp3d = Image(warp3d)
+    im_warp3d.copy_qform_from_ref(im_dest)
 
     # set "intent" code to vector, to be interpreted as warping field
     im_warp3d.header.set_intent('vector', (), '')
-    nib.save(im_warp3d, fname_warp3d)
+    im_warp3d.save(fname_warp3d)
 
 
 def add_suffix(fname, suffix):

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -12,7 +12,7 @@ import psutil
 from math import asin, cos, sin, acos
 
 import numpy as np
-from nibabel import load, Nifti1Image, save, aff2axcodes
+from nibabel import load, Nifti1Image, aff2axcodes
 from nilearn.image import resample_img
 from scipy.signal import argrelmax, medfilt
 from scipy.ndimage import gaussian_filter, gaussian_filter1d, convolve

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -503,21 +503,21 @@ def register_dl_multimodal_cascaded_reg(fname_src, fname_dest, fname_warp_forwar
 
     # Forward registration
     warp_data = warp_data_exp_first + warp_data_exp_second
-    warp = Nifti1Image(warp_data, fx_preproc_nii.affine)
+    warp = image.Image(param=warp_data, hdr=fx_preproc_nii.header)
     # Set the intent code to vector
     # The intent code 1007 was chosen based on information found on:
     #     -  https://brainder.org/2012/09/23/the-nifti-file-format/
     #     -  http://users.bmap.ucla.edu/~mchamber/npl/nifti_8h_source.html#l00470
     warp.header['intent_code'] = 1007
     # Save the composed warping field [forward]
-    save(warp, fname_warp_forward)
+    warp.save(fname_warp_forward)
 
     # Reverse registration
     warp_data_rev = -warp_data
-    warp_rev = Nifti1Image(warp_data_rev, fx_preproc_nii.affine)
+    warp_rev = image.Image(param=warp_data_rev, hdr=fx_preproc_nii.header)
     warp_rev.header['intent_code'] = 1007
     # Save the composed warping field [reverse]
-    save(warp_rev, fname_warp_reverse)
+    warp_rev.save(fname_warp_reverse)
 
 
 def register_dl_inference(fname_model, input_moving, input_fixed, reg_args, device):
@@ -1399,8 +1399,8 @@ def generate_warping_field(fname_dest, warp_x, warp_y, fname_warp='warping_field
     hdr_warp = hdr_dest.copy()
     hdr_warp.set_intent('vector', (), '')
     hdr_warp.set_data_dtype('float32')
-    img = Nifti1Image(data_warp, None, hdr_warp)
-    save(img, fname_warp)
+    img = image.Image(param=data_warp, hdr=hdr_warp)
+    img.save(fname_warp)
     logger.info(f" --> {fname_warp}")
 
 

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -172,13 +172,13 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation,
     """
     # Load data
     logger.info('load data...')
-    nii = nib.load(fname_data)
+    img = Image(fname_data)
     if fname_ref is not None:
-        nii_ref = nib.load(fname_ref)
+        img_ref = Image(fname_ref)
     else:
-        nii_ref = None
+        img_ref = None
 
-    nii_r = resample_nib(nii, new_size.split('x'), new_size_type, image_dest=nii_ref, interpolation=interpolation)
+    img_r = resample_nib(img, new_size.split('x'), new_size_type, image_dest=img_ref, interpolation=interpolation)
 
     # build output file name
     if fname_out == '':
@@ -187,9 +187,9 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation,
         fname_out = fname_out
 
     # save data
-    nib.save(nii_r, fname_out)
+    img_r.save(fname_out)
 
     # to view results
     display_viewer_syntax([fname_out], verbose=verbose)
 
-    return nii_r
+    return img_r

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -286,7 +286,7 @@ class Transform:
         # Copy affine matrix from destination space to make sure qform/sform are the same
         printv("Copy affine matrix from destination space to make sure qform/sform are the same.", verbose)
         im_src_reg = Image(fname_out)
-        im_src_reg.copy_qform_from_ref(Image(fname_dest))
+        im_src_reg.copy_affine_from_ref(Image(fname_dest))
         im_src_reg.save(verbose=0)  # set verbose=0 to avoid warning message about rewriting file
 
         if islabel:

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -13,6 +13,7 @@ import numpy as np
 import nibabel as nib
 from dipy.denoise.nlmeans import nlmeans
 
+from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
@@ -183,14 +184,14 @@ def main(argv: Sequence[str]):
         plt.show()
 
     # Save files
-    img_denoise = nib.Nifti1Image(den, None, hdr_0)
-    img_diff = nib.Nifti1Image(diff_3d, None, hdr_0)
+    img_denoise = Image(param=den, hdr=hdr_0)
+    img_diff = Image(param=diff_3d, hdr=hdr_0)
     if output_file_name is not None:
         output_file_name = output_file_name
     else:
         output_file_name = file + '_denoised' + ext
-    nib.save(img_denoise, output_file_name)
-    nib.save(img_diff, file + '_difference' + ext)
+    img_denoise.save(output_file_name)
+    img_diff.save(file + '_difference' + ext)
 
     display_viewer_syntax(files=[file_to_denoise, output_file_name], verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -216,7 +216,7 @@ class DetectPMJ:
         run_proc(cmd_pmj, verbose=0, is_sct_binary=True)
 
         img = nib.load(self.dection_map_pmj + '_svm.hdr')  # convert .img and .hdr files to .nii
-        nib.save(img, self.dection_map_pmj + '.nii')
+        nib.save(img, self.dection_map_pmj + '.nii')  # NB: Use nib.save instead of Image.save for hdr file
 
         self.dection_map_pmj += '.nii'  # fname of the resulting detection map
 

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -13,7 +13,7 @@ import numpy as np
 import nibabel as nib
 from dipy.denoise.patch2self import patch2self
 
-from spinalcordtoolbox.image import add_suffix
+from spinalcordtoolbox.image import add_suffix, Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
 
@@ -137,10 +137,10 @@ def main(argv: Sequence[str]):
         plt.show()
 
     # Save files
-    nii_denoised = nib.Nifti1Image(data_denoised, None, hdr)
-    nii_diff = nib.Nifti1Image(data_diff, None, hdr)
-    nib.save(nii_denoised, output_file_name_denoised)
-    nib.save(nii_diff, output_file_name_diff)
+    nii_denoised = Image(param=data_denoised, hdr=hdr)
+    nii_diff = Image(param=data_diff, hdr=hdr)
+    nii_denoised.save(output_file_name_denoised)
+    nii_diff.save(output_file_name_diff)
 
     display_viewer_syntax([file_to_denoise, output_file_name_denoised, output_file_name_diff], verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -409,10 +409,10 @@ def func_rescale_header(fname_data, rescale_factor, verbose=0):
     header_rescaled = img.header.copy()
     header_rescaled.set_qform(qform)
     # the data are the same-- only the header changes
-    img_rescaled = nib.nifti1.Nifti1Image(np.asanyarray(img.dataobj), None, header=header_rescaled)
+    img_rescaled = Image(np.asanyarray(img.dataobj), hdr=header_rescaled)
     path_tmp = tmp_create(basename="propseg-rescale-header")
     fname_data_rescaled = os.path.join(path_tmp, os.path.basename(add_suffix(fname_data, "_rescaled")))
-    nib.save(img_rescaled, fname_data_rescaled)
+    img_rescaled.save(fname_data_rescaled)
     return fname_data_rescaled
 
 

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -508,13 +508,13 @@ class SpinalCordStraightener(object):
         hdr_warp.set_intent('vector', (), '')
         hdr_warp.set_data_dtype('float32')
         if self.curved2straight:
-            img = Nifti1Image(data_warp_curved2straight, None, hdr_warp_s)
-            save(img, 'tmp.curve2straight.nii.gz')
+            img = Image(param=data_warp_curved2straight, hdr=hdr_warp_s)
+            img.save('tmp.curve2straight.nii.gz')
             logger.info('Warping field generated: tmp.curve2straight.nii.gz')
 
         if self.straight2curved:
-            img = Nifti1Image(data_warp_straight2curved, None, hdr_warp)
-            save(img, 'tmp.straight2curve.nii.gz')
+            img = Image(param=data_warp_straight2curved, hdr=hdr_warp)
+            img.save('tmp.straight2curve.nii.gz')
             logger.info('Warping field generated: tmp.straight2curve.nii.gz')
 
         image_centerline_straight.save(fname_ref)

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -13,7 +13,6 @@ import logging
 import bisect
 
 import numpy as np
-from nibabel import Nifti1Image, save
 
 from spinalcordtoolbox.types import Centerline
 from spinalcordtoolbox.image import Image, spatial_crop, generate_output_file, pad_image


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR is a follow up to previous PRs:

- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3944
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4346

We have the fix for the scaling issues in `Image.save()` -- we just need to make sure `Image.save()` is actually being used instead of `nib.save()`. So, this PR takes care of the remaining usages of `nib.save()`, _except_:

- `image.py`: This the 1 necessary usage for `Image.save()`
- `sct_detect_pmj.py`: Here, we use `nib.save()` for a `.hdr` file, which I don't think SCT's `Image` class was built to handle.
- `testing/`: These usages are entirely for dummy data creation, where datatype mismatches wouldn't be an issue.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3232.