### PR TITLE
Ensure that `-transpose` also transposes the zoom order (needed for anisotropic images)

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -369,6 +369,7 @@ def main(argv: Sequence[str]):
         transpose_numerical = [DIM_LIST.index(axis)  # Convert [x, y, z, t] to [0, 1, 2, 3]
                                for axis in arguments.transpose]
         im_out.data = np.transpose(im_out.data, axes=transpose_numerical)
+        im_out.header.set_zooms([im_out.header.get_zooms()[ax] for ax in transpose_numerical])
         im_out = [im_out]
 
     elif arguments.header is not None:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR ensures that, when transposing just the data array, we also transpose the zooms (to ensure that the correct resolution is applied for anisotropic images).

Issue #4417 contains an illustrative comparison for when A) zooms aren't transposed and B) zooms are correctly transposed.

## Alternative solution

While writing this simple fix, I also noticed that we perform similar transposing during the `-setorient` command:

- `-setorient`: Change the axis order for both the data array _and_ the header.
- `-transpose`: Change the axis order for _just_ the data array.

However, `-setorient` [isn't affected by this bug](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4417#issuecomment-2040175904)! So, I was wondering if it might be better to perform a refactor where both `-setorient` and `-transpose` use the same function, but `-transpose` is run with some sort of `data_only=True` argument. That way, we're consistently using the same transpose logic for both arguments.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4417.
