### PR TITLE
Fix tiny sagittal mosaic QC Report for large images with many slices

### DIFF
--- a/spinalcordtoolbox/reports/assets/_assets/css/style.css
+++ b/spinalcordtoolbox/reports/assets/_assets/css/style.css
@@ -60,7 +60,6 @@
 
 .Sagittal, .Axial{
     max-width: 100%;
-    max-height: 400vh;
     overflow-y: hidden;
 }
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -646,6 +646,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     """
     logger.info('\n*** Generate Quality Control (QC) html report ***')
     dpi = 300  # Output resolution of the image
+    p_resample = 0.6  # Resolution in mm to resample the image to
 
     # The following are the expected types for some variables that get values
     # assigned in all branches of the big `if...elif...elif...` construct below
@@ -659,25 +660,26 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Axial orientation, switch between two input images
     if process in ['sct_register_multimodal', 'sct_register_to_template']:
         plane = 'Axial'
-        qcslice = Axial([Image(fname_in1), Image(fname_in2), Image(fname_seg)])
+        im_list = [Image(fname_in1), Image(fname_in2), Image(fname_seg)]
         action_list = [QcImage.no_seg_seg]
         def qcslice_layout(x): return x.mosaic()[:2]
     # Axial orientation, switch between the image and the segmentation
     elif process in ['sct_propseg', 'sct_deepseg_sc', 'sct_deepseg_gm']:
         plane = 'Axial'
-        qcslice = Axial([Image(fname_in1), Image(fname_seg)])
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.listed_seg]
         def qcslice_layout(x): return x.mosaic()
     # Axial orientation, switch between the image and the centerline
     elif process in ['sct_get_centerline']:
         plane = 'Axial'
-        qcslice = Axial([Image(fname_in1), Image(fname_seg)], p_resample=None)
+        p_resample = None
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.label_centerline]
         def qcslice_layout(x): return x.mosaic()
     # Axial orientation, switch between the image and the white matter segmentation (linear interp, in blue)
     elif process in ['sct_warp_template']:
         plane = 'Axial'
-        qcslice = Axial([Image(fname_in1), Image(fname_seg)])
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.template]
         def qcslice_layout(x): return x.mosaic()
     # Axial orientation, switch between gif image (before and after motion correction) and grid overlay
@@ -685,69 +687,74 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         plane = 'Axial'
         if fname_seg is None:
             raise ValueError("Segmentation is needed to ensure proper cropping around spinal cord.")
-        qcslice = Axial([Image(fname_in1), Image(fname_in2), Image(fname_seg)])
+        im_list = [Image(fname_in1), Image(fname_in2), Image(fname_seg)]
         action_list = [QcImage.grid]
         def qcslice_layout(x): return x.mosaics_through_time()
     # Sagittal orientation, display vertebral labels
     elif process in ['sct_label_vertebrae']:
         plane = 'Sagittal'
+        p_resample = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
-        qcslice = Sagittal([Image(fname_in1), Image(fname_seg)], p_resample=None)
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.label_vertebrae]
         def qcslice_layout(x): return x.single()
     #  Sagittal orientation, display posterior labels
     elif process in ['sct_label_utils']:
         plane = 'Sagittal'
+        p_resample = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         # projected_image = projected(Image(fname_seg))
-        qcslice = Sagittal([Image(fname_in1), Image(fname_seg)], p_resample=None)
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.label_utils]
         def qcslice_layout(x): return x.single()
     # Sagittal orientation, display PMJ box
     elif process in ['sct_detect_pmj']:
         plane = 'Sagittal'
-        qcslice = Sagittal([Image(fname_in1), Image(fname_seg)], p_resample=None)
+        p_resample = None
+        im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.highlight_pmj]
         def qcslice_layout(x): return x.single()
     # Sagittal orientation, static image
     elif process in ['sct_straighten_spinalcord']:
         plane = 'Sagittal'
+        p_resample = None
         dpi = 100
-        qcslice = Sagittal([Image(fname_in1), Image(fname_in1)], p_resample=None)
+        im_list = [Image(fname_in1), Image(fname_in1)]
         action_list = [QcImage.vertical_line]
         def qcslice_layout(x): return x.single()
     # Metric outputs (only graphs)
     elif process in ['sct_process_segmentation']:
         plane = 'Sagittal'
+        p_resample = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         fname_list = [fname_in1]
         # fname_seg should be a list of 4 images: 3 for each operation in `action_list`, plus an extra
         # centerline image, which is needed to make `Sagittal.get_center_spit` work correctly
         fname_list.extend(fname_seg)
-        qcslice = Sagittal([Image(fname) for fname in fname_list], p_resample=None)
+        im_list = [Image(fname) for fname in fname_list]
         action_list = [QcImage.smooth_centerline, QcImage.highlight_pmj, QcImage.listed_seg]
         def qcslice_layout(x): return x.single()
     elif process in ['sct_image_stitch']:
         plane = 'Sagittal'
+        p_resample = None
         dpi = 150
-        qcslice = Sagittal([Image(fname_in1), Image(fname_in2)], p_resample=None)
+        im_list = [Image(fname_in1), Image(fname_in2)]
         action_list = [QcImage.no_seg_seg]
         def qcslice_layout(x): return x.single()
     elif process in ['sct_deepseg_lesion']:
-        if plane == 'Axial':
-            SliceSubtype = Axial
-        elif plane == 'Sagittal':
-            SliceSubtype = Sagittal
-        else:
-            raise ValueError(f"Invalid plane '{plane}'. Valid choices are 'Axial' and 'Sagittal'.")
         # Note, spinal cord segmentation (fname_seg) is used to crop the input image.
         # Then, the input image (fname_in1) is overlaid by the lesion (fname_in2).
-        qcslice = SliceSubtype([Image(fname_in1), Image(fname_in2), Image(fname_seg)])
+        im_list = [Image(fname_in1), Image(fname_in2), Image(fname_seg)]
         action_list = [QcImage.listed_seg]
         def qcslice_layout(x): return x.mosaic()[:2]
     else:
         raise ValueError("Unrecognized process: {}".format(process))
 
+    slice_subtypes = {'Axial': Axial, 'Sagittal': Sagittal}
+    if plane not in slice_subtypes.keys():
+        raise ValueError(f"Invalid plane '{plane}'. Valid choices are {slice_subtypes.keys()}.")
+    SliceSubtype = slice_subtypes[plane]
+    qcslice = SliceSubtype(im_list, p_resample=p_resample)
     qc_report = QcReport(fname_in1, process, args, plane, path_qc, dpi, dataset, subject)
 
     QcImage(

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -305,15 +305,12 @@ class QcImage:
         if self._stretch_contrast:
             img = self._func_stretch_contrast(img)
 
-        # Axial views into images == A mosaic of axial slices. For QC reports, axial mosaics will often have smaller
-        # height than width (e.g. WxH = 20x3 slice images). So, we want to reduce the fig height to match this.
-        if plane == 'Axial':
-            # `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
-            size_fig = [5, 5 * img.shape[0] / img.shape[1]]
-        # Sagittal views into images, on the other hand, use a single image instead of a mosaic of slices.
-        # This sagittal view will typically have H ~= W, so there is no need to adjust the dimensions of the figure.
-        elif plane == 'Sagittal':
-            size_fig = [5, 5]
+        # For QC reports, mosaics will often have smaller or larger height than width:
+        #  - Axial mosaic: e.g. WxH = 20x3 slice images.
+        #  - Sagittal mosaic: e.g. WxH = 3x20 slice images
+        #  So, we want to scale the fig height to match this.
+        #  NB: `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
+        size_fig = [5, 5 * img.shape[0] / img.shape[1]]
 
         fig = Figure()
         fig.set_size_inches(size_fig[0], size_fig[1], forward=True)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -626,7 +626,7 @@ def get_json_data_from_path(path_json):
 
 
 def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None, path_qc=None, dataset=None,
-                subject=None, process=None, fps=None, draw_text=True):
+                subject=None, process=None, fps=None, p_resample=None, draw_text=True):
     """
     Generate a QC entry allowing to quickly review results. This function is the entry point and is called by SCT
     scripts (e.g. sct_propseg).
