### PR TITLE
Avoid nibabel crashes due to `int64` arrays by explicitly passing `dtype`/`header` to `Nifti1Image`

### DIFF
--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -399,10 +399,10 @@ def register_dl_multimodal_cascaded_reg(fname_src, fname_dest, fname_warp_forwar
     # Scale the data between 0 and 1
     fx_img = dest_img.get_fdata()
     scaled_fx_img = (fx_img - np.min(fx_img)) / (np.max(fx_img) - np.min(fx_img))
-    scaled_fx_nii = Nifti1Image(scaled_fx_img, dest_img.affine)
+    scaled_fx_nii = Nifti1Image(scaled_fx_img, dest_img.affine)  # Can't be int64 (#4408)
     mov_img = src_img.get_fdata()
     scaled_mov_img = (mov_img - np.min(mov_img)) / (np.max(mov_img) - np.min(mov_img))
-    scaled_mov_nii = Nifti1Image(scaled_mov_img, src_img.affine)
+    scaled_mov_nii = Nifti1Image(scaled_mov_img, src_img.affine)  # Can't be int64 (#4408)
     # Ensure that the volumes can be used in the registration model
     # (size multiple of 16 because 4 encoder reducing the size by 2)
     fx_img_shape = scaled_fx_img.shape

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -268,7 +268,7 @@ class Slice(object):
         """
         dict_interp = {'im': 'spline', 'seg': 'linear'}
         # Create nibabel object
-        nii = Nifti1Image(image.data, image.hdr.get_best_affine())
+        nii = Nifti1Image(image.data, affine=image.hdr.get_best_affine(), header=image.hdr)
         # If no reference image is provided, resample to specified resolution
         if image_ref is None:
             # Resample each slice to p_resample x p_resample mm (orientation is SAL by convention in QC module)
@@ -283,7 +283,7 @@ class Slice(object):
         # Otherwise, resampling to the space of the reference image
         else:
             # Create nibabel object for reference image
-            nii_ref = Nifti1Image(image_ref.data, image_ref.hdr.get_best_affine())
+            nii_ref = Nifti1Image(image_ref.data, affine=image_ref.hdr.get_best_affine(), header=image_ref.hdr)
             nii_r = resample_nib(nii, image_dest=nii_ref, interpolation=dict_interp[type_img])
         # If resampled image is a segmentation, binarize using threshold at 0.5 for binary segmentation
         # Apply threshold at 0.5 for non-binary segmentation

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -140,7 +140,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
                 cval=0.0, out_class=None)
             data4d[..., it] = np.asanyarray(img3d_r.dataobj)
         # Create 4d nibabel Image
-        img_r = nib.nifti1.Nifti1Image(data4d, affine_r)
+        img_r = nib.nifti1.Nifti1Image(data4d, affine_r)  # Can't be int64 (#4408)
         # Copy over the TR parameter from original 4D image (otherwise it will be incorrectly set to 1)
         img_r.header.set_zooms(list(img_r.header.get_zooms()[0:3]) + [img.header.get_zooms()[3]])
 

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -134,7 +134,8 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         # Loop across 4th dimension and resample each 3d volume
         for it in range(img.shape[3]):
             # Create dummy 3d nibabel image
-            nii_tmp = nib.nifti1.Nifti1Image(np.asanyarray(img.dataobj)[..., it], affine)
+            data3d = np.asanyarray(img.dataobj)[..., it]
+            nii_tmp = nib.nifti1.Nifti1Image(data3d, affine, dtype=data3d.dtype)
             img3d_r = resample_from_to(
                 nii_tmp, to_vox_map=(shape_r[:-1], affine_r), order=dict_interp[interpolation], mode=mode,
                 cval=0.0, out_class=None)

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -118,7 +118,7 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         if isinstance(image_dest, nib.nifti1.Nifti1Image):
             reference = image_dest
         elif isinstance(image_dest, Image):
-            reference = nib.nifti1.Nifti1Image(image_dest.data, image_dest.hdr.get_best_affine())
+            reference = nib.nifti1.Nifti1Image(image_dest.data, affine=image_dest.hdr.get_best_affine(), header=image_dest.hdr)
         else:
             raise TypeError(f'Invalid image type: {type(image_dest)}')
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

nibabel will throw an error for instances of `Nifti1Image(data, affine)` when data is of type
int64 (and no header/dtype arguments are specified):

```python
File "/home/runner/sct_6.3.dev0/testing/api/test_deepseg_sc.py", line 85, in test_uncrop_image
    nii = nib.nifti1.Nifti1Image(data_in, affine)
  File "/home/runner/sct_6.3.dev0/python/envs/venv_sct/lib/python3.9/site-packages/nibabel/nifti1.py", line 1836, in __init__
    alert_future_error(
  File "/home/runner/sct_6.3.dev0/python/envs/venv_sct/lib/python3.9/site-packages/nibabel/deprecated.py", line 120, in alert_future_error
    raise error_class(f'{msg} {error_rec}'.strip())
ValueError: """Image data has type int64, which may cause incompatibilities with other tools. 
               To use this type, pass an explicit header or dtype argument to Nifti1Image()."""
```

To avoid these errors, I did the following:

- Did a project wide search (sans `testing/`) for instances of `Nifti1Image` (15 results)
- Identified instances where `data` and `affine` were specified without `header`/`dtype` (7 results)
- Identified which of these instances cannot have int64 data (3/7 results), and added comments for them.
- For the remaining 4/7 instances, I either specified `header` or `dtype`, depending on context. (I used `header` when simply converting `Image` objects to `Nifti1Image` objects, and used `dtype` for a single dummy image usage.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4420.
Fixes #4408. (The errors, at least!)

This PR doesn't do anything to heed nibabel's warning, though. (It is still possible to generate `int64` images using SCT.) However, I don't think `int64` images are actually explicitly created anywhere by SCT? I think they only ever occur when a user passes `int64` images as input. Given that, I think it's OK to close the underlying issue?
