### PR TITLE
Fix inaccurate line in docs regarding the method used for spinal level estimation (Frostell et al.)

### DIFF
--- a/documentation/source/overview/concepts/pam50.rst
+++ b/documentation/source/overview/concepts/pam50.rst
@@ -93,7 +93,8 @@ encoded by one voxel centered in the spinal cord, and the value of the voxel cor
 file can be useful for registration to the PAM50 using the spinal levels instead of the intervertebral discs, if the 
 former are available (e.g., via nerve rootlets segmentation).
 
-The spinal levels are estimated from the intervertebral discs, using a methods described in 
+The spinal levels are estimated from the relative length of each spinal level with respect to the length of the 
+full spinal cord (expressed as a percentage), found in Table 3 of the article by 
 `Frostell et al. (2016) <https://www.frontiersin.org/articles/10.3389/fneur.2016.00238/full>`_.
 The figure below (extracted from Frostell et al.) shows the spatial correspondance between the spinal vs. vertebral levels.
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->


See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4247#issuecomment-2020338980:

> > _The spinal levels are estimated from the intervertebral discs, using a methods described in [Frostell et al. (2016)](https://www.frontiersin.org/articles/10.3389/fneur.2016.00238/full)._
> 
> From what is explained in the [issue #16](https://github.com/spinalcordtoolbox/PAM50/issues/16) and [the script](https://github.com/spinalcordtoolbox/PAM50/blob/38f6ce3418aebcee1458594f22646dc94ca889f6/scripts/generate_spinal_levels.py), the levels are computed based on the relative length of each spinal level with respect to the length of the full spinal cord  (expressed as a percentage), found in Table 3 of the article by Frostell et al., 2016.
> 
> I thought it might be important to update this ☺️ 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4247#issuecomment-2020338980
