### PR TITLE
Fix small argparse bug when wrapping help text with whitespace-only lines

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_flow.py
+++ b/spinalcordtoolbox/scripts/sct_compute_flow.py
@@ -16,13 +16,13 @@ from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 def get_parser():
     parser = SCTArgumentParser(
-        description=(
-            "Compute velocity from the MRI phase image for velocity encoding (VENC) sequences."
-            "\nMore details in: https://mriquestions.com/what-is-venc.html"
-            "\n"
-            "\nFurther features are planned for this script. Please refer to this issue for more info:"
-            "\n  - https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4298"
-        )
+        description=("""
+Compute velocity from the MRI phase image for velocity encoding (VENC) sequences.
+More details in: https://mriquestions.com/what-is-venc.html
+
+Further features are planned for this script. Please refer to this issue for more info:
+  - https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4298
+        """)
     )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")

--- a/spinalcordtoolbox/scripts/sct_compute_flow.py
+++ b/spinalcordtoolbox/scripts/sct_compute_flow.py
@@ -16,7 +16,7 @@ from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 def get_parser():
     parser = SCTArgumentParser(
-        description=("""
+        description=("""\
 Compute velocity from the MRI phase image for velocity encoding (VENC) sequences.
 More details in: https://mriquestions.com/what-is-venc.html
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -329,6 +329,7 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         offsets = [re.match("^[ \t]*", line).group(0) for line in lines]
         wrapped = []
         for i, li in enumerate(lines):
+            li = li.rstrip()  # strip trailing whitespace
             if len(li) > 0:
                 # Check for ANSI graphics control sequences, and increase width to compensate
                 width_adjusted = width + len("".join(re.findall("\\x1b\[[0-9;]+m", li)))  # noqa: W605


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR ensures that our line-wrapping code doesn't fail when passed a whitespace-only line (e.g. `'     '`). This can occur when using a multiline string with a blank line in between.

As a test, I've reverted the help description string for `sct_compute_flow` back to its multiline version.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4471.
