### PR TITLE
Run all tests in temporary directories (to preserve a clean copy of `sct_testing_data`)

### DIFF
--- a/testing/cli/test_cli_sct_analyze_texture.py
+++ b/testing/cli/test_cli_sct_analyze_texture.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_analyze_texture_image_data_within_threshold():
     """Run the CLI script and verify that the output image data is close to a reference image (within threshold)."""
     sct_analyze_texture.main(argv=['-i', 't2/t2.nii.gz', '-m', 't2/t2_seg-manual.nii.gz', '-feature', 'contrast',

--- a/testing/cli/test_cli_sct_analyze_texture.py
+++ b/testing/cli/test_cli_sct_analyze_texture.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_analyze_texture
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -14,10 +15,11 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sct_testing
 def test_sct_analyze_texture_image_data_within_threshold():
     """Run the CLI script and verify that the output image data is close to a reference image (within threshold)."""
-    sct_analyze_texture.main(argv=['-i', 't2/t2.nii.gz', '-m', 't2/t2_seg-manual.nii.gz', '-feature', 'contrast',
+    sct_analyze_texture.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                   '-m', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-feature', 'contrast',
                                    '-distance', '1', '-ofolder', '.'])
 
     im_texture = Image('t2_contrast_1_mean.nii.gz')
-    im_texture_ref = Image('t2/t2_contrast_1_mean_ref.nii.gz')
+    im_texture_ref = Image(sct_test_path('t2', 't2_contrast_1_mean_ref.nii.gz'))
 
     assert np.linalg.norm(im_texture.data - im_texture_ref.data) <= 0.001

--- a/testing/cli/test_cli_sct_apply_transfo.py
+++ b/testing/cli/test_cli_sct_apply_transfo.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("path_in,path_dest,path_warp,path_out,remaining_args", [
     ('template/template/PAM50_small_t2.nii.gz', 't2/t2.nii.gz', 't2/warp_template2anat.nii.gz',
      'PAM50_small_t2_reg.nii', []),

--- a/testing/cli/test_cli_sct_apply_transfo.py
+++ b/testing/cli/test_cli_sct_apply_transfo.py
@@ -5,23 +5,37 @@ import logging
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_apply_transfo
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("path_in,path_dest,path_warp,path_out,remaining_args", [
-    ('template/template/PAM50_small_t2.nii.gz', 't2/t2.nii.gz', 't2/warp_template2anat.nii.gz',
+    (sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
+     sct_test_path('t2', 't2.nii.gz'),
+     sct_test_path('t2', 'warp_template2anat.nii.gz'),
      'PAM50_small_t2_reg.nii', []),
-    ('template/template/PAM50_small_t2.nii.gz', 't2/t2.nii.gz', 't2/warp_template2anat.nii.gz',
+    (sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
+     sct_test_path('t2', 't2.nii.gz'),
+     sct_test_path('t2', 'warp_template2anat.nii.gz'),
      'PAM50_small_t2_reg-crop1.nii', ['-crop', '1']),
-    ('template/template/PAM50_small_t2.nii.gz', 't2/t2.nii.gz', 't2/warp_template2anat.nii.gz',
+    (sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
+     sct_test_path('t2', 't2.nii.gz'),
+     sct_test_path('t2', 'warp_template2anat.nii.gz'),
      'PAM50_small_t2_reg-crop2.nii', ['-crop', '2']),
-    ('template/template/PAM50_small_t2.nii.gz', 't2/t2.nii.gz', 't2/warp_template2anat.nii.gz',
+    (sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
+     sct_test_path('t2', 't2.nii.gz'),
+     sct_test_path('t2', 'warp_template2anat.nii.gz'),
      'PAM50_small_t2_reg-concatWarp.nii', []),
-    ('template/template/PAM50_small_t2.nii.gz', 'dmri/dmri.nii.gz', 't2/warp_template2anat.nii.gz',
+    (sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
+     sct_test_path('dmri', 'dmri.nii.gz'),
+     sct_test_path('t2', 'warp_template2anat.nii.gz'),
      'PAM50_small_t2_reg-4Dref.nii', []),
-    ('dmri/dmri.nii.gz', 't2/t2.nii.gz', 'mt/warp_t22mt1.nii.gz', 'PAM50_small_t2_reg-4Din.nii', [])
+    (sct_test_path('dmri', 'dmri.nii.gz'),
+     sct_test_path('t2', 't2.nii.gz'),
+     sct_test_path('mt', 'warp_t22mt1.nii.gz'),
+     'PAM50_small_t2_reg-4Din.nii', [])
 ])
 def test_sct_apply_transfo_output_image_attributes(path_in, path_dest, path_warp, path_out, remaining_args):
     """Run the CLI script and verify transformed images have expected attributes."""

--- a/testing/cli/test_cli_sct_compute_compression.py
+++ b/testing/cli/test_cli_sct_compute_compression.py
@@ -50,7 +50,6 @@ def dummy_3d_mask_nib():
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_compute_compression_value_against_groundtruth():
     """Run the CLI script and verify that computed mscc value is equivalent to known ground truth value."""
     di, da, db = 6.85, 7.65, 7.02

--- a/testing/cli/test_cli_sct_compute_ernst_angle.py
+++ b/testing/cli/test_cli_sct_compute_ernst_angle.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_compute_ernst_angle_value_against_groundtruth():
     """Run the CLI script and verify that computed ernst angle is equivalent to known ground truth value."""
     fname_out = 'ernst_angle.txt'

--- a/testing/cli/test_cli_sct_compute_hausdorff_distance.py
+++ b/testing/cli/test_cli_sct_compute_hausdorff_distance.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_compute_hausdorff_distance_null_values():
     """Run the CLI script and verify computed distances between identical images are all zero."""
     # TODO: Test distances between non-identical images`

--- a/testing/cli/test_cli_sct_compute_hausdorff_distance.py
+++ b/testing/cli/test_cli_sct_compute_hausdorff_distance.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_compute_hausdorff_distance
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,8 @@ logger = logging.getLogger(__name__)
 def test_sct_compute_hausdorff_distance_null_values():
     """Run the CLI script and verify computed distances between identical images are all zero."""
     # TODO: Test distances between non-identical images`
-    sct_compute_hausdorff_distance.main(argv=['-i', 't2s/t2s_gmseg_manual.nii.gz', '-d', 't2s/t2s_gmseg_manual.nii.gz'])
+    sct_compute_hausdorff_distance.main(argv=['-i', sct_test_path('t2s', 't2s_gmseg_manual.nii.gz'),
+                                              '-d', sct_test_path('t2s', 't2s_gmseg_manual.nii.gz')])
 
     with open('hausdorff_distance.txt', 'r') as f:
         hausdorff_distance_lst = []

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -7,6 +7,7 @@ import nibabel as nib
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_compute_mtr
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,9 @@ def test_sct_compute_mtr_results_are_identical(tmp_path):
     images remains the same.
     """
 
-    mt0_path = 'mt/mt0_reg_slicereg_goldstandard.nii.gz'
-    mt1_path = 'mt/mt1.nii.gz'
-    mtr_groundtruth_path = 'mt/mtr.nii.gz'
+    mt0_path = sct_test_path('mt', 'mt0_reg_slicereg_goldstandard.nii.gz')
+    mt1_path = sct_test_path('mt', 'mt1.nii.gz')
+    mtr_groundtruth_path = sct_test_path('mt', 'mtr.nii.gz')
     mtr_output_path = str(tmp_path / 'mtr_output.nii.gz')
 
     # We increase the threshold here because the default value is 100, but the

--- a/testing/cli/test_cli_sct_compute_mtr.py
+++ b/testing/cli/test_cli_sct_compute_mtr.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_compute_mtr_results_are_identical(tmp_path):
     """
     Test the CLI script to ensure that MTR computed with sct_testing_data

--- a/testing/cli/test_cli_sct_concat_transfo.py
+++ b/testing/cli/test_cli_sct_concat_transfo.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_concat_transfo
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,5 +13,7 @@ logger = logging.getLogger(__name__)
 def test_sct_concat_transfo_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_concat_transfo.main(argv=['-w', 't2/warp_template2anat.nii.gz', 'mt/warp_t22mt1.nii.gz',
-                                  '-d', 'template/template/PAM50_small_t2.nii.gz'])
+    sct_concat_transfo.main(argv=['-w',
+                                  sct_test_path('t2', 'warp_template2anat.nii.gz'),
+                                  sct_test_path('mt', 'warp_t22mt1.nii.gz'),
+                                  '-d', sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz')])

--- a/testing/cli/test_cli_sct_concat_transfo.py
+++ b/testing/cli/test_cli_sct_concat_transfo.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_concat_transfo_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_convert.py
+++ b/testing/cli/test_cli_sct_convert.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_convert_output_file_exists():
     """Run the CLI script and verify output file exists."""
     path_out = 't2.nii'

--- a/testing/cli/test_cli_sct_convert.py
+++ b/testing/cli/test_cli_sct_convert.py
@@ -6,6 +6,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_convert
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -14,5 +15,5 @@ logger = logging.getLogger(__name__)
 def test_sct_convert_output_file_exists():
     """Run the CLI script and verify output file exists."""
     path_out = 't2.nii'
-    sct_convert.main(argv=['-i', 't2/t2.nii.gz', '-o', path_out])
+    sct_convert.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-o', path_out])
     assert os.path.exists(path_out)

--- a/testing/cli/test_cli_sct_create_mask.py
+++ b/testing/cli/test_cli_sct_create_mask.py
@@ -4,17 +4,18 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_create_mask
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("path_input,process,size", [
-    ('mt/mt1.nii.gz', 'coord,15x17', '10'),
-    ('mt/mt1.nii.gz', 'point,mt/mt1_point.nii.gz', '10'),
-    ('mt/mt1.nii.gz', 'center', '10'),
-    ('mt/mt1.nii.gz', 'centerline,mt/mt1_seg.nii.gz', '5'),
-    ('dmri/dmri.nii.gz', 'center', '10')
+    (sct_test_path('mt', 'mt1.nii.gz'), 'coord,15x17', '10'),
+    (sct_test_path('mt', 'mt1.nii.gz'), 'point,'+sct_test_path('mt', 'mt1_point.nii.gz'), '10'),
+    (sct_test_path('mt', 'mt1.nii.gz'), 'center', '10'),
+    (sct_test_path('mt', 'mt1.nii.gz'), 'centerline,'+sct_test_path('mt', 'mt1_seg.nii.gz'), '5'),
+    (sct_test_path('dmri', 'dmri.nii.gz'), 'center', '10')
 ])
 def test_sct_create_mask_no_checks(path_input, process, size):
     """Run the CLI script without checking results.

--- a/testing/cli/test_cli_sct_create_mask.py
+++ b/testing/cli/test_cli_sct_create_mask.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("path_input,process,size", [
     ('mt/mt1.nii.gz', 'coord,15x17', '10'),
     ('mt/mt1.nii.gz', 'point,mt/mt1_point.nii.gz', '10'),

--- a/testing/cli/test_cli_sct_crop_image.py
+++ b/testing/cli/test_cli_sct_crop_image.py
@@ -5,38 +5,39 @@ import logging
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_crop_image
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("path_in,path_out,remaining_args,expected_dim", [
-    ('t2/t2.nii.gz', 't2_crop_xyz.nii', [
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_xyz.nii', [
         '-xmin', '1',
         '-xmax', '-3',
         '-ymin', '2',
         '-ymax', '10',
     ], (57, 9, 52)),
-    ('t2/t2.nii.gz', 't2_crop_mask.nii', [
-        '-m', 't2/t2_seg-manual.nii.gz',
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_mask.nii', [
+        '-m', sct_test_path('t2', 't2_seg-manual.nii.gz'),
     ], (11, 55, 13)),
-    ('t2/t2.nii.gz', 't2_crop_ref.nii', [
-        '-ref', 'mt/mt0.nii.gz',
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_ref.nii', [
+        '-ref', sct_test_path('mt', 'mt0.nii.gz'),
     ], (37, 55, 34)),
-    ('t2/t2.nii.gz', 't2_crop_dilate_xyz.nii', [
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_dilate_xyz.nii', [
         '-dilate', '0x1x2',
         '-xmin', '1',
         '-xmax', '-3',
         '-ymin', '2',
         '-ymax', '10',
     ], (57, 11, 52)),
-    ('t2/t2.nii.gz', 't2_crop_dilate_mask.nii', [
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_dilate_mask.nii', [
         '-dilate', '3',
-        '-m', 't2/t2_seg-manual.nii.gz',
+        '-m', sct_test_path('t2', 't2_seg-manual.nii.gz'),
     ], (17, 55, 19)),
-    ('t2/t2.nii.gz', 't2_crop_dilate_ref.nii', [
+    (sct_test_path('t2', 't2.nii.gz'), 't2_crop_dilate_ref.nii', [
         '-dilate', '100',
-        '-ref', 'mt/mt0.nii.gz',
+        '-ref', sct_test_path('mt', 'mt0.nii.gz'),
     ], (60, 55, 52)),
 ])
 def test_sct_crop_image_output_has_expected_dimensions(path_in, path_out, remaining_args, expected_dim):
@@ -55,7 +56,7 @@ def test_sct_crop_image_permissive_qform(tmp_path):
     b, c, d quaternions is slightly larger than 1.)
     """
     # Prepare the image
-    im = Image('t2/t2.nii.gz')
+    im = Image(sct_test_path('t2', 't2.nii.gz'))
     im.header['quatern_b'] = 1.0
     im.header['quatern_c'] = 0.0
     im.header['quatern_d'] = 0.9e-3

--- a/testing/cli/test_cli_sct_crop_image.py
+++ b/testing/cli/test_cli_sct_crop_image.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("path_in,path_out,remaining_args,expected_dim", [
     ('t2/t2.nii.gz', 't2_crop_xyz.nii', [
         '-xmin', '1',
@@ -49,7 +48,6 @@ def test_sct_crop_image_output_has_expected_dimensions(path_in, path_out, remain
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_crop_image_permissive_qform(tmp_path):
     """
     Check that we can load an image with a slightly bad qform.

--- a/testing/cli/test_cli_sct_deepseg_gm.py
+++ b/testing/cli/test_cli_sct_deepseg_gm.py
@@ -5,6 +5,7 @@ import logging
 
 from spinalcordtoolbox.image import Image, compute_dice
 from spinalcordtoolbox.scripts import sct_deepseg_gm
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,8 @@ logger = logging.getLogger(__name__)
 def test_sct_deepseg_gm_check_dice_coefficient_against_groundtruth():
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
     fname_out = 'output.nii.gz'
-    fname_gt = 't2s/t2s_uncropped_gmseg_manual.nii.gz'
-    sct_deepseg_gm.main(argv=['-i', 't2s/t2s_uncropped.nii.gz', '-o', fname_out, '-qc', 'testing-qc'])
+    fname_gt = sct_test_path('t2s', 't2s_uncropped_gmseg_manual.nii.gz')
+    sct_deepseg_gm.main(argv=['-i', sct_test_path('t2s', 't2s_uncropped.nii.gz'),
+                              '-o', fname_out, '-qc', 'testing-qc'])
     dice_segmentation = compute_dice(Image(fname_out), Image(fname_gt), mode='3d', zboundaries=False)
     assert dice_segmentation >= 0.85

--- a/testing/cli/test_cli_sct_deepseg_gm.py
+++ b/testing/cli/test_cli_sct_deepseg_gm.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_deepseg_gm_check_dice_coefficient_against_groundtruth():
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
     fname_out = 'output.nii.gz'

--- a/testing/cli/test_cli_sct_deepseg_lesion.py
+++ b/testing/cli/test_cli_sct_deepseg_lesion.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_deepseg_lesion
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,4 @@ logger = logging.getLogger(__name__)
 def test_sct_deepseg_lesion_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_deepseg_lesion.main(argv=['-i', 't2/t2.nii.gz', '-c', 't2'])
+    sct_deepseg_lesion.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2'])

--- a/testing/cli/test_cli_sct_deepseg_lesion.py
+++ b/testing/cli/test_cli_sct_deepseg_lesion.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_deepseg_lesion_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -27,7 +27,6 @@ def test_sct_deepseg_sc_check_output_qform_sform(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_deepseg_sc_qc_report_exists():
     dir_qc = 'testing-qc'
     sct_deepseg_sc.main(argv=['-i', 't2/t2.nii.gz', '-c', 't2', '-qc', dir_qc])

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -29,5 +29,5 @@ def test_sct_deepseg_sc_check_output_qform_sform(tmp_path):
 @pytest.mark.sct_testing
 def test_sct_deepseg_sc_qc_report_exists():
     dir_qc = 'testing-qc'
-    sct_deepseg_sc.main(argv=['-i', 't2/t2.nii.gz', '-c', 't2', '-qc', dir_qc])
+    sct_deepseg_sc.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', dir_qc])
     assert os.path.isfile(os.path.join(dir_qc, 'index.html'))

--- a/testing/cli/test_cli_sct_denoising_onlm.py
+++ b/testing/cli/test_cli_sct_denoising_onlm.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_denoising_onlm
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,4 @@ logger = logging.getLogger(__name__)
 def test_sct_denoising_onlm_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_denoising_onlm.main(argv=['-i', 't2/t2.nii.gz', '-v', '2'])
+    sct_denoising_onlm.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-v', '2'])

--- a/testing/cli/test_cli_sct_denoising_onlm.py
+++ b/testing/cli/test_cli_sct_denoising_onlm.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_denoising_onlm_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_detect_pmj.py
+++ b/testing/cli/test_cli_sct_detect_pmj.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_detect_pmj_check_euclidean_distance_against_groundtruth():
     """Run the CLI script and verify that euclidean distances between predicted and ground truth coordinates
     are within a certain threshold."""

--- a/testing/cli/test_cli_sct_detect_pmj.py
+++ b/testing/cli/test_cli_sct_detect_pmj.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_detect_pmj
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +16,9 @@ logger = logging.getLogger(__name__)
 def test_sct_detect_pmj_check_euclidean_distance_against_groundtruth():
     """Run the CLI script and verify that euclidean distances between predicted and ground truth coordinates
     are within a certain threshold."""
-    fname_in = 'template/template/PAM50_small_t2.nii.gz'
+    fname_in = sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz')
     fname_out = 'PAM50_small_t2_pmj.nii.gz'
-    fname_gt = 'template/template/PAM50_small_t2_pmj_manual.nii.gz'
+    fname_gt = sct_test_path('template', 'template', 'PAM50_small_t2_pmj_manual.nii.gz')
     sct_detect_pmj.main(argv=['-i', fname_in, '-o', fname_out, '-c', 't2', '-qc', 'testing-qc'])
 
     im_pmj = Image(fname_out)

--- a/testing/cli/test_cli_sct_dice_coefficient.py
+++ b/testing/cli/test_cli_sct_dice_coefficient.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dice_coefficient_check_output_against_groundtruth():
     """Run the CLI script and verify its output matches a known ground truth value."""
     # FIXME: The results of "sct_dice_coefficient" are not actually verified. Instead, the "compute_dice" function

--- a/testing/cli/test_cli_sct_dice_coefficient.py
+++ b/testing/cli/test_cli_sct_dice_coefficient.py
@@ -5,6 +5,7 @@ import logging
 
 from spinalcordtoolbox.image import Image, compute_dice
 from spinalcordtoolbox.scripts import sct_dice_coefficient
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ def test_sct_dice_coefficient_check_output_against_groundtruth():
     # FIXME: The results of "sct_dice_coefficient" are not actually verified. Instead, the "compute_dice" function
     #        is called, and THOSE results are verified instead.
     # This was copied as-is from the existing 'sct_testing' test, but should be fixed at a later date.
-    path_data = 't2/t2_seg-manual.nii.gz'
+    path_data = sct_test_path('t2', 't2_seg-manual.nii.gz')
     sct_dice_coefficient.main(argv=['-i', path_data, '-d', path_data])
     im_seg_manual = Image(path_data)
     dice_segmentation = compute_dice(im_seg_manual, im_seg_manual, mode='3d', zboundaries=False)

--- a/testing/cli/test_cli_sct_dmri_compute_bvalue.py
+++ b/testing/cli/test_cli_sct_dmri_compute_bvalue.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_compute_bvalue_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_dmri_compute_dti.py
+++ b/testing/cli/test_cli_sct_dmri_compute_dti.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_dmri_compute_dti
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,6 @@ logger = logging.getLogger(__name__)
 def test_sct_dmri_compute_dti_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_dmri_compute_dti.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-bval', 'dmri/bvals.txt'])
+    sct_dmri_compute_dti.main(argv=['-i', sct_test_path('dmri', 'dmri.nii.gz'),
+                                    '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                                    '-bval', sct_test_path('dmri', 'bvals.txt')])

--- a/testing/cli/test_cli_sct_dmri_compute_dti.py
+++ b/testing/cli/test_cli_sct_dmri_compute_dti.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_compute_dti_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_dmri_concat_b0_and_dwi.py
+++ b/testing/cli/test_cli_sct_dmri_concat_b0_and_dwi.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_concat_b0_and_dwi_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_dmri_concat_b0_and_dwi.py
+++ b/testing/cli/test_cli_sct_dmri_concat_b0_and_dwi.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_dmri_concat_b0_and_dwi
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,10 @@ logger = logging.getLogger(__name__)
 def test_sct_dmri_concat_b0_and_dwi_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_dmri_concat_b0_and_dwi.main(argv=['-i', 'dmri/dmri_T0000.nii.gz', 'dmri/dmri.nii.gz',
-                                          '-bvec', 'dmri/bvecs.txt', '-bval', 'dmri/bvals.txt',
+    sct_dmri_concat_b0_and_dwi.main(argv=['-i',
+                                          sct_test_path('dmri', 'dmri_T0000.nii.gz'),
+                                          sct_test_path('dmri', 'dmri.nii.gz'),
+                                          '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                                          '-bval', sct_test_path('dmri', 'bvals.txt'),
                                           '-order', 'b0', 'dwi', '-o', 'b0_dwi_concat.nii',
                                           '-obval', 'bvals_concat.txt', '-obvec', 'bvecs_concat.txt'])

--- a/testing/cli/test_cli_sct_dmri_concat_bvals.py
+++ b/testing/cli/test_cli_sct_dmri_concat_bvals.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_concat_bvals_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_dmri_concat_bvals.py
+++ b/testing/cli/test_cli_sct_dmri_concat_bvals.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_dmri_concat_bvals
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,7 @@ logger = logging.getLogger(__name__)
 def test_sct_dmri_concat_bvals_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_dmri_concat_bvals.main(argv=['-i', 'dmri/bvals.txt', 'dmri/bvals.txt', '-o', 'bvals_concat.txt'])
+    sct_dmri_concat_bvals.main(argv=['-i',
+                                     sct_test_path('dmri', 'bvals.txt'),
+                                     sct_test_path('dmri', 'bvals.txt'),
+                                     '-o', 'bvals_concat.txt'])

--- a/testing/cli/test_cli_sct_dmri_concat_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_concat_bvecs.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_concat_bvecs_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_dmri_concat_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_concat_bvecs.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_dmri_concat_bvecs
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,7 @@ logger = logging.getLogger(__name__)
 def test_sct_dmri_concat_bvecs_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_dmri_concat_bvecs.main(argv=['-i', 'dmri/bvecs.txt', 'dmri/bvecs.txt', '-o', 'bvecs_concat.txt'])
+    sct_dmri_concat_bvecs.main(argv=['-i',
+                                     sct_test_path('dmri', 'bvecs.txt'),
+                                     sct_test_path('dmri', 'bvecs.txt'),
+                                     '-o', 'bvecs_concat.txt'])

--- a/testing/cli/test_cli_sct_dmri_moco.py
+++ b/testing/cli/test_cli_sct_dmri_moco.py
@@ -6,6 +6,7 @@ import logging
 from numpy import allclose, genfromtxt
 
 from spinalcordtoolbox.scripts import sct_dmri_moco, sct_image, sct_crop_image, sct_create_mask
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,9 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sct_testing
 def test_sct_dmri_moco_check_params(tmp_path):
     """Run the CLI script and validate output moco params."""
-    sct_dmri_moco.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-g', '3', '-x', 'nn', '-r', '0',
+    sct_dmri_moco.main(argv=['-i', sct_test_path('dmri', 'dmri.nii.gz'),
+                             '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                             '-g', '3', '-x', 'nn', '-r', '0',
                              '-ofolder', str(tmp_path)])
 
     lresults = genfromtxt(tmp_path / "moco_params.tsv", skip_header=1, delimiter='\t')
@@ -33,7 +36,8 @@ def test_sct_dmri_moco_check_params(tmp_path):
 def dmri_mask(tmp_path):
     """Mask image for testing."""
     path_out = str(tmp_path / 'mask.nii')
-    sct_create_mask.main(argv=['-i', 'dmri/dmri_T0000.nii.gz', '-p', 'center', '-size', '5mm', '-f', 'gaussian',
+    sct_create_mask.main(argv=['-i', sct_test_path('dmri', 'dmri_T0000.nii.gz'),
+                               '-p', 'center', '-size', '5mm', '-f', 'gaussian',
                                '-o', path_out])
 
     return path_out
@@ -42,7 +46,9 @@ def dmri_mask(tmp_path):
 @pytest.mark.sct_testing
 def test_sct_dmri_moco_with_mask_check_params(tmp_path, dmri_mask):
     """Run the CLI script with '-m' option and validate output moco params."""
-    sct_dmri_moco.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-g', '3', '-r', '0',
+    sct_dmri_moco.main(argv=['-i', sct_test_path('dmri', 'dmri.nii.gz'),
+                             '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                             '-g', '3', '-r', '0',
                              '-m', dmri_mask, '-ofolder', str(tmp_path)])
 
     lresults = genfromtxt(tmp_path / "moco_params.tsv", skip_header=1, delimiter='\t')
@@ -61,9 +67,11 @@ def test_sct_dmri_moco_with_mask_check_params(tmp_path, dmri_mask):
 @pytest.fixture
 def dmri_ail_cropped(tmp_path):
     """Reorient image to sagittal for testing another orientation (and crop to save time)."""
+    path_out_orient = str(tmp_path / 'dmri_AIL.nii')
     path_out = str(tmp_path / 'dmri_AIL_crop.nii')
-    sct_image.main(argv=['-i', 'dmri/dmri.nii.gz', '-setorient', 'AIL', '-o', 'dmri/dmri_AIL.nii'])
-    sct_crop_image.main(argv=['-i', 'dmri/dmri_AIL.nii', '-zmin', '19', '-zmax', '21', '-o', path_out])
+    sct_image.main(argv=['-i', sct_test_path('dmri', 'dmri.nii.gz'),
+                         '-setorient', 'AIL', '-o', path_out_orient])
+    sct_crop_image.main(argv=['-i', path_out_orient, '-zmin', '19', '-zmax', '21', '-o', path_out])
 
     return path_out
 
@@ -71,6 +79,7 @@ def dmri_ail_cropped(tmp_path):
 @pytest.mark.sct_testing
 def test_sct_dmri_moco_sagittal_no_checks(tmp_path, dmri_ail_cropped):
     """Run the CLI script, but don't check anything."""
-    sct_dmri_moco.main(argv=['-i', dmri_ail_cropped, '-bvec', 'dmri/bvecs.txt', '-x', 'nn', '-r', '0',
+    sct_dmri_moco.main(argv=['-i', dmri_ail_cropped, '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                             '-x', 'nn', '-r', '0',
                              '-ofolder', str(tmp_path)])
     # NB: We skip checking params because there are no output moco params for sagittal images (*_AIL)

--- a/testing/cli/test_cli_sct_dmri_moco.py
+++ b/testing/cli/test_cli_sct_dmri_moco.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_moco_check_params(tmp_path):
     """Run the CLI script and validate output moco params."""
     sct_dmri_moco.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-g', '3', '-x', 'nn', '-r', '0',
@@ -41,7 +40,6 @@ def dmri_mask(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_moco_with_mask_check_params(tmp_path, dmri_mask):
     """Run the CLI script with '-m' option and validate output moco params."""
     sct_dmri_moco.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-g', '3', '-r', '0',
@@ -71,7 +69,6 @@ def dmri_ail_cropped(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_moco_sagittal_no_checks(tmp_path, dmri_ail_cropped):
     """Run the CLI script, but don't check anything."""
     sct_dmri_moco.main(argv=['-i', dmri_ail_cropped, '-bvec', 'dmri/bvecs.txt', '-x', 'nn', '-r', '0',

--- a/testing/cli/test_cli_sct_dmri_separate_b0_and_dwi.py
+++ b/testing/cli/test_cli_sct_dmri_separate_b0_and_dwi.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_dmri_separate_b0_and_dwi
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -14,16 +15,18 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sct_testing
 def test_sct_dmri_separate_b0_and_dwi_image_data_within_threshold():
     """Run the CLI script and verify that the data of the output images is close to references (within threshold)."""
-    sct_dmri_separate_b0_and_dwi.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-a', '1', '-r', '0'])
+    sct_dmri_separate_b0_and_dwi.main(argv=['-i', sct_test_path('dmri', 'dmri.nii.gz'),
+                                            '-bvec', sct_test_path('dmri', 'bvecs.txt'),
+                                            '-a', '1', '-r', '0'])
 
     # check DWI
-    ref_dwi = Image('dmri/dwi.nii.gz')
+    ref_dwi = Image(sct_test_path('dmri', 'dwi.nii.gz'))
     new_dwi = Image('dmri_dwi.nii.gz')
     norm_img = np.linalg.norm(ref_dwi.data - new_dwi.data)
     assert norm_img < 0.001
 
     # check b=0
-    ref_dwi = Image('dmri/dmri_T0000.nii.gz')
+    ref_dwi = Image(sct_test_path('dmri', 'dmri_T0000.nii.gz'))
     new_dwi = Image('dmri_b0.nii.gz')
     norm_img = np.linalg.norm(ref_dwi.data - new_dwi.data)
     assert norm_img < 0.001

--- a/testing/cli/test_cli_sct_dmri_separate_b0_and_dwi.py
+++ b/testing/cli/test_cli_sct_dmri_separate_b0_and_dwi.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_separate_b0_and_dwi_image_data_within_threshold():
     """Run the CLI script and verify that the data of the output images is close to references (within threshold)."""
     sct_dmri_separate_b0_and_dwi.main(argv=['-i', 'dmri/dmri.nii.gz', '-bvec', 'dmri/bvecs.txt', '-a', '1', '-r', '0'])

--- a/testing/cli/test_cli_sct_dmri_transpose_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_transpose_bvecs.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_dmri_transpose_bvecs
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,4 @@ logger = logging.getLogger(__name__)
 def test_sct_dmri_transpose_bvecs_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_dmri_transpose_bvecs.main(argv=['-bvec', 'dmri/bvecs.txt', '-o', 'bvecs.txt'])
+    sct_dmri_transpose_bvecs.main(argv=['-bvec', sct_test_path('dmri', 'bvecs.txt'), '-o', 'bvecs.txt'])

--- a/testing/cli/test_cli_sct_dmri_transpose_bvecs.py
+++ b/testing/cli/test_cli_sct_dmri_transpose_bvecs.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_dmri_transpose_bvecs_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_extract_metric.py
+++ b/testing/cli/test_cli_sct_extract_metric.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_extract_metric_against_groundtruth():
     """Verify that computed values are equivalent to known ground truth values."""
     fname_out = 'quantif_mtr.csv'

--- a/testing/cli/test_cli_sct_extract_metric.py
+++ b/testing/cli/test_cli_sct_extract_metric.py
@@ -6,6 +6,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_extract_metric
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -14,8 +15,9 @@ logger = logging.getLogger(__name__)
 def test_sct_extract_metric_against_groundtruth():
     """Verify that computed values are equivalent to known ground truth values."""
     fname_out = 'quantif_mtr.csv'
-    sct_extract_metric.main(argv=['-i', 'mt/mtr.nii.gz', '-f', 'mt/label/atlas', '-method', 'wa', '-l', '51',
-                                  '-z', '1:2', '-o', fname_out])
+    sct_extract_metric.main(argv=['-i', sct_test_path('mt', 'mtr.nii.gz'),
+                                  '-f', sct_test_path('mt', 'label/atlas'),
+                                  '-method', 'wa', '-l', '51', '-z', '1:2', '-o', fname_out])
     results = np.genfromtxt(fname_out, skip_header=1, delimiter=',')
     results = results[~np.isnan(results)]  # Remove non-numeric fields such as filename, SCT version, etc.
     assert results == pytest.approx([176.1532, 32.6404, 11.4573], abs=0.001)  # Size[vox], WA, and STD respectively

--- a/testing/cli/test_cli_sct_flatten_sagittal.py
+++ b/testing/cli/test_cli_sct_flatten_sagittal.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_flatten_sagittal_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_flatten_sagittal.py
+++ b/testing/cli/test_cli_sct_flatten_sagittal.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_flatten_sagittal
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,5 @@ logger = logging.getLogger(__name__)
 def test_sct_flatten_sagittal_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_flatten_sagittal.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz'])
+    sct_flatten_sagittal.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                    '-s', sct_test_path('t2', 't2_seg-manual.nii.gz')])

--- a/testing/cli/test_cli_sct_fmri_compute_tsnr.py
+++ b/testing/cli/test_cli_sct_fmri_compute_tsnr.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_fmri_compute_tsnr
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,5 @@ logger = logging.getLogger(__name__)
 def test_sct_sct_fmri_compute_tsnr_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_fmri_compute_tsnr.main(argv=['-i', 'fmri/fmri.nii.gz', '-o', 'out_fmri_tsnr.nii.gz'])
+    sct_fmri_compute_tsnr.main(argv=['-i', sct_test_path('fmri', 'fmri.nii.gz'),
+                                     '-o', 'out_fmri_tsnr.nii.gz'])

--- a/testing/cli/test_cli_sct_fmri_compute_tsnr.py
+++ b/testing/cli/test_cli_sct_fmri_compute_tsnr.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_sct_fmri_compute_tsnr_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_fmri_moco.py
+++ b/testing/cli/test_cli_sct_fmri_moco.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_fmri_moco
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,4 @@ logger = logging.getLogger(__name__)
 def test_sct_fmri_moco_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_fmri_moco.main(argv=['-i', 'fmri/fmri_r.nii.gz', '-g', '4', '-x', 'nn', '-r', '0'])
+    sct_fmri_moco.main(argv=['-i', sct_test_path('fmri', 'fmri_r.nii.gz'), '-g', '4', '-x', 'nn', '-r', '0'])

--- a/testing/cli/test_cli_sct_fmri_moco.py
+++ b/testing/cli/test_cli_sct_fmri_moco.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_fmri_moco_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_get_centerline_output_file_exists(tmp_path):
     """This test checks the output file using default usage of the CLI script.
 
@@ -28,7 +27,6 @@ def test_sct_get_centerline_output_file_exists(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize('ext', ["", ".nii.gz"])
 def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, ext):
     """This test checks the '-o' argument with and without an extension to
@@ -40,7 +38,6 @@ def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, ext):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
     """
     This test checks two necessary conditions of the soft centerline:

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -8,6 +8,7 @@ import pytest
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_get_centerline
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +22,8 @@ def test_sct_get_centerline_output_file_exists(tmp_path):
     'unit_testing/test_centerline.py'. For more details, see:
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774/commits/5e6bd57abf6bcf825cd110e0d74b8e465d298409
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774#discussion_r450546434"""
-    sct_get_centerline.main(argv=['-i', 't2s/t2s.nii.gz', '-c', 't2s', '-qc', str(tmp_path)])
-    for file in [os.path.join('t2s', 't2s_centerline.nii.gz'), os.path.join('t2s', 't2s_centerline.csv')]:
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-qc', str(tmp_path)])
+    for file in [sct_test_path('t2s', 't2s_centerline.nii.gz'), sct_test_path('t2s', 't2s_centerline.csv')]:
         assert os.path.exists(file)
 
 
@@ -31,9 +32,9 @@ def test_sct_get_centerline_output_file_exists(tmp_path):
 def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, ext):
     """This test checks the '-o' argument with and without an extension to
     ensure that the correct output file is created either way."""
-    sct_get_centerline.main(argv=['-i', 't2s/t2s.nii.gz', '-c', 't2s', '-qc', str(tmp_path),
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-qc', str(tmp_path),
                                   '-o', os.path.join(tmp_path, 't2s_centerline'+ext)])
-    for file in [os.path.join('t2s', 't2s_centerline.nii.gz'), os.path.join('t2s', 't2s_centerline.csv')]:
+    for file in [sct_test_path('t2s', 't2s_centerline.nii.gz'), sct_test_path('t2s', 't2s_centerline.csv')]:
         assert os.path.exists(file)
 
 
@@ -46,7 +47,8 @@ def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
     2) The output maximum of the soft centerline overlaps with the binary segmentation on all slices.
     """
     # Condition 1: All slices of the soft centerline sum to 1
-    sct_get_centerline.main(argv=['-i', 't2/t2_seg-manual.nii.gz', '-method', 'fitseg', '-centerline-soft', '1', '-o',
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-method', 'fitseg', '-centerline-soft', '1', '-o',
                                   os.path.join(tmp_path, 't2_seg_centerline_soft.nii.gz')])
     im_soft = Image(os.path.join(tmp_path, 't2_seg_centerline_soft.nii.gz'))
     # Sum soft centerline intensities in the (x,y) plane, across all slices
@@ -55,7 +57,8 @@ def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
     assert (sum_over_slices == 1).all()
 
     # Condition 2: The max voxels of the soft centerline overlap with the binary centerline
-    sct_get_centerline.main(argv=['-i', 't2/t2_seg-manual.nii.gz', '-method', 'fitseg', '-centerline-soft', '0', '-o',
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                  '-method', 'fitseg', '-centerline-soft', '0', '-o',
                                   os.path.join(tmp_path, 't2_seg_centerline_bin.nii.gz')])
     im_bin = Image(os.path.join(tmp_path, 't2_seg_centerline_bin.nii.gz'))
     # Find the maximum intensity voxel across all slices in soft centerline and binary centerline

--- a/testing/cli/test_cli_sct_image.py
+++ b/testing/cli/test_cli_sct_image.py
@@ -32,7 +32,6 @@ def dmri_t_slices(tmp_path, dmri_in):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_image_split_dmri(dmri_t_slices):
     """Verify the output of '-split' matches reference image. Note: CLI script is run by the 'dmri_t_slices' fixture."""
     _, filename, ext = extract_fname(dmri_t_slices[0])
@@ -42,7 +41,6 @@ def test_sct_image_split_dmri(dmri_t_slices):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_image_concat_dmri(tmp_path, dmri_t_slices, dmri_in):
     """Run the CLI script and verify concatenated image matches reference image."""
     path_out = str(tmp_path / 'dmri_concat.nii.gz')
@@ -53,7 +51,6 @@ def test_sct_image_concat_dmri(tmp_path, dmri_t_slices, dmri_in):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("path_in", ['t2/t2.nii.gz',       # 3D
                                      'dmri/dmri.nii.gz'])  # 4D
 def test_sct_image_getorient(path_in):
@@ -62,7 +59,6 @@ def test_sct_image_getorient(path_in):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_image_pad():
     """Run the CLI script and test the '-pad' option."""
     pad = 2
@@ -90,7 +86,6 @@ def test_sct_image_display_warp_check_output_exists():
     assert os.path.exists(sct_test_path('t2', fname_out))
 
 
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_image_stitch(tmp_path):
     """Run the CLI script and check that the stitched file was generated."""
     # crop images for testing stitching function

--- a/testing/cli/test_cli_sct_image.py
+++ b/testing/cli/test_cli_sct_image.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def dmri_in():
     """Filepath for input 4D dMRI image."""
-    return 'dmri/dmri.nii.gz'
+    return sct_test_path('dmri', 'dmri.nii.gz')
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def dmri_t_slices(tmp_path, dmri_in):
 def test_sct_image_split_dmri(dmri_t_slices):
     """Verify the output of '-split' matches reference image. Note: CLI script is run by the 'dmri_t_slices' fixture."""
     _, filename, ext = extract_fname(dmri_t_slices[0])
-    ref = Image(f'dmri/{filename}{ext}')  # Reference image should exist inside working directory (sct_testing_data)
+    ref = Image(sct_test_path('dmri', f'{filename}{ext}'))  # Reference image should exist inside working directory (sct_testing_data)
     new = Image(dmri_t_slices[0])         # New image should be generated inside tmp directory
     assert np.linalg.norm(ref.data - new.data) == 0
 
@@ -51,8 +51,8 @@ def test_sct_image_concat_dmri(tmp_path, dmri_t_slices, dmri_in):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.parametrize("path_in", ['t2/t2.nii.gz',       # 3D
-                                     'dmri/dmri.nii.gz'])  # 4D
+@pytest.mark.parametrize("path_in", [sct_test_path('t2', 't2.nii.gz'),       # 3D
+                                     sct_test_path('dmri', 'dmri.nii.gz')])  # 4D
 def test_sct_image_getorient(path_in):
     """Run the CLI script and ."""
     sct_image.main(argv=['-i', path_in, '-getorient'])
@@ -62,7 +62,7 @@ def test_sct_image_getorient(path_in):
 def test_sct_image_pad():
     """Run the CLI script and test the '-pad' option."""
     pad = 2
-    path_in = 'mt/mtr.nii.gz'  # 3D
+    path_in = sct_test_path('mt', 'mtr.nii.gz')  # 3D
     path_out = 'sct_image_out.nii.gz'
     sct_image.main(argv=['-i', path_in, '-o', 'sct_image_out.nii.gz', '-pad', f'0,0,{pad}'])
 
@@ -89,7 +89,7 @@ def test_sct_image_display_warp_check_output_exists():
 def test_sct_image_stitch(tmp_path):
     """Run the CLI script and check that the stitched file was generated."""
     # crop images for testing stitching function
-    path_in = os.path.join('t2', 't2.nii.gz')
+    path_in = sct_test_path('t2', 't2.nii.gz')
     fname_roi1 = os.path.join(tmp_path, 't2_roi1.nii.gz')
     fname_roi2 = os.path.join(tmp_path, 't2_roi2.nii.gz')
     sct_crop_image.main(argv=['-i', path_in, '-o', fname_roi1, '-xmin', '0', '-xmax', '59',

--- a/testing/cli/test_cli_sct_label_utils.py
+++ b/testing/cli/test_cli_sct_label_utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def test_sct_label_utils_cubic_to_point():
     """Run the CLI script and verify the resulting center of mass coordinate."""
     fname_out = 'test_centerofmass.nii.gz'
-    sct_label_utils.main(argv=['-i', 't2/t2_seg-manual.nii.gz', '-cubic-to-point', '-o', fname_out])
+    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-cubic-to-point', '-o', fname_out])
     # Note: Old, broken 'sct_testing' test used '31,28,25,1' as ground truth. Is this a regression?
     assert Image(fname_out).getNonZeroCoordinates() == [Coordinate([31, 27, 25, 1])]
 
@@ -26,7 +26,7 @@ def test_sct_label_utils_cubic_to_point():
 def test_sct_label_utils_create():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_label_utils.main(argv=['-i', 't2/t2_seg-manual.nii.gz', '-create', '1,1,1,1:2,2,2,2'])
+    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-create', '1,1,1,1:2,2,2,2'])
 
 
 def test_create_seg_mid(tmp_path):

--- a/testing/cli/test_cli_sct_label_utils.py
+++ b/testing/cli/test_cli_sct_label_utils.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_label_utils_cubic_to_point():
     """Run the CLI script and verify the resulting center of mass coordinate."""
     fname_out = 'test_centerofmass.nii.gz'
@@ -24,7 +23,6 @@ def test_sct_label_utils_cubic_to_point():
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_label_utils_create():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sct_testing
 def test_sct_label_vertebrae_consistent_disc(tmp_path):
     """Check that all expected output labeled discs exist"""
-    fname_ref = 't2/labels.nii.gz'
-    sct_label_vertebrae.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz', '-c', 't2',
-                                   '-discfile', fname_ref, '-ofolder', str(tmp_path)])
+    fname_ref = sct_test_path('t2', 'labels.nii.gz')
+    sct_label_vertebrae.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                   '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                   '-c', 't2', '-discfile', fname_ref, '-ofolder', str(tmp_path)])
     ref = Image(fname_ref)
     pred = Image(os.path.join(tmp_path, 't2_seg-manual_labeled_discs.nii.gz'))
     fp, fn = check_missing_label(pred, ref)
@@ -35,8 +36,11 @@ def test_sct_label_vertebrae_consistent_disc(tmp_path):
 def test_sct_label_vertebrae_initfile_qc_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_label_vertebrae.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz', '-c', 't2',
-                                   '-initfile', 't2/init_label_vertebrae.txt', '-t', 'template', '-qc', 'testing-qc'])
+    sct_label_vertebrae.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                   '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                   '-c', 't2',
+                                   '-initfile', sct_test_path('t2', 'init_label_vertebrae.txt'),
+                                   '-t', sct_test_path('template'), '-qc', 'testing-qc'])
 
 
 def test_sct_label_vertebrae_initz_error():

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_label_vertebrae_consistent_disc(tmp_path):
     """Check that all expected output labeled discs exist"""
     fname_ref = 't2/labels.nii.gz'
@@ -33,7 +32,6 @@ def test_sct_label_vertebrae_consistent_disc(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_label_vertebrae_initfile_qc_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_maths_percent_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
@@ -22,7 +21,6 @@ def test_sct_maths_percent_no_checks():
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_maths_add_integer_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -17,14 +17,14 @@ logger = logging.getLogger(__name__)
 def test_sct_maths_percent_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_maths.main(argv=['-i', 'mt/mtr.nii.gz', '-percent', '95', '-o', 'test.nii.gz'])
+    sct_maths.main(argv=['-i', sct_test_path('mt', 'mtr.nii.gz'), '-percent', '95', '-o', 'test.nii.gz'])
 
 
 @pytest.mark.sct_testing
 def test_sct_maths_add_integer_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_maths.main(argv=['-i', 'mt/mtr.nii.gz', '-add', '1', '-o', 'test.nii.gz'])
+    sct_maths.main(argv=['-i', sct_test_path('mt', 'mtr.nii.gz'), '-add', '1', '-o', 'test.nii.gz'])
 
 
 @pytest.mark.parametrize('dim', ['0', '1', '2'])

--- a/testing/cli/test_cli_sct_merge_images.py
+++ b/testing/cli/test_cli_sct_merge_images.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_merge_images_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_merge_images.py
+++ b/testing/cli/test_cli_sct_merge_images.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_merge_images
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,10 @@ logger = logging.getLogger(__name__)
 def test_sct_merge_images_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_merge_images.main(argv=['-i', 'template/template/PAM50_small_cord.nii.gz', 't2/t2_seg-manual.nii.gz',
-                                '-w', 'mt/warp_template2mt.nii.gz', 't2/warp_template2anat.nii.gz',
-                                '-d', 'mt/mt1.nii.gz'])
+    sct_merge_images.main(argv=['-i',
+                                sct_test_path('template', 'template', 'PAM50_small_cord.nii.gz'),
+                                sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                '-w',
+                                sct_test_path('mt', 'warp_template2mt.nii.gz'),
+                                sct_test_path('t2', 'warp_template2anat.nii.gz'),
+                                '-d', sct_test_path('mt', 'mt1.nii.gz')])

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -132,7 +132,6 @@ def test_sct_process_segmentation_check_normalize_PAM50_missing_vertfile(tmp_pat
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_process_segmentation_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -135,4 +135,4 @@ def test_sct_process_segmentation_check_normalize_PAM50_missing_vertfile(tmp_pat
 def test_sct_process_segmentation_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_process_segmentation.main(argv=['-i', 't2/t2_seg-manual.nii.gz'])
+    sct_process_segmentation.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz')])

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sct_testing
 def test_sct_propseg_check_dice_coefficient_against_groundtruth():
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
-    sct_propseg.main(argv=['-i', 't2/t2.nii.gz', '-c', 't2', '-qc', 'testing-qc'])
+    sct_propseg.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', 'testing-qc'])
 
     # open output segmentation
     im_seg = Image('t2_seg.nii.gz')
     # open ground truth
-    im_seg_manual = Image('t2/t2_seg-manual.nii.gz')
+    im_seg_manual = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
     # compute dice coefficient between generated image and image from database
     dice_segmentation = compute_dice(im_seg, im_seg_manual, mode='3d', zboundaries=False)
 

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_propseg_check_dice_coefficient_against_groundtruth():
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
     sct_propseg.main(argv=['-i', 't2/t2.nii.gz', '-c', 't2', '-qc', 'testing-qc'])

--- a/testing/cli/test_cli_sct_qc.py
+++ b/testing/cli/test_cli_sct_qc.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_qc_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_qc.py
+++ b/testing/cli/test_cli_sct_qc.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_qc
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,5 +13,7 @@ logger = logging.getLogger(__name__)
 def test_sct_qc_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_qc.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz', '-p', 'sct_deepseg_sc',
+    sct_qc.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                      '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                      '-p', 'sct_deepseg_sc',
                       '-qc-dataset', 'sct_testing_data', '-qc-subject', 'dummy'])

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -46,7 +46,6 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("use_seg,param,fname_gt", [
     (False, 'step=1,algo=syn,type=im,iter=1,smooth=1,shrink=2,metric=MI', 'mt/mt0_reg_syn_goldstandard.nii.gz'),
     (False, 'step=1,algo=slicereg,type=im,iter=5,smooth=0,metric=MeanSquares', 'mt/mt0_reg_slicereg_goldstandard.nii.gz'),

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -47,8 +47,10 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("use_seg,param,fname_gt", [
-    (False, 'step=1,algo=syn,type=im,iter=1,smooth=1,shrink=2,metric=MI', 'mt/mt0_reg_syn_goldstandard.nii.gz'),
-    (False, 'step=1,algo=slicereg,type=im,iter=5,smooth=0,metric=MeanSquares', 'mt/mt0_reg_slicereg_goldstandard.nii.gz'),
+    (False, 'step=1,algo=syn,type=im,iter=1,smooth=1,shrink=2,metric=MI',
+     sct_test_path('mt', 'mt0_reg_syn_goldstandard.nii.gz')),
+    (False, 'step=1,algo=slicereg,type=im,iter=5,smooth=0,metric=MeanSquares',
+     sct_test_path('mt', 'mt0_reg_slicereg_goldstandard.nii.gz')),
     (False, 'step=1,algo=dl,type=im', None),
     (True, 'step=1,algo=centermassrot,type=seg,rot_method=pca', None),
     (True, 'step=1,algo=centermassrot,type=imseg,rot_method=hog', None),
@@ -62,9 +64,11 @@ def test_sct_register_multimodal_mt0_image_data_within_threshold(use_seg, param,
     fname_owarp = str(tmp_path/'warp_mt02mt1.nii.gz')
     fname_owarpinv = str(tmp_path/'warp_mt12mt0.nii.gz')
 
-    argv = ['-i', 'mt/mt0.nii.gz', '-d', 'mt/mt1.nii.gz', '-x', 'linear', '-r', '0', '-param', param,
+    argv = ['-i', sct_test_path('mt', 'mt0.nii.gz'),
+            '-d', sct_test_path('mt', 'mt1.nii.gz'), '-x', 'linear', '-r', '0', '-param', param,
             '-o', fname_out_src, '-owarp', fname_owarp, '-owarpinv', fname_owarpinv]
-    seg_argv = ['-iseg', 'mt/mt0_seg.nii.gz', '-dseg', 'mt/mt1_seg.nii.gz']
+    seg_argv = ['-iseg', sct_test_path('mt', 'mt0_seg.nii.gz'),
+                '-dseg', sct_test_path('mt', 'mt1_seg.nii.gz')]
     sct_register_multimodal.main(argv=(argv + seg_argv) if use_seg else argv)
 
     for f in [fname_out_src, fname_out_dest, fname_owarp, fname_owarpinv]:

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -63,17 +63,18 @@ def test_sct_register_to_template_non_rpi_data(tmp_path, template_lpi):
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("fname_gt, remaining_args", [
-    ('template/template/PAM50_small_cord.nii.gz',
-     ['-l', 't2/labels.nii.gz', '-t', 'template', '-qc', 'qc-testing', '-param',
+    (sct_test_path('template', 'template', 'PAM50_small_cord.nii.gz'),
+     ['-l', sct_test_path('t2', 'labels.nii.gz'), '-t', sct_test_path('template'), '-qc', 'qc-testing', '-param',
       'step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares']),
     (os.path.join(__sct_dir__, 'data/PAM50/template/PAM50_cord.nii.gz'),
-     ['-ldisc', 't2/labels.nii.gz', '-ref', 'subject'])
+     ['-ldisc', sct_test_path('t2', 'labels.nii.gz'), '-ref', 'subject'])
 ])
 def test_sct_register_to_template_dice_coefficient_against_groundtruth(fname_gt, remaining_args, tmp_path):
     """Run the CLI script and verify transformed images have expected attributes."""
-    fname_seg = 't2/t2_seg-manual.nii.gz'
+    fname_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
     dice_threshold = 0.9
-    sct_register_to_template.main(argv=['-i', 't2/t2.nii.gz', '-s', fname_seg, '-ofolder', str(tmp_path)]
+    sct_register_to_template.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                        '-s', fname_seg, '-ofolder', str(tmp_path)]
                                   + remaining_args)
 
     # Straightening files are only generated for `-ref template`. They should *not* exist for `-ref subject`.

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -62,7 +62,6 @@ def test_sct_register_to_template_non_rpi_data(tmp_path, template_lpi):
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("fname_gt, remaining_args", [
     ('template/template/PAM50_small_cord.nii.gz',
      ['-l', 't2/labels.nii.gz', '-t', 'template', '-qc', 'qc-testing', '-param',

--- a/testing/cli/test_cli_sct_resample.py
+++ b/testing/cli/test_cli_sct_resample.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 @pytest.mark.parametrize("path_in,type_arg,dim,expected_dim", [
     ('fmri/fmri.nii.gz', '-mm', '1x1x3', (65, 65, 34, 30, 1.0, 1.0, 3.0, 1.13)),                     # 4D, mm
     ('dmri/dmri.nii.gz', '-f', '0.5x0.5x1', (20, 21, 5, 7, 1.682692, 1.682692, 17.5, 2.2)),          # 4D, factor

--- a/testing/cli/test_cli_sct_resample.py
+++ b/testing/cli/test_cli_sct_resample.py
@@ -5,16 +5,17 @@ import logging
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_resample
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("path_in,type_arg,dim,expected_dim", [
-    ('fmri/fmri.nii.gz', '-mm', '1x1x3', (65, 65, 34, 30, 1.0, 1.0, 3.0, 1.13)),                     # 4D, mm
-    ('dmri/dmri.nii.gz', '-f', '0.5x0.5x1', (20, 21, 5, 7, 1.682692, 1.682692, 17.5, 2.2)),          # 4D, factor
-    ('t2/t2.nii.gz', '-mm', '0.97x1.14x1.2', (62, 48, 43, 1, 0.97, 1.14, 1.2, 1)),                   # 3D, mm
-    ('t2/t2.nii.gz', '-vox', '120x110x26', (120, 110, 26, 1, 0.5, 0.5, 2.0, 1)),                     # 3D, vox
+    (sct_test_path('fmri', 'fmri.nii.gz'), '-mm', '1x1x3', (65, 65, 34, 30, 1.0, 1.0, 3.0, 1.13)),                     # 4D, mm
+    (sct_test_path('dmri', 'dmri.nii.gz'), '-f', '0.5x0.5x1', (20, 21, 5, 7, 1.682692, 1.682692, 17.5, 2.2)),          # 4D, factor
+    (sct_test_path('t2', 't2.nii.gz'), '-mm', '0.97x1.14x1.2', (62, 48, 43, 1, 0.97, 1.14, 1.2, 1)),                   # 3D, mm
+    (sct_test_path('t2', 't2.nii.gz'), '-vox', '120x110x26', (120, 110, 26, 1, 0.5, 0.5, 2.0, 1)),                     # 3D, vox
 ])
 def test_sct_resample_output_has_expected_dimensions(path_in, type_arg, dim, expected_dim, tmp_path):
     """Run the CLI script and verify output file exists."""

--- a/testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 from spinalcordtoolbox.scripts import sct_smooth_spinalcord
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +14,9 @@ logger = logging.getLogger(__name__)
 def test_sct_smooth_spinalcord_check_output_files(tmp_path):
     """Run the CLI script and ensure output files exist."""
     fname_out = os.path.join(str(tmp_path), "test_smooth.nii.gz")
-    sct_smooth_spinalcord.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz', '-smooth', '0,0,5',
-                                     '-o', fname_out])
+    sct_smooth_spinalcord.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                     '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                     '-smooth', '0,0,5', '-o', fname_out])
     assert os.path.isfile(fname_out)
 
     # Currently, 3 of SCT's CLI scripts output "straightening cache files" to the working directory. There's no way

--- a/testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_smooth_spinalcord_check_output_files(tmp_path):
     """Run the CLI script and ensure output files exist."""
     fname_out = os.path.join(str(tmp_path), "test_smooth.nii.gz")

--- a/testing/cli/test_cli_sct_straighten_spinalcord.py
+++ b/testing/cli/test_cli_sct_straighten_spinalcord.py
@@ -4,6 +4,7 @@ import pytest
 import logging
 
 from spinalcordtoolbox.scripts import sct_straighten_spinalcord
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +13,5 @@ logger = logging.getLogger(__name__)
 def test_sct_straighten_spinalcord_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_straighten_spinalcord.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz'])
+    sct_straighten_spinalcord.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                         '-s', sct_test_path('t2', 't2_seg-manual.nii.gz')])

--- a/testing/cli/test_cli_sct_straighten_spinalcord.py
+++ b/testing/cli/test_cli_sct_straighten_spinalcord.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_straighten_spinalcord_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""

--- a/testing/cli/test_cli_sct_warp_template.py
+++ b/testing/cli/test_cli_sct_warp_template.py
@@ -4,21 +4,24 @@ import logging
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_warp_template, sct_register_to_template
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
 def test_sct_warp_template_warp_small_PAM50():
     """Warp the cropped, resampled version of the template from `sct_testing_data/template`."""
-    sct_warp_template.main(argv=['-d', 'mt/mt1.nii.gz', '-w', 'mt/warp_template2mt.nii.gz',
+    sct_warp_template.main(argv=['-d', sct_test_path('mt', 'mt1.nii.gz'),
+                                 '-w', sct_test_path('mt', 'warp_template2mt.nii.gz'),
                                  '-a', '0',  # -a is '1' by default, but atlas isn't present in 'template'
-                                 '-t', 'template',
+                                 '-t', sct_test_path('template'),
                                  '-qc', 'testing-qc'])
 
 
 def test_sct_warp_template_warp_full_PAM50():
     """Warp the full PAM50 template (i.e. the one that is downloaded to `data/PAM50` during installation)."""
-    sct_warp_template.main(argv=['-d', 'mt/mt1.nii.gz', '-w', 'mt/warp_template2mt.nii.gz',
+    sct_warp_template.main(argv=['-d', sct_test_path('mt', 'mt1.nii.gz'),
+                                 '-w', sct_test_path('mt', 'warp_template2mt.nii.gz'),
                                  '-a', '1', '-histo', '1',
                                  '-qc', 'testing-qc'])
 
@@ -26,13 +29,15 @@ def test_sct_warp_template_warp_full_PAM50():
 def test_sct_warp_template_point_labels(tmp_path):
     """Warp the full PAM50 template, then test whether point labels are preserved."""
     # Register the cropped T2 image to the full PAM50 template
-    sct_register_to_template.main(argv=['-i', 't2/t2.nii.gz', '-s', 't2/t2_seg-manual.nii.gz',
-                                        '-ldisc', 't2/labels.nii.gz', '-ref', 'subject',
-                                        '-ofolder', str(tmp_path)])
+    sct_register_to_template.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
+                                        '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                        '-ldisc', sct_test_path('t2', 'labels.nii.gz'),
+                                        '-ref', 'subject', '-ofolder', str(tmp_path)])
 
     # Warp the PAM50 template to the cropped T2 image space
     path_out = tmp_path/"PAM50_warped"
-    sct_warp_template.main(argv=['-d', 't2/t2.nii.gz', '-w', str(tmp_path/'warp_template2anat.nii.gz'),
+    sct_warp_template.main(argv=['-d', sct_test_path('t2', 't2.nii.gz'),
+                                 '-w', str(tmp_path/'warp_template2anat.nii.gz'),
                                  '-a', '0',  # -a is '1' by default, but save time since not needed for point labels
                                  '-qc', 'testing-qc', '-ofolder', str(path_out)])
 

--- a/testing/cli/test_cli_sct_warp_template.py
+++ b/testing/cli/test_cli_sct_warp_template.py
@@ -1,6 +1,5 @@
 # pytest unit tests for sct_warp_template
 
-import pytest
 import logging
 
 from spinalcordtoolbox.image import Image
@@ -9,7 +8,6 @@ from spinalcordtoolbox.scripts import sct_warp_template, sct_register_to_templat
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_warp_template_warp_small_PAM50():
     """Warp the cropped, resampled version of the template from `sct_testing_data/template`."""
     sct_warp_template.main(argv=['-d', 'mt/mt1.nii.gz', '-w', 'mt/warp_template2mt.nii.gz',
@@ -18,7 +16,6 @@ def test_sct_warp_template_warp_small_PAM50():
                                  '-qc', 'testing-qc'])
 
 
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_warp_template_warp_full_PAM50():
     """Warp the full PAM50 template (i.e. the one that is downloaded to `data/PAM50` during installation)."""
     sct_warp_template.main(argv=['-d', 'mt/mt1.nii.gz', '-w', 'mt/warp_template2mt.nii.gz',
@@ -26,7 +23,6 @@ def test_sct_warp_template_warp_full_PAM50():
                                  '-qc', 'testing-qc'])
 
 
-@pytest.mark.usefixtures("run_in_sct_testing_data_dir")
 def test_sct_warp_template_point_labels(tmp_path):
     """Warp the full PAM50 template, then test whether point labels are preserved."""
     # Register the cropped T2 image to the full PAM50 template

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -33,12 +33,17 @@ def pytest_sessionstart():
         install_named_dataset('sct_testing_data', dest_folder=sct_test_path())
 
 
-@pytest.fixture
-def run_in_sct_testing_data_dir():
-    """Temporarily change the working directory to 'sct_testing_data'. This replicates the behavior of the old
-    `sct_testing`, and is needed to prevent tests from cluttering the working directory with output files."""
+@pytest.fixture(autouse=True)
+def run_in_tmp_path(tmp_path):
+    """
+    Temporarily change the working directory to a pytest temporary dir. This is needed to prevent tests from
+    cluttering the working directory *or* the sct_testing_data directory with output files.
+
+    Note: Because this uses the `tmp_path` fixture, which generates one temporary directory per test, this allows
+          tests to _also_ call `tmp_path` and access the same directory (e.g. for checking outputs).
+    """
     cwd = os.getcwd()
-    os.chdir(sct_test_path())
+    os.chdir(tmp_path)
     yield
     os.chdir(cwd)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

**Context:** SCT used to manage its own testing framework. This framework was ported to `pytest` in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3373. However, many of the old tests used relative paths to input data, which would fail unless the new pytest tests were run in `sct_testing_data` (or the tests were rewritten).

At the time, in order to keep the diffs for https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3373 a little more manageable, I opted to keep the relative paths but add a fixture to run the tests in `sct_testing_data`. This was never meant to be a long-term solution, as it meant that outputs to the PWD would clutter `sct_testing_data`.

This PR is that final follow-up to properly rewrite all relative paths, so that we can run the tests themselves in tempdirs, rather than `sct_testing_data`. (This has the added benefit of rendering the data integrity check actually useful now, since it shouldn't throw spurious errors anymore.)

## Reviewing this PR

This PR is very large, but most of the changes are uncomplicated. I was able to find+replace most relative paths by searching for e.g. `'t2/`, `'dmri/`, etc. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2911.
