### PR TITLE
Switch from two-tone colormap to transparency for `sct_deepseg` QC

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -316,21 +316,18 @@ def sct_deepseg(
         fig.set_size_inches(*size_fig, forward=True)
         FigureCanvas(fig)
         ax = fig.add_axes((0, 0, 1, 1))
-        colormaps = {
-            # Single color (Red, Cyan)
-            'seg': ["#ff0000", "#00ffff"],
-            # Two-tone colormap (Red-darkred, Cyan-darkcyan)
-            'softseg': [color.ListedColormap(["#4d0000", "#ff0000"]),
-                        color.ListedColormap(["#004d4d", "#00ffff"])],
-        }
+        colormaps = [color.ListedColormap(["#ff0000"]),  # Red for first image
+                     color.ListedColormap(["#00ffff"])]  # Cyan for second
         for i, image in enumerate([img_seg_sc, img_seg_lesion]):
             if not image:
                 continue
             img = mosaic(image, centers)
             img = np.ma.masked_equal(img, 0)
             ax.imshow(img,
-                      cmap=(colormaps['seg'] if check_image_kind(image.data) == 'seg' else colormaps['softseg'])[i],
+                      cmap=colormaps[i],
                       norm=color.Normalize(vmin=0.5, vmax=1),
+                      # img==1 -> opaque, but soft regions -> more transparent as value decreases
+                      alpha=(img / img.max()),  # scale to [0, 1]
                       interpolation='none',
                       aspect=1.0)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

> [!NOTE]
> Terribly sorry for the last minute PR, right before the SCT release! But, it's important that we have a good-looking QC when showing off the new contrast agnostic model. :)

This PR is a small amendment to #4446. Using a dark color for values <1.0 was making it much more difficult to QC the soft perimeter of softsegs.

This solution scales the transparency to the image values. If the segmentation == 1.0, then the image will be opaque red (as it already was). But, as the values get closer to 0, the voxels will get more and more transparent. This will prevent low values (e.g. 0.01) from showing up in the QC report.

Sample output for the SCI SC+lesion seg:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/39cb585f-957f-4e35-ba84-35171e12490e)


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4457.
