### PR TITLE
Fix broken link checker

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -16,7 +16,7 @@ jobs:
         touch valid_urls.txt redirected_urls.txt invalid_urls.txt
         find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
           \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) |
-          xargs grep -Eo "\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]" |
+          xargs grep -Eio "\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]" |
           sed 's/:/;/' |
           xargs -n 1 ./.github/workflows/check-url.sh
 

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -39,7 +39,7 @@ jobs:
         set -eu -o pipefail
         git diff origin/master... |
           (grep '^+' || (($? == 1)) ) |
-          (grep -Eo '\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
+          (grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
           sed 's/^/;/' |
           xargs -rn 1 .github/workflows/check-url.sh
         test ! -s invalid_urls.txt

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -40,6 +40,6 @@ jobs:
         git diff origin/master... |
           (grep '^+' || (($? == 1)) ) |
           (grep -Eo '\b(https?)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
-          sed 's/:/;/' |
+          sed 's/^/;/' |
           xargs -rn 1 .github/workflows/check-url.sh
         test ! -s invalid_urls.txt

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -40,6 +40,6 @@ jobs:
         git diff origin/master... |
           (grep '^+' || (($? == 1)) ) |
           (grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
-          sed 's/^/;/' |
+          sed 's/^/diff;/' |
           xargs -rn 1 .github/workflows/check-url.sh
         test ! -s invalid_urls.txt


### PR DESCRIPTION
Since `grep` no longer receives filenames, it no longer puts `$FILENAME:` at the start of each line. But `check-url.sh` _does_ expect a semicolon before the url to check. So we need to insert it, rather than changing the colon after `https` into a semicolon.

Sorry!

Follow-up for #4428.