@@ -641,12 +641,15 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     :param subject: str: Subject name
     :param process: str: Name of SCT function. e.g., sct_propseg
     :param fps: float: Number of frames per second for output gif images. Used only for sct_frmi_moco and sct_dmri_moco.
+    :param p_resample: float: Resolution (in mm) to resample the image to. If not provided, resampling will fall back
+                              to the default value of the specific QC report layout (typically no resampling, or 0.6mm).
+                              To turn off resampling, pass `p_resample==0`.
     :param exclude_text: bool: If provided, text won't be drawn on top of labels. Used only for sct_label_vertebrae.
     :return: None
     """
     logger.info('\n*** Generate Quality Control (QC) html report ***')
     dpi = 300  # Output resolution of the image
-    p_resample = 0.6  # Resolution in mm to resample the image to
+    p_resample_default = 0.6  # Resolution in mm to resample the image to
 
     # The following are the expected types for some variables that get values
     # assigned in all branches of the big `if...elif...elif...` construct below
@@ -672,7 +675,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Axial orientation, switch between the image and the centerline
     elif process in ['sct_get_centerline']:
         plane = 'Axial'
-        p_resample = None
+        p_resample_default = None
         im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.label_centerline]
         def qcslice_layout(x): return x.mosaic()
@@ -693,7 +696,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Sagittal orientation, display vertebral labels
     elif process in ['sct_label_vertebrae']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.label_vertebrae]
@@ -701,7 +704,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     #  Sagittal orientation, display posterior labels
     elif process in ['sct_label_utils']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         # projected_image = projected(Image(fname_seg))
         im_list = [Image(fname_in1), Image(fname_seg)]
@@ -710,14 +713,14 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Sagittal orientation, display PMJ box
     elif process in ['sct_detect_pmj']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         im_list = [Image(fname_in1), Image(fname_seg)]
         action_list = [QcImage.highlight_pmj]
         def qcslice_layout(x): return x.single()
     # Sagittal orientation, static image
     elif process in ['sct_straighten_spinalcord']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         dpi = 100
         im_list = [Image(fname_in1), Image(fname_in1)]
         action_list = [QcImage.vertical_line]
@@ -725,7 +728,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Metric outputs (only graphs)
     elif process in ['sct_process_segmentation']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         fname_list = [fname_in1]
         # fname_seg should be a list of 4 images: 3 for each operation in `action_list`, plus an extra
@@ -736,7 +739,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         def qcslice_layout(x): return x.single()
     elif process in ['sct_image_stitch']:
         plane = 'Sagittal'
-        p_resample = None
+        p_resample_default = None
         dpi = 150
         im_list = [Image(fname_in1), Image(fname_in2)]
         action_list = [QcImage.no_seg_seg]
@@ -754,6 +757,11 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     if plane not in slice_subtypes.keys():
         raise ValueError(f"Invalid plane '{plane}'. Valid choices are {slice_subtypes.keys()}.")
     SliceSubtype = slice_subtypes[plane]
+
+    if p_resample is None:  # If no resample value is specified, fall back to default
+        p_resample = p_resample_default
+    elif p_resample == 0:   # If user specified `-resample 0`, turn off resampling
+        p_resample = None
     qcslice = SliceSubtype(im_list, p_resample=p_resample)
     qc_report = QcReport(fname_in1, process, args, plane, path_qc, dpi, dataset, subject)
 

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -7,6 +7,7 @@ License: see the file LICENSE
 
 # TODO: Replace slice by spinalcordtoolbox.image.Slicer
 
+import os
 import abc
 import logging
 import math
@@ -46,7 +47,6 @@ class Slice(object):
         """
         :param images: list of 3D or 4D volumes to be separated into slices.
         """
-        logger.info('Resample images to {}x{} mm'.format(p_resample, p_resample))
         self._images = list()  # 3d volumes
         self._4d_images = list()  # 4d volumes
         self._image_seg = None  # for cropping
@@ -266,6 +266,7 @@ class Slice(object):
         :param image_ref: Destination Image() to resample image to.
         :return:
         """
