### PR TITLE
Skip empty slicegroups to avoid creating blank rows in output metric CSV file

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -315,7 +315,7 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
         else:
             # slicegroups = [(0, 1, 2, 3, 4, 5, 6, 7, 8)]
             slicegroups = [tuple(slices)]
-    agg_metric = dict((slicegroup, dict()) for slicegroup in slicegroups if slicegroup)  # skip empty slicegroups '()'
+    agg_metric = {}
     # loop across slice group
     for slicegroup in slicegroups:
         # Skip empty slicegroups. This can occur if, for example, the user requests vertlevels that are not in the
@@ -323,6 +323,10 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
         # slicegroups = [(), (2,), (1,), ()].
         if not slicegroup:
             continue
+
+        # initialize slicegroup entry
+        if slicegroup not in agg_metric:
+            agg_metric[slicegroup] = {}
 
         # add distance from PMJ info
         if distance_pmj is not None:

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -315,9 +315,15 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
         else:
             # slicegroups = [(0, 1, 2, 3, 4, 5, 6, 7, 8)]
             slicegroups = [tuple(slices)]
-    agg_metric = dict((slicegroup, dict()) for slicegroup in slicegroups)
+    agg_metric = dict((slicegroup, dict()) for slicegroup in slicegroups if slicegroup)  # skip empty slicegroups '()'
     # loop across slice group
     for slicegroup in slicegroups:
+        # Skip empty slicegroups. This can occur if, for example, the user requests vertlevels that are not in the
+        # data. e.g. -vert 4:7 but data only has 5+6. In that case, vertgroups = [(4,), (5,), (6,), (7,)] but
+        # slicegroups = [(), (2,), (1,), ()].
+        if not slicegroup:
+            continue
+
         # add distance from PMJ info
         if distance_pmj is not None:
             agg_metric[slicegroup]['DistancePMJ'] = distance_pmj

--- a/testing/cli/test_cli_sct_extract_metric.py
+++ b/testing/cli/test_cli_sct_extract_metric.py
@@ -21,3 +21,17 @@ def test_sct_extract_metric_against_groundtruth():
     results = np.genfromtxt(fname_out, skip_header=1, delimiter=',')
     results = results[~np.isnan(results)]  # Remove non-numeric fields such as filename, SCT version, etc.
     assert results == pytest.approx([176.1532, 32.6404, 11.4573], abs=0.001)  # Size[vox], WA, and STD respectively
+
+
+def test_sct_extract_metric_vertlevel_outside_bounds():
+    """Make sure that specifying -vert values outside the bounds of the data does not produce an empty row."""
+    fname_out = 'quantif_mtr.csv'
+    sct_extract_metric.main(argv=['-i', sct_test_path('mt', 'mtr.nii.gz'),
+                                  '-f', sct_test_path('mt', 'label/atlas'),
+                                  '-vertfile', sct_test_path('mt', 'label', 'template', 'PAM50_levels.nii.gz'),
+                                  '-vert', '1:12', '-perlevel', '1',
+                                  '-method', 'wa', '-l', '51', '-o', fname_out])
+    results = np.genfromtxt(fname_out, delimiter=',', dtype=None, encoding="utf-8")  # dtype=None preserves str data
+    header_row, data_rows = results[0],  np.char.strip(results[1:], '"')
+    idx_vertlevel = np.where(header_row == "VertLevel")[0][0]
+    assert list(data_rows[:, idx_vertlevel].astype(int)) == [5, 4]  # VertLevel column should only have 2 values


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

For data where an image is [split into multiple chunks](https://github.com/sct-pipeline/spine-park/issues/10#issuecomment-2113482362), you may want to call the same `sct_extract_metric` command on multiple chunks spanning a range of vertlevels (e.g. `-vert 1:12`). But, not all chunks will contain all of the specified levels.

For this case, there is a bug where an `agg_metric` entry will be created for the slicegroup "`()`", i.e. a group containing no slices. This will result in an empty row containing no data.

This PR adds a test that reproduces the condition and fails. As soon as the empty slicegroup row is removed, the test will pass.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/sct-pipeline/spine-park/issues/35.
