### PR TITLE
Ignore case where user selects 'combine=1' with CombinedLabels

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -392,7 +392,7 @@ def check_labels(indiv_labels_ids, selected_labels):
         if not set(list_ids_of_labels_of_interest).issubset(set(indiv_labels_ids)):
             logging.error(
                 'At least one of the selected labels (' + str(list_ids_of_labels_of_interest) + ') is not available \
-                according to the label list from the text file in the atlas folder.')
+according to the label list from the text file in the atlas folder.')
 
     return list_ids_of_labels_of_interest
 

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -372,10 +372,14 @@ def main(argv: Sequence[str]):
         # Avoid case where user asked to combine a single label which is already a combination of 'native' labels
         # Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4467
         if not (len(labels_id_user)==1 and labels_id_user[0] in combined_labels_ids):
-            # Add entry with internal ID value (99) which corresponds to combined labels
-            label_struc[99] = LabelStruc(id=labels_id_user, name=','.join([str(i) for i in labels_id_user]),
-                                        map_cluster=None)
-            labels_id_user = [99]
+            # If user is trying to combine more than one label that is part of CombinedLabels, exit with error
+            if len(labels_id_user)!=1 and any(element in combined_labels_ids for element in labels_id_user):
+                printv('\nERROR: You are trying to combine multiple labels that are already combined (under section "# Combined labels" the info_label.txt file. Instead, enter the all the labels that you wish to combine from the list "# Keyword=IndivLabels".', 1, type='error')
+            else:
+                # Add entry with internal ID value (99) which corresponds to combined labels
+                label_struc[99] = LabelStruc(id=labels_id_user, name=','.join([str(i) for i in labels_id_user]),
+                                            map_cluster=None)
+                labels_id_user = [99]
 
     for id_label in labels_id_user:
         printv('Estimation for label: ' + label_struc[id_label].name, verbose)

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -369,10 +369,13 @@ def main(argv: Sequence[str]):
 
     # Combine individual labels for estimation
     if combine_labels:
-        # Add entry with internal ID value (99) which corresponds to combined labels
-        label_struc[99] = LabelStruc(id=labels_id_user, name=','.join([str(i) for i in labels_id_user]),
-                                     map_cluster=None)
-        labels_id_user = [99]
+        # Avoid case where user asked to combine a single label which is already a combination of 'native' labels
+        # Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4467
+        if not (len(labels_id_user)==1 and labels_id_user[0] in combined_labels_ids):
+            # Add entry with internal ID value (99) which corresponds to combined labels
+            label_struc[99] = LabelStruc(id=labels_id_user, name=','.join([str(i) for i in labels_id_user]),
+                                        map_cluster=None)
+            labels_id_user = [99]
 
     for id_label in labels_id_user:
         printv('Estimation for label: ' + label_struc[id_label].name, verbose)

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -369,9 +369,10 @@ def main(argv: Sequence[str]):
 
     # Combine individual labels for estimation
     if combine_labels:
-        # Avoid case where user asked to combine a single label which is already a combination of 'native' labels
-        # Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4467
-        if not (len(labels_id_user) == 1 and labels_id_user[0] in combined_labels_ids):
+        if len(labels_id_user) == 1:
+            # Trying to combine 1 label may result in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4467
+            printv("Ignoring `-combine` arg since only 1 label value was provided", 1, type='warning')
+        else:
             # If user is trying to combine more than one label that is part of CombinedLabels, exit with error
             if len(labels_id_user) != 1 and any(element in combined_labels_ids for element in labels_id_user):
                 printv('\nERROR: You are trying to combine multiple labels that are already combined (under '

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -371,14 +371,16 @@ def main(argv: Sequence[str]):
     if combine_labels:
         # Avoid case where user asked to combine a single label which is already a combination of 'native' labels
         # Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4467
-        if not (len(labels_id_user)==1 and labels_id_user[0] in combined_labels_ids):
+        if not (len(labels_id_user) == 1 and labels_id_user[0] in combined_labels_ids):
             # If user is trying to combine more than one label that is part of CombinedLabels, exit with error
-            if len(labels_id_user)!=1 and any(element in combined_labels_ids for element in labels_id_user):
-                printv('\nERROR: You are trying to combine multiple labels that are already combined (under section "# Combined labels" the info_label.txt file. Instead, enter the all the labels that you wish to combine from the list "# Keyword=IndivLabels".', 1, type='error')
+            if len(labels_id_user) != 1 and any(element in combined_labels_ids for element in labels_id_user):
+                printv('\nERROR: You are trying to combine multiple labels that are already combined (under '
+                       'section "# Combined labels" the info_label.txt file. Instead, enter the all the labels that '
+                       'you wish to combine from the list "# Keyword=IndivLabels".', 1, type='error')
             else:
                 # Add entry with internal ID value (99) which corresponds to combined labels
                 label_struc[99] = LabelStruc(id=labels_id_user, name=','.join([str(i) for i in labels_id_user]),
-                                            map_cluster=None)
+                                             map_cluster=None)
                 labels_id_user = [99]
 
     for id_label in labels_id_user:


### PR DESCRIPTION
Fixes #4467

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution nope 😢 (see #4468)
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I'm having issues creating a test for it (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4468), we should add the following tests for `test_cli_sct_extract_metric.py`:

- Labels under `Keyword=IndivLabels`: `-l 2,3 -combine 1` --> it should combine 2,3 into a single label
- Labels under `Keyword=IndivLabels`: `-l 2 -combine 1` --> it should not crash, and extract in label 2
- Labels under `Keyword=CombinedLabels`: `-l 52 -combine 1` --> it should not crash, and extract in label 52 (the test I was trying to make)
- Labels under `Keyword=CombinedLabels`: `-l 51,52 -combine 1` --> Now that's an interesting one. I'm now sure what will happen in the code to be honest 😅 but ideally we would produce a label (99) that combines all tracts within 51 and 52 (and deal with the redundancy)
 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