+        logger.info(f'Resampling image "{os.path.basename(image.absolutepath)}" to {p_resample}x{p_resample} mm')
         dict_interp = {'im': 'spline', 'seg': 'linear'}
         # Create nibabel object
         nii = Nifti1Image(image.data, affine=image.hdr.get_best_affine(), header=image.hdr)

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -48,7 +48,9 @@ def get_parser():
                         choices=('axial', 'sagittal'),
                         required=False)
     parser.add_argument('-resample',
-                        help='Millimeter resolution to resample the image to. Set to 0 to turn off resampling.',
+                        help='Millimeter resolution to resample the image to. Set to 0 to turn off resampling. You can'
+                             'use this option to control the zoom of the QC report: higher values will result in '
+                             'smaller images, and lower values will result in larger images.',
                         type=float,
                         required=False)
     parser.add_argument('-text-labels',

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -48,7 +48,7 @@ def get_parser():
                         choices=('axial', 'sagittal'),
                         required=False)
     parser.add_argument('-resample',
-                        help='Millimeter resolution to resample the image to. Set to 0 to turn off resampling. You can'
+                        help='Millimeter resolution to resample the image to. Set to 0 to turn off resampling. You can '
                              'use this option to control the zoom of the QC report: higher values will result in '
                              'smaller images, and lower values will result in larger images.',
                         type=float,

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -47,6 +47,10 @@ def get_parser():
                         help='Plane of the output QC. Only relevant for -p sct_deepseg_lesion.',
                         choices=('axial', 'sagittal'),
                         required=False)
