### PR TITLE
Avoid `nnunetv2=={2.4.0,2.4.1}` to mitigate upstream bug for `predict_single_npy_array`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
-nnunetv2 @ git+https://github.com/joshuacwnewton/nnUNet@jn/2112-fix-unpacking-bug-v2.4
+nnunetv2!=2.4.0,!=2.4.1
 numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ monai[nibabel]
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
-nnunetv2
+# 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
+nnunetv2<2.4.0
 numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
-nnunetv2<2.4.0
+nnunetv2 @ git+https://github.com/joshuacwnewton/nnUNet@jn/2112-fix-unpacking-bug-v2.4
 numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I've opened an upstream PR to fix this issue here: https://github.com/MIC-DKFZ/nnUNet/pull/2114

I'm hoping that this will be merged for nnunetv2==2.4.2, hence avoiding only 2.4.0/2.4.1.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4444.
