### PR TITLE
Update url to slicer documentation

### DIFF
--- a/documentation/source/overview/concepts/spaces-and-coordinates.rst
+++ b/documentation/source/overview/concepts/spaces-and-coordinates.rst
@@ -85,7 +85,7 @@ References
   <https://nipy.org/nibabel/coordinate_systems.html#naming-reference-spaces>`_
 
 - ITK (`ANTs <https://sourceforge.net/p/advants/discussion/840261/thread/2a1e9307/#fb5a>`_,
-  `Slicer <https://www.slicer.org/wiki/Coordinate_systems>`_) reference coordinate system is different (LPS-).
+  `Slicer <https://slicer.readthedocs.io/en/latest/user_guide/coordinate_systems.html>`_) reference coordinate system is different (LPS-).
 
 - `Matlab FieldTrip toolbox "How are the different head and MRI coordinate systems defined?"
   <https://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined>`_


### PR DESCRIPTION
The old url has a big banner at the top of the page, claiming that this new url contains the latest version. A quick look confirms that the content is essentially the same.

I noticed this when checking the daily broken url results:
https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/9050554894/job/24866074154