+    parser.add_argument('-resample',
+                        help='Millimeter resolution to resample the image to. Set to 0 to turn off resampling.',
+                        type=float,
+                        required=False)
     parser.add_argument('-text-labels',
                         help="If set to 0, text won't be drawn on top of labels. Only relevant for -p "
                              "sct_label_vertebrae.",
@@ -106,6 +110,7 @@ def main(argv: Sequence[str]):
                 subject=arguments.qc_subject,
                 process=arguments.p,
                 fps=arguments.fps,
+                p_resample=arguments.resample,
                 draw_text=bool(arguments.text_labels))
 
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Sagittal mosaics are a (relatively) new type of QC report, added in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4102. They are based off of mosaics of Axial slices. However, there is a key difference: Axial slice mosaics are fixed at 30x30vox per axial slice, whereas sagittal slice mosaics vary depending on the extents of the sagittal segmentation.

In #4458, @NathanMolinier discovered an edge case: If the resolution of the image is sufficiently large, and if the segmentation spans many sagittal slices, then the mosaic can grow way too big in size. At that point, it hits our height limitations for QC reports (both in matplotlib canvas size, and CSS max-height), and thus the whole mosaic image gets scaled down to fit:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/8492dac3-742a-4d0b-8f23-aa4f6ec8ffb8)

So, this PR adjusts the height limitations to allow sagittal mosaics to display in full size:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/fcb2a7f4-10b3-4b09-b7d5-2d54aab3f3b0)

However, this causes a new issue: Now the QC report is so large that it becomes unwieldy to actually view, thanks to the resampling step. (1.0mm -> 0.6mm causes the voxel size of the image to balloon.) So, to counteract that, this PR adds a `-resample` option to allow the user to vary the resampling value to change the zoom of the QC report.

- `-resample 0` (keeping original resolution of 1.0mm):

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/24af287d-b508-4199-8f2c-251d3c66d002)

- `-resample 2.0` (doubling mm resolution -> halving the voxel resolution)

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/2d2b86e5-0478-41a9-b70b-8b4a7bcd729e)

## Testing this PR

Currently, the `batch_processing.sh` test uploads the generated QC report as a workflow artifact. So, we should be able to quickly manually check that these changes don't modify any of the existing QC reports. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4458.
