### PR TITLE
Move most broken link checking to a daily job

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -18,7 +18,7 @@ jobs:
           \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) |
           xargs grep -Eo "\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]" |
           sed 's/:/;/' |
-          xargs -n 1 -P 8 ./.github/workflows/check-url.sh
+          xargs -n 1 ./.github/workflows/check-url.sh
 
     - name: Summarize
       run: |

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,0 +1,30 @@
+name: Check for broken links
+
+on:
+  schedule:
+    - cron:  '0 10 * * *'
+
+jobs:
+  check_broken_links:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check for broken links
+      run: |
+        touch valid_urls.txt redirected_urls.txt invalid_urls.txt
+        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
+          \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) |
+          xargs grep -Eo "\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]" |
+          sed 's/:/;/' |
+          xargs -n 1 -P 8 ./.github/workflows/check-url.sh
+
+    - name: Summarize
+      run: |
+        NUM_OK=$(wc -l valid_urls.txt | cut -d " " -f 1)
+        NUM_REDIRECT=$(wc -l redirected_urls.txt | cut -d " " -f 1)
+        NUM_BAD=$(wc -l invalid_urls.txt | cut -d " " -f 1)
+        cat invalid_urls.txt
+        echo -en "========== \033[0;32m$NUM_OK passed\033[0;0m, \033[0;33m$NUM_REDIRECT redirected\033[0;0m, \033[0;31m$NUM_BAD failed\033[0;0m ==========\n"
+        exit $NUM_BAD

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -3,7 +3,7 @@ name: Check code quality
 on: [pull_request]
 
 jobs:
-  run_flake8_and_shellcheck:
+  run_flake8_and_shellcheck_and_checkurl:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -31,3 +31,15 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         severity: style
+
+    # There's a daily check for _all_ links in check-broken-links.yml,
+    # so this only checks for new/changed links in the PR
+    - name: Check for broken links
+      run: |
+        set -eu -o pipefail
+        git diff origin/master... |
+          (grep '^+' || (($? == 1)) ) |
+          (grep -Eo '\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
+          sed 's/:/;/' |
+          xargs -rn 1 .github/workflows/check-url.sh
+        test ! -s invalid_urls.txt

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -31,22 +31,3 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         severity: style
-
-    - name: Check for broken links
-      run: | 
-        touch valid_urls.txt redirected_urls.txt invalid_urls.txt
-        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
-          \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) | 
-          xargs grep -Eo "\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]" | 
-          sed 's/:/;/' | 
-          xargs -n 1 -P 8 ./.github/workflows/check-url.sh
-
-    - name: Summarize broken link check
-      run: |
-        NUM_OK=$(wc -l valid_urls.txt | cut -d " " -f 1)
-        NUM_REDIRECT=$(wc -l redirected_urls.txt | cut -d " " -f 1)
-        NUM_BAD=$(wc -l invalid_urls.txt | cut -d " " -f 1)
-        cat invalid_urls.txt
-        echo -en "========== \033[0;32m$NUM_OK passed\033[0;0m, \033[0;33m$NUM_REDIRECT redirected\033[0;0m, \033[0;31m$NUM_BAD failed\033[0;0m ==========\n"
-        exit $NUM_BAD
-


### PR DESCRIPTION
Fixes #4426.

I still kept a limited form of the link checker for PRs. It should only check added/modified lines, so that should catch typos in new/changed links. The daily job should catch websites that stop working.

For the daily run, I picked a scheduled time that's an hour before all the other tests (either 5am or 6am Montreal time, depending on daylight savings), to avoid resource bottlenecks.