### PR TITLE
Replace `libglib2.0-0` with `t64` version to fix Debian Rolling Release test failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - name: Dependencies
         run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
-          apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl
+          apt update && apt install -y libglib2.0-0t64 libgl1-mesa-dev procps gcc git curl
       - uses: actions/checkout@v4
       - name: Install SCT
         run: |


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

From what I can tell, Debian is in the process of [migrating from `libglib2.0-0` to `libglib2.0-0t64`](https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1958242.html) (64-bit time) to fix the [Year 2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem). 

Currently, we manually install the old `libglib2.0-0`, which appears to cause a conflict with the new `libglib2.0-0t64`. My best guess is that one of the other packages that we install (e.g. `gcc`/`git`/`curl`/etc.) had upgraded to `libglib2.0-0t64`, so by simultaneously installing the old package, we run into: 

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

Unsatisfied dependencies:
 libglib2.0-0t64 : Breaks: libglib2.0-0 (< 2.78.4-7~)
Error: Unable to correct problems, you have held broken packages.
```

It's hard to find a concrete source that precisely explains the issue. The closest I got was [this post on /r/Debian](https://www.reddit.com/r/debian/comments/1cdkax2/debian_testing_apt_upgrade_installed/). Their case is mostly unrelated to our issue, but I'll give a tl;dr just to illustrate how these types of conflicts can occur:

<details>

- The rollout for `t64` is done package-by-package. Some packages may upgrade to `t64` while others (temporarily) remain on the `t32` version.
- The user ran `dist-upgrade`, which is a [potentially dangerous](https://askubuntu.com/a/602) command to run:
    > But `dist-upgrade` **can be quite dangerous.** [Unlike `upgrade`](https://askubuntu.com/questions/194651/why-use-apt-get-upgrade-instead-of-apt-get-dist-upgrade) it may _remove_ packages to resolve complex dependency situations. Unlike you, APT isn't always smart enough to know whether these additions and removals could wreak havoc.
- Exactly as described above, `dist-upgrade` upgraded to `libglib2.0-0t64` while removing any packages that still depended on the old `libglib2.0-0` (in this case, GNOME).
- When the user tried to reinstall GNOME, they got the [exact same error](https://www.reddit.com/r/debian/comments/1cdkax2/debian_testing_apt_upgrade_installed/l1crknz/) as us, presumably because GNOME still depended on the older version. (It has since upgraded to `t64` as well.)
</details>

Lesson: Avoid trying to install `libglib2.0-0` (and anything that still depends on it)!

## Testing this PR

I ran the CI for Debian Rolling Release, and there [was no failure](https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/8882203703/job/24386310423#step:3:30).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4452.