### PR TITLE
Use Tensorflow's simple `LazyLoader` class to minimize import times of expensive packages

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -48,7 +48,8 @@ check_dependencies() {
 
 run_tests() {
   activate_venv_sct
-  pytest testing/api testing/cli
+  # re-run failed tests, just in case something flaky has happened. if no failures, do nothing.
+  pytest testing/api testing/cli || pytest --last-failed --last-failed-no-failures none
   # NB: 'testing/batch_processing' is run by a separate CI workflow
 }
 

--- a/contrib/tensorflow/lazy_loader.py
+++ b/contrib/tensorflow/lazy_loader.py
@@ -1,0 +1,86 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A LazyLoader class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import types
+import logging
+
+
+# Note: Prior to adopting Tensorflow's LazyLoader class, we tried instead to use the `lazy_import` magic function,
+# as detailed in https://docs.python.org/3/library/importlib.html#implementing-lazy-imports.
+#
+# However, this function was a little too "magical": There were quite a few behind-the-scenes side effects that made
+# the lazy behavior unpredictable:
+#   - Importing a parent module would throw an `AttributeNotFoundError` when trying to access submodules/classes/etc.
+#   - Importing a submodule instead (e.g. `lazy_import("sklearn.metrics")` would inadvertently trigger imports in the
+#     parent module during the call to `loader.exec_module(module)`.
+#   - There seemed to be complex side effects for our deep learning packages, especially those that depended on `torch`.
+#     Lazy loading `torch` seemed to cause obscure errors for other packages such as `monai`.
+#
+# Because we are trying to lazy load deep learning packages, it made sense to look to the Python DL ecosystem for
+# lazy loading implementations. And, luckily, Tensorflow has an incredibly straightforward implementation that removes
+# much of the magic that comes with the `ModuleSpec` and `LazyLoader` classes from importlib.
+#
+# This class is also in use as-is in many downstream DL packages, signifying its reliability. For example:
+#  - https://github.com/bentoml/BentoML/blob/df2c7b86decbdff053002bddf7beb228d012a895/src/bentoml/_internal/utils/lazy_loader.py
+
+
+class LazyLoader(types.ModuleType):
+    """Lazily import a module, mainly to avoid pulling in large dependencies.
+
+    `contrib`, and `ffmpeg` are examples of modules that are large and not always
+    needed, and this allows them to only be loaded when they are used.
+    """
+
+    # The lint error here is incorrect.
+    def __init__(self, local_name, parent_module_globals, name, warning=None):  # pylint: disable=super-on-old-class
+        self._local_name = local_name
+        self._parent_module_globals = parent_module_globals
+        self._warning = warning
+
+        super(LazyLoader, self).__init__(name)
+
+    def _load(self):
+        """Load the module and insert it into the parent's globals."""
+        # Import the target module and insert it into the parent's namespace
+        module = importlib.import_module(self.__name__)
+        self._parent_module_globals[self._local_name] = module
+
+        # Emit a warning if one was specified
+        if self._warning:
+            logging.warning(self._warning)
+            # Make sure to only warn once.
+            self._warning = None
+
+        # Update this object's dict so that if someone keeps a reference to the
+        #     LazyLoader, lookups are efficient (__getattr__ is only called on lookups
+        #     that fail).
+        self.__dict__.update(module.__dict__)
+
+        return module
+
+    def __getattr__(self, item):
+        module = self._load()
+        return getattr(module, item)
+
+    def __dir__(self):
+        module = self._load()
+        return dir(module)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -26,10 +26,9 @@ import transforms3d.affines as affines
 
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.utils.fs import extract_fname, mv, tmp_create
-from spinalcordtoolbox.utils.sys import run_proc, lazy_import
+from spinalcordtoolbox.utils.sys import run_proc, LazyLoader
 
-ndimage = lazy_import("scipy.ndimage")
-
+ndimage = LazyLoader("ndimage", globals(), "scipy.ndimage")
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -23,11 +23,12 @@ import pathlib
 from contrib import fslhd
 
 import transforms3d.affines as affines
-from scipy.ndimage import map_coordinates
 
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.utils.fs import extract_fname, mv, tmp_create
-from spinalcordtoolbox.utils.sys import run_proc
+from spinalcordtoolbox.utils.sys import run_proc, lazy_import
+
+ndimage = lazy_import("scipy.ndimage")
 
 
 logger = logging.getLogger(__name__)
@@ -679,7 +680,8 @@ class Image(object):
         :param interpolation_mode: 0=nearest neighbor, 1= linear, 2= 2nd-order spline, 3= 2nd-order spline, 4= 2nd-order spline, 5= 5th-order spline
         :return: intensity values at continuouspix with interpolation_mode
         """
-        return map_coordinates(self.data, coordi, output=np.float32, order=interpolation_mode, mode=border, cval=cval)
+        return ndimage.map_coordinates(self.data, coordi, output=np.float32, order=interpolation_mode,
+                                       mode=border, cval=cval)
 
     def get_transform(self, im_ref, mode='affine'):
         aff_im_self = self.affine

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -13,11 +13,11 @@ from skimage.filters import threshold_local, threshold_otsu, rank
 from scipy.ndimage import gaussian_filter, gaussian_laplace
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.sys import lazy_import
+from spinalcordtoolbox.utils.sys import LazyLoader
 
-dipy = lazy_import("dipy")
-metrics = lazy_import("sklearn.metrics")
-stats = lazy_import("scipy.stats")
+dipy = LazyLoader("dipy", globals(), "dipy")
+skl_metrics = LazyLoader("skl_metrics", globals(), "sklearn.metrics")
+scipy_stats = LazyLoader("scipy_stats", globals(), "scipy.stats")
 
 logger = logging.getLogger(__name__)
 
@@ -154,10 +154,10 @@ def mutual_information(x, y, nbins=32, normalized=False):
     :return: float non negative value : mutual information
     """
     if normalized:
-        mi = metrics.normalized_mutual_info_score(x, y)
+        mi = skl_metrics.normalized_mutual_info_score(x, y)
     else:
         c_xy = np.histogram2d(x, y, nbins)[0]
-        mi = metrics.mutual_info_score(None, None, contingency=c_xy)
+        mi = skl_metrics.mutual_info_score(None, None, contingency=c_xy)
     return mi
 
 
@@ -173,9 +173,9 @@ def correlation(x, y, type='pearson'):
     """
 
     if type == 'pearson':
-        corr = stats.pearsonr(x, y)[0]
+        corr = scipy_stats.pearsonr(x, y)[0]
     if type == 'spearman':
-        corr = stats.spearmanr(x, y)[0]
+        corr = scipy_stats.spearmanr(x, y)[0]
 
     return corr
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -11,14 +11,13 @@ import numpy as np
 from skimage.morphology import erosion, dilation, disk, ball, square, cube
 from skimage.filters import threshold_local, threshold_otsu, rank
 from scipy.ndimage import gaussian_filter, gaussian_laplace
-from scipy.stats import pearsonr, spearmanr
-from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.segment.mask import median_otsu
-from dipy.denoise.nlmeans import nlmeans
-from dipy.denoise.patch2self import patch2self
-from sklearn.metrics import normalized_mutual_info_score, mutual_info_score
 
 from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils.sys import lazy_import
+
+dipy = lazy_import("dipy")
+metrics = lazy_import("sklearn.metrics")
+stats = lazy_import("scipy.stats")
 
 logger = logging.getLogger(__name__)
 
@@ -155,10 +154,10 @@ def mutual_information(x, y, nbins=32, normalized=False):
     :return: float non negative value : mutual information
     """
     if normalized:
-        mi = normalized_mutual_info_score(x, y)
+        mi = metrics.normalized_mutual_info_score(x, y)
     else:
         c_xy = np.histogram2d(x, y, nbins)[0]
-        mi = mutual_info_score(None, None, contingency=c_xy)
+        mi = metrics.mutual_info_score(None, None, contingency=c_xy)
     return mi
 
 
@@ -174,9 +173,9 @@ def correlation(x, y, type='pearson'):
     """
 
     if type == 'pearson':
-        corr = pearsonr(x, y)[0]
+        corr = stats.pearsonr(x, y)[0]
     if type == 'spearman':
-        corr = spearmanr(x, y)[0]
+        corr = stats.spearmanr(x, y)[0]
 
     return corr
 
@@ -251,7 +250,7 @@ def adap(data, block_size, offset):
 
 
 def otsu_median(data, size, n_iter):
-    data, mask = median_otsu(data, size, n_iter)
+    data, mask = dipy.segment.mask.median_otsu(data, size, n_iter)
     return mask
 
 
@@ -314,8 +313,8 @@ def denoise_nlmeans(data_in, patch_radius=1, block_radius=5):
     block_radius_max = min(data_in.shape) - 1
     block_radius = block_radius_max if block_radius > block_radius_max else block_radius
 
-    sigma = estimate_sigma(data_in)
-    denoised = nlmeans(data_in, sigma, patch_radius=patch_radius, block_radius=block_radius)
+    sigma = dipy.denoise.noise_estimate.estimate_sigma(data_in)
+    denoised = dipy.denoise.nlmeans.nlmeans(data_in, sigma, patch_radius=patch_radius, block_radius=block_radius)
 
     return denoised
 
@@ -343,7 +342,6 @@ def denoise_patch2self(data_in, bvals_in, patch_radius=0, model='ols'):
         for more info about patch_radius and model, please refer to the dipy website:
         https://docs.dipy.org/stable/examples_built/preprocessing/denoise_patch2self.html
     """
-    denoised = patch2self(data_in, bvals_in, patch_radius=patch_radius,
-                          model=model)
+    denoised = dipy.denoise.patch2self.patch2self(data_in, bvals_in, patch_radius=patch_radius, model=model)
 
     return denoised

--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -22,7 +22,7 @@ from spinalcordtoolbox.registration.landmarks import register_landmarks
 from spinalcordtoolbox.registration import core
 from spinalcordtoolbox.scripts import sct_resample
 from spinalcordtoolbox.utils.fs import copy_helper, tmp_create
-from spinalcordtoolbox.utils.sys import run_proc, sct_dir_local_path, sct_progress_bar, lazy_import
+from spinalcordtoolbox.utils.sys import run_proc, sct_dir_local_path, sct_progress_bar, LazyLoader
 
 from spinalcordtoolbox.scripts import sct_image
 
@@ -30,11 +30,11 @@ from spinalcordtoolbox.scripts import sct_image
 os.environ['VXM_BACKEND'] = 'pytorch'
 os.environ['NEURITE_BACKEND'] = 'pytorch'
 
-vxm = lazy_import("voxelmorph")
-torch = lazy_import("torch")
-nil_image = lazy_import("nilearn.image")
-decomposition = lazy_import("sklearn.decomposition")
-scipy_signal = lazy_import("scipy.signal")
+vxm = LazyLoader("vxm", globals(), "voxelmorph")
+torch = LazyLoader("torch", globals(), "torch")
+nil_image = LazyLoader("nil_image", globals(), "nilearn.image")
+skl_decomposition = LazyLoader("skl_decomposition", globals(), "sklearn.decomposition")
+scipy_signal = LazyLoader("scipy_signal", globals(), "scipy.signal")
 
 
 # TODO [AJ]
@@ -1446,7 +1446,7 @@ def compute_pca(data2d):
     coordsrc /= coordsrc.std()
 
     # Performs PCA
-    pca = decomposition.PCA(n_components=2, copy=False, whiten=False)
+    pca = skl_decomposition.PCA(n_components=2, copy=False, whiten=False)
     pca.fit(coordsrc)
 
     return coordsrc, pca, centermass

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -19,20 +19,22 @@ import skimage
 import skimage.io
 import skimage.exposure
 from scipy.ndimage import center_of_mass
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-from matplotlib.figure import Figure
-from matplotlib.axes import Axes
-from matplotlib.animation import FuncAnimation, PillowWriter
-import matplotlib.colors as color
-from matplotlib import cm
-import matplotlib.patheffects as path_effects
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Slice, Axial, Sagittal
 from spinalcordtoolbox.reports.assets._assets.py import refresh_qc_entries
 from spinalcordtoolbox.utils.fs import copy, extract_fname, mutex
-from spinalcordtoolbox.utils.sys import __version__, list2cmdline
+from spinalcordtoolbox.utils.sys import __version__, list2cmdline, LazyLoader
 from spinalcordtoolbox.utils.shell import display_open
+
+mpl_figure = LazyLoader("mpl_figure", globals(), "matplotlib.figure")
+mpl_axes = LazyLoader("mpl_axes", globals(), "matplotlib.axes")
+mpl_cm = LazyLoader("mpl_cm", globals(), "matplotlib.cm")
+mpl_colors = LazyLoader("mpl_colors", globals(), "matplotlib.colors")
+mpl_backend_agg = LazyLoader("mpl_backend_agg", globals(), "matplotlib.backends.backend_agg")
+mpl_animation = LazyLoader("mpl_animation", globals(), "matplotlib.animation")
+mpl_patheffects = LazyLoader("mpl_patheffects", globals(), "matplotlib.patheffects")
+
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +101,8 @@ class QcImage:
             color_list = ['#000000'] * (labels.max() - labels.min() + 1)
             # Assign a colormap to each group of labels (while sampling the colormap at different points)
             for i, label_group in enumerate(label_groups):
-                colormap = cm.get_cmap(distinct_colormaps[i % len(distinct_colormaps)])
-                sampled_colors = [color.to_hex(c) for c in [colormap(n) for n in colormap_sampling]]
+                colormap = mpl_cm.get_cmap(distinct_colormaps[i % len(distinct_colormaps)])
+                sampled_colors = [mpl_colors.to_hex(c) for c in [colormap(n) for n in colormap_sampling]]
                 # Then, assign a color to each label within the group
                 for j, label in enumerate(label_group):
                     color_list[label - labels.min()] = sampled_colors[j % len(sampled_colors)]
@@ -138,8 +140,8 @@ class QcImage:
         """Create figure with red segmentation. Common scenario."""
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
-                  cmap=color.LinearSegmentedColormap.from_list("", self._seg_colormap),
-                  norm=color.Normalize(vmin=0.5, vmax=1),
+                  cmap=mpl_colors.LinearSegmentedColormap.from_list("", self._seg_colormap),
+                  norm=mpl_colors.Normalize(vmin=0.5, vmax=1),
                   interpolation=self.interpolation,
                   aspect=float(self.aspect_mask))
         ax.get_xaxis().set_visible(False)
@@ -149,11 +151,11 @@ class QcImage:
         """Show template statistical atlas"""
         values = mask
         values[values < 0.5] = 0
-        color_white = color.colorConverter.to_rgba('white', alpha=0.0)
-        color_blue = color.colorConverter.to_rgba('blue', alpha=0.7)
-        color_cyan = color.colorConverter.to_rgba('cyan', alpha=0.8)
-        cmap = color.LinearSegmentedColormap.from_list('cmap_atlas',
-                                                       [color_white, color_blue, color_cyan], N=256)
+        color_white = mpl_colors.colorConverter.to_rgba('white', alpha=0.0)
+        color_blue = mpl_colors.colorConverter.to_rgba('blue', alpha=0.7)
+        color_cyan = mpl_colors.colorConverter.to_rgba('cyan', alpha=0.8)
+        cmap = mpl_colors.LinearSegmentedColormap.from_list('cmap_atlas',
+                                                            [color_white, color_blue, color_cyan], N=256)
         ax.imshow(values,
                   cmap=cmap,
                   interpolation=self.interpolation,
@@ -181,7 +183,8 @@ class QcImage:
             ax.plot(coord[1], coord[0], 'o', color='lime', markersize=5)
             label_text = ax.text(coord[1] + horiz_offset, coord[0], str(round(mask[coord[0], coord[1]])), color='lime',
                                  fontsize=15, verticalalignment='center', clip_on=True)
-            label_text.set_path_effects([path_effects.Stroke(linewidth=2, foreground='black'), path_effects.Normal()])
+            label_text.set_path_effects([mpl_patheffects.Stroke(linewidth=2, foreground='black'),
+                                         mpl_patheffects.Normal()])
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)
 
@@ -191,7 +194,7 @@ class QcImage:
         labels = np.unique(img[np.where(~img.mask)]).astype(int)  # get available labels
         color_list = self._assign_label_colors_by_groups(labels)
         ax.imshow(img,
-                  cmap=color.ListedColormap(color_list),
+                  cmap=mpl_colors.ListedColormap(color_list),
                   interpolation=self.interpolation,
                   alpha=1,
                   aspect=float(self.aspect_mask))
@@ -214,8 +217,8 @@ class QcImage:
                         x += data.shape[1] / 25
                         label = list(self._labels_regions.keys())[list(self._labels_regions.values()).index(index)]
                         label_text = ax.text(x, y, label, color=label_color, clip_on=True)
-                        label_text.set_path_effects([path_effects.Stroke(linewidth=2, foreground='black'),
-                                                     path_effects.Normal()])
+                        label_text.set_path_effects([mpl_patheffects.Stroke(linewidth=2, foreground='black'),
+                                                     mpl_patheffects.Normal()])
 
     def highlight_pmj(self, mask, ax):
         """Hook to show a rectangle where PMJ is on the slice"""
@@ -236,8 +239,8 @@ class QcImage:
             # ax.text(cord[1]+5,cord[0]+5, str(mask[cord]), color='lime', clip_on=True)
         img = np.rint(np.ma.masked_where(mask < 1, mask))
         ax.imshow(img,
-                  cmap=color.ListedColormap(self._color_bin_red),
-                  norm=color.Normalize(vmin=0, vmax=1),
+                  cmap=mpl_colors.ListedColormap(self._color_bin_red),
+                  norm=mpl_colors.Normalize(vmin=0, vmax=1),
                   interpolation=self.interpolation,
                   alpha=1,
                   aspect=float(self.aspect_mask))
@@ -269,8 +272,8 @@ class QcImage:
         mask[mask < 0.05] = 0  # Apply 0.5 threshold
         img = np.ma.masked_equal(mask, 0)
         ax.imshow(img,
-                  cmap=color.LinearSegmentedColormap.from_list("", self._ctl_colormap),
-                  norm=color.Normalize(vmin=0, vmax=1),
+                  cmap=mpl_colors.LinearSegmentedColormap.from_list("", self._ctl_colormap),
+                  norm=mpl_colors.Normalize(vmin=0, vmax=1),
                   interpolation=self.interpolation,
                   aspect=float(self.aspect_mask))
         ax.get_xaxis().set_visible(False)
@@ -312,9 +315,9 @@ class QcImage:
         #  NB: `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
         size_fig = [5, 5 * img.shape[0] / img.shape[1]]
 
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(size_fig[0], size_fig[1], forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         ax = fig.add_axes((0, 0, 1, 1))
         ax.imshow(img, cmap='gray', interpolation=self.interpolation, aspect=float(self.aspect_img))
         self._add_orientation_label(ax)
@@ -323,9 +326,9 @@ class QcImage:
         logger.info(self.qc_report.abs_background_img_path())
         self._save(fig, self.qc_report.abs_background_img_path(), dpi=self.qc_report.dpi)
 
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(size_fig[0], size_fig[1], forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         for i, action in enumerate(self.action_list):
             logger.debug('Action List %s', action.__name__)
             if self._stretch_contrast and action.__name__ in ("no_seg_seg",):
@@ -408,10 +411,10 @@ class QcImage:
             text_l = ax.text(0, 18, 'L', color='yellow', size=4)
             text_r = ax.text(24, 18, 'R', color='yellow', size=4)
             # Add a black outline surrounding the text
-            text_a.set_path_effects([path_effects.Stroke(linewidth=1, foreground='black'), path_effects.Normal()])
-            text_p.set_path_effects([path_effects.Stroke(linewidth=1, foreground='black'), path_effects.Normal()])
-            text_l.set_path_effects([path_effects.Stroke(linewidth=1, foreground='black'), path_effects.Normal()])
-            text_r.set_path_effects([path_effects.Stroke(linewidth=1, foreground='black'), path_effects.Normal()])
+            text_a.set_path_effects([mpl_patheffects.Stroke(linewidth=1, foreground='black'), mpl_patheffects.Normal()])
+            text_p.set_path_effects([mpl_patheffects.Stroke(linewidth=1, foreground='black'), mpl_patheffects.Normal()])
+            text_l.set_path_effects([mpl_patheffects.Stroke(linewidth=1, foreground='black'), mpl_patheffects.Normal()])
+            text_r.set_path_effects([mpl_patheffects.Stroke(linewidth=1, foreground='black'), mpl_patheffects.Normal()])
 
     def _generate_and_save_gif(self, top_images, bottom_images, size_fig, is_mask=False):
         """
@@ -429,8 +432,8 @@ class QcImage:
         else:
             aspect = self.aspect_img
 
-        fig = Figure()
-        FigureCanvas(fig)
+        fig = mpl_figure.Figure()
+        mpl_backend_agg.FigureCanvasAgg(fig)
         fig.set_size_inches(size_fig[0], size_fig[1], forward=True)
         fig.subplots_adjust(left=0, top=0.9, bottom=0.1)
 
@@ -464,7 +467,7 @@ class QcImage:
             ann.set_text(f'Volume: {i + 1}/{len(top_images)}')
 
         # FuncAnimation creates an animation by repeatedly calling the function update_figure for each frame
-        ani = FuncAnimation(fig, update_figure, frames=len(top_images))
+        ani = mpl_animation.FuncAnimation(fig, update_figure, frames=len(top_images))
 
         if is_mask:
             gif_out_path = self.qc_report.abs_overlay_img_path()
@@ -473,7 +476,7 @@ class QcImage:
 
         if self._fps is None:
             self._fps = 3
-        writer = PillowWriter(self._fps)
+        writer = mpl_animation.PillowWriter(self._fps)
         logger.info('Saving gif %s', gif_out_path)
         ani.save(gif_out_path, writer=writer, dpi=self.qc_report.dpi)
 
@@ -654,7 +657,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # The following are the expected types for some variables that get values
     # assigned in all branches of the big `if...elif...elif...` construct below
     qcslice: Slice
-    action_list: List[Callable[[QcImage, np.ndarray, Axes], None]]
+    action_list: List[Callable[[QcImage, np.ndarray, mpl_axes.Axes], None]]
     qcslice_layout: Callable[[Slice],
                              Union[List[np.ndarray],
                                    Tuple[List[List[np.ndarray]], List[Tuple[int, int]]]]]

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -15,11 +15,6 @@ import math
 from pathlib import Path
 from typing import Optional, Sequence
 
-from matplotlib.axes import Axes
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
-from matplotlib.figure import Figure
-import matplotlib.patheffects as path_effects
-import matplotlib.colors as color
 import numpy as np
 from scipy.ndimage import center_of_mass
 import skimage.exposure
@@ -29,8 +24,15 @@ import spinalcordtoolbox.reports
 from spinalcordtoolbox.reports.assets._assets.py import refresh_qc_entries
 from spinalcordtoolbox.resampling import resample_nib
 from spinalcordtoolbox.utils.shell import display_open
-from spinalcordtoolbox.utils.sys import __version__, list2cmdline
+from spinalcordtoolbox.utils.sys import __version__, list2cmdline, LazyLoader
 from spinalcordtoolbox.utils.fs import mutex
+
+mpl_figure = LazyLoader("mpl_figure", globals(), "matplotlib.figure")
+mpl_axes = LazyLoader("mpl_axes", globals(), "matplotlib.axes")
+mpl_cm = LazyLoader("mpl_cm", globals(), "matplotlib.cm")
+mpl_colors = LazyLoader("mpl_colors", globals(), "matplotlib.colors")
+mpl_backend_agg = LazyLoader("mpl_backend_agg", globals(), "matplotlib.backends.backend_agg")
+mpl_patheffects = LazyLoader("mpl_patheffects", globals(), "matplotlib.patheffects")
 
 logger = logging.getLogger(__name__)
 
@@ -204,9 +206,9 @@ def sct_register_multimodal(
         # `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
         size_fig = [5, 5 * img.shape[0] / img.shape[1]]
 
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(*size_fig, forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         ax = fig.add_axes((0, 0, 1, 1))
         ax.imshow(img, cmap='gray', interpolation='none', aspect=1.0)
         add_orientation_labels(ax)
@@ -218,9 +220,9 @@ def sct_register_multimodal(
 
         # Generate the second QC report image
         img = equalize_histogram(mosaic(img_output, centers))
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(*size_fig, forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         ax = fig.add_axes((0, 0, 1, 1), label='0')
         ax.imshow(img, cmap='gray', interpolation='none', aspect=1.0)
         add_orientation_labels(ax)
@@ -299,9 +301,9 @@ def sct_deepseg(
         # `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
         size_fig = [5, 5 * img.shape[0] / img.shape[1]]
 
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(*size_fig, forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         ax = fig.add_axes((0, 0, 1, 1))
         ax.imshow(img, cmap='gray', interpolation='none', aspect=1.0)
         add_orientation_labels(ax)
@@ -312,12 +314,12 @@ def sct_deepseg(
         fig.savefig(img_path, format='png', transparent=True, dpi=300)
 
         # Generate the second QC report image
-        fig = Figure()
+        fig = mpl_figure.Figure()
         fig.set_size_inches(*size_fig, forward=True)
-        FigureCanvas(fig)
+        mpl_backend_agg.FigureCanvasAgg(fig)
         ax = fig.add_axes((0, 0, 1, 1))
-        colormaps = [color.ListedColormap(["#ff0000"]),  # Red for first image
-                     color.ListedColormap(["#00ffff"])]  # Cyan for second
+        colormaps = [mpl_colors.ListedColormap(["#ff0000"]),  # Red for first image
+                     mpl_colors.ListedColormap(["#00ffff"])]  # Cyan for second
         for i, image in enumerate([img_seg_sc, img_seg_lesion]):
             if not image:
                 continue
@@ -326,7 +328,7 @@ def sct_deepseg(
             img.set_fill_value(0)
             ax.imshow(img,
                       cmap=colormaps[i],
-                      norm=color.Normalize(vmin=0.5, vmax=1),
+                      norm=mpl_colors.Normalize(vmin=0.5, vmax=1),
                       # img==1 -> opaque, but soft regions -> more transparent as value decreases
                       alpha=(img / img.max()),  # scale to [0, 1]
                       interpolation='none',
@@ -384,7 +386,7 @@ def mosaic(img: Image, centers: np.ndarray, radius: tuple[int, int] = (15, 15)):
     return np.block([cropped[i:i+num_col] for i in range(0, len(cropped), num_col)])
 
 
-def add_orientation_labels(ax: Axes):
+def add_orientation_labels(ax: mpl_axes.Axes):
     """
     Add orientation labels (A, P, L, R) to a figure, yellow with a black outline.
     """
@@ -395,8 +397,8 @@ def add_orientation_labels(ax: Axes):
         (24, 18, 'R'),
     ]:
         ax.text(x, y, letter, color='yellow', size=4).set_path_effects([
-            path_effects.Stroke(linewidth=1, foreground='black'),
-            path_effects.Normal(),
+            mpl_patheffects.Stroke(linewidth=1, foreground='black'),
+            mpl_patheffects.Normal(),
         ])
 
 

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -11,14 +11,15 @@ import pickle
 from typing import Sequence
 
 import numpy as np
-import pandas as pd
 from skimage.measure import label
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
+
+pd = lazy_import("pandas")
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -16,10 +16,10 @@ from skimage.measure import label
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
-pd = lazy_import("pandas")
+pd = LazyLoader("pd", globals(), "pandas")
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -580,7 +580,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_mask = arguments.m
     fname_sc = arguments.s

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -304,7 +304,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # create param object
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -326,7 +326,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     input_filename = arguments.i
     fname_out = arguments.o if arguments.o is not None else os.path.basename(add_suffix(input_filename, '_reg'))

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -194,7 +194,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = complete_test = arguments.complete
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     print("\nSYSTEM INFORMATION"
           "\n------------------")

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -12,16 +12,16 @@ import os
 import numpy as np
 import logging
 from typing import Sequence
-import pandas as pd
 from spinalcordtoolbox.utils.fs import extract_fname, get_absolute_path
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline
 from spinalcordtoolbox.types import Centerline
-from spinalcordtoolbox.utils.sys import __data_dir__
+from spinalcordtoolbox.utils.sys import __data_dir__, lazy_import
 from spinalcordtoolbox.scripts import sct_process_segmentation
 
+pd = lazy_import("pandas")
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -531,7 +531,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)    # values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG]
+    set_loglevel(verbose=verbose, caller_module_name=__name__)    # values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG]
 
     # Step 0: Argument loading and validation
     # ---------------------------

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -18,10 +18,10 @@ from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline
 from spinalcordtoolbox.types import Centerline
-from spinalcordtoolbox.utils.sys import __data_dir__, lazy_import
+from spinalcordtoolbox.utils.sys import __data_dir__, LazyLoader
 from spinalcordtoolbox.scripts import sct_process_segmentation
 
-pd = lazy_import("pandas")
+pd = LazyLoader("pd", globals(), "pandas")
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -119,7 +119,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Initialization
     input_t1 = arguments.t1

--- a/spinalcordtoolbox/scripts/sct_compute_flow.py
+++ b/spinalcordtoolbox/scripts/sct_compute_flow.py
@@ -71,7 +71,7 @@ def main(argv: Sequence[str]):
     arguments = parser.parse_args(argv)
     venc = float(arguments.venc)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     printv(f"Load data: {arguments.i}", verbose)
     nii_phase = Image(arguments.i)

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -505,7 +505,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     param = Param()
     if param.debug:

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -70,7 +70,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_mtr = arguments.o
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -159,7 +159,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     printv('Load data...', verbose)
     nii_mt = Image(arguments.mt)

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -130,7 +130,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Default params
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -33,7 +33,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
     param = Param()
 
     # Initialization

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -70,7 +70,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Building the command, do sanity checks
     fname_in = arguments.i

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -123,7 +123,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     param = Param()
     param.fname_data = os.path.abspath(arguments.i)

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -153,7 +153,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     dilate = arguments.dilate
     if dilate is not None:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -18,17 +18,17 @@ import sys
 import logging
 from typing import Sequence
 
+from spinalcordtoolbox.reports import qc2
 from spinalcordtoolbox.image import splitext, Image, check_image_kind
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, __version__, _git_info
 from spinalcordtoolbox.utils.fs import tmp_create
-from spinalcordtoolbox.utils.sys import lazy_import
+from spinalcordtoolbox.utils.sys import LazyLoader
 
-cuda = lazy_import('torch.cuda')
+cuda = LazyLoader("cuda", globals(), 'torch.cuda')
 
-qc2 = lazy_import('spinalcordtoolbox.reports.qc2')
-inference = lazy_import('spinalcordtoolbox.deepseg.inference')
-models = lazy_import('spinalcordtoolbox.deepseg.models')
+inference = LazyLoader("inference", globals(), 'spinalcordtoolbox.deepseg.inference')
+models = LazyLoader("models", globals(), 'spinalcordtoolbox.deepseg.models')
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -153,7 +153,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     if (arguments.list_tasks is False
             and arguments.install is None

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -18,14 +18,17 @@ import sys
 import logging
 from typing import Sequence
 
-import torch
-
-from spinalcordtoolbox.reports import qc2
-from spinalcordtoolbox.deepseg import models, inference
 from spinalcordtoolbox.image import splitext, Image, check_image_kind
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, __version__, _git_info
 from spinalcordtoolbox.utils.fs import tmp_create
+from spinalcordtoolbox.utils.sys import lazy_import
+
+cuda = lazy_import('torch.cuda')
+
+qc2 = lazy_import('spinalcordtoolbox.reports.qc2')
+inference = lazy_import('spinalcordtoolbox.deepseg.inference')
+models = lazy_import('spinalcordtoolbox.deepseg.models')
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +275,7 @@ def main(argv: Sequence[str]):
         # Control GPU usage based on SCT-specific environment variable
         # NB: We use 'SCT_USE_GPU' as a "hidden option" to turn on GPU inference internally.
         # NB: Controlling which GPU(s) are used should be done by the environment variable 'CUDA_VISIBLE_DEVICES'.
-        use_gpu = torch.cuda.is_available() and "SCT_USE_GPU" in os.environ
+        use_gpu = cuda.is_available() and "SCT_USE_GPU" in os.environ
 
         if model_type == 'ivadomed':
             # NB: For single models, the averaging will have no effect.

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -101,7 +101,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     input_filename = arguments.i
     if arguments.o is not None:

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -100,7 +100,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_image = arguments.i
     contrast_type = arguments.c

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -124,7 +124,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_image = os.path.abspath(arguments.i)
     contrast_type = arguments.c

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -104,7 +104,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     parameter = arguments.p
     remove_temp_files = arguments.r

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -11,12 +11,13 @@ from typing import Sequence
 
 import numpy as np
 import nibabel as nib
-from dipy.denoise.nlmeans import nlmeans
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.fs import extract_fname
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
+
+nlmeans = lazy_import("dipy.denoise.nlmeans")
 
 
 # DEFAULT PARAMETERS
@@ -141,9 +142,9 @@ def main(argv: Sequence[str]):
         # Application of NLM filter to the image
         printv('Applying Non-local mean filter...')
         if param.parameter == 'Rician':
-            den = nlmeans(data, sigma=sigma, mask=None, rician=True, block_radius=block_radius)
+            den = nlmeans.nlmeans(data, sigma=sigma, mask=None, rician=True, block_radius=block_radius)
         else:
-            den = nlmeans(data, sigma=sigma, mask=None, rician=False, block_radius=block_radius)
+            den = nlmeans.nlmeans(data, sigma=sigma, mask=None, rician=False, block_radius=block_radius)
     else:
         # # Process for manual detecting of background
         mask = data > noise_threshold
@@ -151,9 +152,9 @@ def main(argv: Sequence[str]):
         # Application of NLM filter to the image
         printv('Applying Non-local mean filter...')
         if param.parameter == 'Rician':
-            den = nlmeans(data, sigma=sigma, mask=mask, rician=True, block_radius=block_radius)
+            den = nlmeans.nlmeans(data, sigma=sigma, mask=mask, rician=True, block_radius=block_radius)
         else:
-            den = nlmeans(data, sigma=sigma, mask=mask, rician=False, block_radius=block_radius)
+            den = nlmeans.nlmeans(data, sigma=sigma, mask=mask, rician=False, block_radius=block_radius)
 
     t = time()
     printv("total time: %s" % (time() - t))

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -14,10 +14,10 @@ import nibabel as nib
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.fs import extract_fname
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser, display_viewer_syntax
 
-nlmeans = lazy_import("dipy.denoise.nlmeans")
+nlmeans = LazyLoader("nlmeans", globals(), "dipy.denoise.nlmeans")
 
 
 # DEFAULT PARAMETERS

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -290,7 +290,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Set param arguments ad inputted by user
     fname_in = arguments.i

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -101,7 +101,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_input1 = arguments.i
     fname_input2 = arguments.d

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -19,7 +19,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     GYRO = float(42.576 * 10 ** 6)  # gyromagnetic ratio (in Hz.T^-1)
     gradamp = []

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -84,7 +84,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initialization
     file_mask = ''

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -105,7 +105,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # check number of input args
     if not len(arguments.i) == len(arguments.order):

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -10,11 +10,12 @@ import sys
 from typing import Sequence
 
 import numpy as np
-from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image, concat_data
+
+fetcher = lazy_import("dipy.data.fetcher")
 
 
 def get_parser():
@@ -131,7 +132,7 @@ def main(argv: Sequence[str]):
             bvec = np.array([[0.0, 0.0, 0.0]] * n_b0)
         elif arguments.order[i_item] == 'dwi':
             # read bval/bvec files
-            bval, bvec = read_bvals_bvecs(arguments.bval[i_dwi], arguments.bvec[i_dwi])
+            bval, bvec = fetcher.read_bvals_bvecs(arguments.bval[i_dwi], arguments.bvec[i_dwi])
             i_dwi += 1
         # Concatenate bvals
         bvals_concat += ' '.join(str(v) for v in bval)

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -11,11 +11,11 @@ from typing import Sequence
 
 import numpy as np
 
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 from spinalcordtoolbox.image import Image, concat_data
 
-fetcher = lazy_import("dipy.data.fetcher")
+fetcher = LazyLoader("fetcher", globals(), "dipy.data.fetcher")
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -55,7 +55,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_bval_list = arguments.i
     # Build fname_out

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -57,7 +57,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_bvecs_list = arguments.i
     # Build fname_out

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -11,11 +11,12 @@ from typing import Sequence
 
 import numpy as np
 import nibabel as nib
-from dipy.denoise.patch2self import patch2self
 
 from spinalcordtoolbox.image import add_suffix, Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv, lazy_import
+
+patch2self = lazy_import('dipy.denoise.patch2self')
 
 
 def get_parser():
@@ -115,7 +116,7 @@ def main(argv: Sequence[str]):
     data = nii.get_fdata()
 
     printv("Applying Patch2Self Denoising...")
-    data_denoised = patch2self(data, bvals, patch_radius, model, verbose=True)
+    data_denoised = patch2self.patch2self(data, bvals, patch_radius, model, verbose=True)
     data_diff = np.absolute(data_denoised.astype('f8') - data.astype('f8'))
 
     if verbose == 2:

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -91,7 +91,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     model = arguments.model
     if "," in arguments.radius:

--- a/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_denoise_patch2self.py
@@ -14,9 +14,9 @@ import nibabel as nib
 
 from spinalcordtoolbox.image import add_suffix, Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv, LazyLoader
 
-patch2self = lazy_import('dipy.denoise.patch2self')
+patch2self = LazyLoader("patch2self", globals(), 'dipy.denoise.patch2self')
 
 
 def get_parser():

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -9,14 +9,15 @@ import sys
 from typing import Sequence
 
 import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
-from dipy.data.fetcher import read_bvals_bvecs
 from matplotlib.lines import Line2D
 from matplotlib import cm
 
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
+
+fetcher = lazy_import('dipy.data.fetcher')
+pd = lazy_import("pandas")
 
 BZERO_THRESH = 0.0001  # b-zero threshold
 
@@ -115,7 +116,7 @@ def main(argv: Sequence[str]):
     fname_bvecs = arguments.bvec
     fname_bvals = arguments.bval
     # Read bvals and bvecs files (if arguments.bval is not passed, bvals will be None)
-    bvals, bvecs = read_bvals_bvecs(fname_bvals, fname_bvecs)
+    bvals, bvecs = fetcher.read_bvals_bvecs(fname_bvals, fname_bvecs)
     # if first dimension is not equal to 3 (x,y,z), transpose bvecs file
     if bvecs.shape[0] != 3:
         bvecs = bvecs.transpose()

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -13,11 +13,11 @@ import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 from matplotlib import cm
 
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
 from spinalcordtoolbox.utils.shell import Metavar, SCTArgumentParser
 
-fetcher = lazy_import('dipy.data.fetcher')
-pd = lazy_import("pandas")
+fetcher = LazyLoader("fetcher", globals(), 'dipy.data.fetcher')
+pd = LazyLoader("pd", globals(), "pandas")
 
 BZERO_THRESH = 0.0001  # b-zero threshold
 

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -110,7 +110,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_bvecs = arguments.bvec
     fname_bvals = arguments.bval

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -216,7 +216,7 @@ def main(argv: Sequence[str]):
     # run moco
     fname_output_image = moco_wrapper(param)
 
-    set_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
+    set_loglevel(verbose, caller_module_name=__name__)  # moco_wrapper changes verbose to 0, see issue #3341
 
     # QC report
     if path_qc is not None:

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -184,7 +184,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initialization
     param = ParamMoco(is_diffusion=True, group_size=3, metric='MI', smooth='1')

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -107,7 +107,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initialize parameters
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -57,7 +57,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_in = arguments.bvec
     fname_out = arguments.o

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -63,7 +63,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     install_named_dataset(arguments.d, dest_folder=arguments.o, keep=arguments.k)
 

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -273,7 +273,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     param_default = Param()
 

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -37,7 +37,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_anat = arguments.i
     fname_centerline = arguments.s

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -97,7 +97,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     param = Param()
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -180,7 +180,7 @@ def main(argv: Sequence[str]):
     # run moco
     fname_output_image = moco_wrapper(param)
 
-    set_loglevel(verbose)  # moco_wrapper changes verbose to 0, see issue #3341
+    set_loglevel(verbose, caller_module_name=__name__)  # moco_wrapper changes verbose to 0, see issue #3341
 
     # QC report
     if path_qc is not None:

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -149,7 +149,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initialization
     param = ParamMoco(group_size=1, metric='MeanSquares', smooth='0')

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -147,7 +147,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Input filename
     fname_input_data = arguments.i

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -247,7 +247,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initializations
     output_type = None

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -245,7 +245,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     input_filename = arguments.i
     output_fname = arguments.o

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -272,7 +272,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_in = os.path.abspath(arguments.i)
     fname_seg = os.path.abspath(arguments.s)

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -12,13 +12,14 @@ import argparse
 from typing import Sequence
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
 from spinalcordtoolbox.utils.fs import extract_fname
+
+plt = lazy_import("matplotlib.pyplot")
 
 
 class ParseDataOrScalarArgument(argparse.Action):

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -297,7 +297,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     dim_list = ['x', 'y', 'z', 't']
 

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -16,10 +16,10 @@ import numpy as np
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, lazy_import
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
 from spinalcordtoolbox.utils.fs import extract_fname
 
-plt = lazy_import("matplotlib.pyplot")
+plt = LazyLoader("plt", globals(), "matplotlib.pyplot")
 
 
 class ParseDataOrScalarArgument(argparse.Action):

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -190,7 +190,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # set param arguments ad inputted by user
     list_fname_src = arguments.i

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -31,9 +31,9 @@ from spinalcordtoolbox.utils.fs import get_absolute_path
 from spinalcordtoolbox.utils.sys import __sct_dir__, init_sct, sct_progress_bar, set_loglevel
 from spinalcordtoolbox.utils.shell import (ActionCreateFolder, Metavar, SCTArgumentParser,
                                            display_open, parse_num_list)
-from spinalcordtoolbox.utils.sys import __data_dir__, lazy_import
+from spinalcordtoolbox.utils.sys import __data_dir__, LazyLoader
 
-pd = lazy_import("pandas")
+pd = LazyLoader("pd", globals(), "pandas")
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -15,7 +15,6 @@ import logging
 import argparse
 from typing import Sequence
 
-import pandas as pd
 import numpy as np
 from matplotlib.ticker import MaxNLocator
 
@@ -32,7 +31,9 @@ from spinalcordtoolbox.utils.fs import get_absolute_path
 from spinalcordtoolbox.utils.sys import __sct_dir__, init_sct, sct_progress_bar, set_loglevel
 from spinalcordtoolbox.utils.shell import (ActionCreateFolder, Metavar, SCTArgumentParser,
                                            display_open, parse_num_list)
-from spinalcordtoolbox.utils.sys import __data_dir__
+from spinalcordtoolbox.utils.sys import __data_dir__, lazy_import
+
+pd = lazy_import("pandas")
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -388,7 +388,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Initialization
     group_funcs = (('MEAN', func_wa), ('STD', func_std))  # functions to perform when aggregating metrics along S-I

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -670,7 +670,7 @@ def main(argv: Sequence[str]):
                      "https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3694")
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     fname_input_data = os.path.abspath(arguments.i)
     img_input = Image(fname_input_data)

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -96,7 +96,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     if arguments.p == 'sct_deepseg_lesion' and arguments.plane is None:
         parser.error('Please provide the plane of the output QC with -plane')

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -305,7 +305,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initialize parameters
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -296,7 +296,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # initializations
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -113,7 +113,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
     param.verbose = verbose
 
     param.fname_data = arguments.i

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -350,7 +350,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # See if there's a configuration file and import those options
     if arguments.config is not None:

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -122,7 +122,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     # Initialization
     param = Param()

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -196,7 +196,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     input_filename = arguments.i
     centerline_file = arguments.s

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -249,7 +249,7 @@ def main(argv: Sequence[str]):
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v
-    set_loglevel(verbose=verbose)
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     if arguments.s:
         parser.error(S_DEPRECATION_STRING)

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import logging
 import argparse
+import inspect
 
 from enum import Enum
 
@@ -188,15 +189,22 @@ class SCTArgumentParser(argparse.ArgumentParser):
         TODO: Centralize `-v`, `-r`, and `-h` arguments here too, as they're copied
               and pasted across all SCT scripts.
     """
-    def __init__(self, description, epilog=None):
-        super(SCTArgumentParser, self).__init__(
-            description=description,
-            epilog=epilog,
-            formatter_class=SmartFormatter,
-            # Disable "add_help", because it won't properly add '-h' to our custom argument groups
-            # (We use custom argument groups because of https://stackoverflow.com/a/24181138)
-            add_help=False
-        )
+    def __init__(self, *args, **kwargs):
+        def update_parent_default(key, value):
+            """A polite way of letting a child class have different default values than the parent class."""
+            # Source: https://stackoverflow.com/a/41623488
+            argspec = inspect.getfullargspec(super(SCTArgumentParser, self).__init__)
+            arg_index = argspec.args.index(key)
+            if len(args) < arg_index and key not in kwargs:
+                kwargs[key] = value
+
+        update_parent_default('formatter_class', SmartFormatter)
+
+        # Disable "add_help", because it won't properly add '-h' to our custom argument groups
+        # (We use custom argument groups because of https://stackoverflow.com/a/24181138)
+        update_parent_default('add_help', False)
+
+        super(SCTArgumentParser, self).__init__(*args, **kwargs)
 
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
         self.prog = removesuffix(self.prog, ".py")

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -11,7 +11,6 @@ import re
 import shutil
 import logging
 import argparse
-import inspect
 
 from enum import Enum
 
@@ -189,22 +188,15 @@ class SCTArgumentParser(argparse.ArgumentParser):
         TODO: Centralize `-v`, `-r`, and `-h` arguments here too, as they're copied
               and pasted across all SCT scripts.
     """
-    def __init__(self, *args, **kwargs):
-        def update_parent_default(key, value):
-            """A polite way of letting a child class have different default values than the parent class."""
-            # Source: https://stackoverflow.com/a/41623488
-            argspec = inspect.getfullargspec(super(SCTArgumentParser, self).__init__)
-            arg_index = argspec.args.index(key)
-            if len(args) < arg_index and key not in kwargs:
-                kwargs[key] = value
-
-        update_parent_default('formatter_class', SmartFormatter)
-
-        # Disable "add_help", because it won't properly add '-h' to our custom argument groups
-        # (We use custom argument groups because of https://stackoverflow.com/a/24181138)
-        update_parent_default('add_help', False)
-
-        super(SCTArgumentParser, self).__init__(*args, **kwargs)
+    def __init__(self, description, epilog=None):
+        super(SCTArgumentParser, self).__init__(
+            description=description,
+            epilog=epilog,
+            formatter_class=SmartFormatter,
+            # Disable "add_help", because it won't properly add '-h' to our custom argument groups
+            # (We use custom argument groups because of https://stackoverflow.com/a/24181138)
+            add_help=False
+        )
 
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
         self.prog = removesuffix(self.prog, ".py")

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -15,7 +15,7 @@ import inspect
 
 from enum import Enum
 
-from .sys import check_exe, printv, removesuffix, ANSIColors16
+from .sys import check_exe, printv, ANSIColors16
 from .fs import relpath_or_abspath
 
 logger = logging.getLogger(__name__)
@@ -201,9 +201,9 @@ class SCTArgumentParser(argparse.ArgumentParser):
         update_parent_default('formatter_class', SmartFormatter)
 
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
-        frame = inspect.stack()[1]
-        module = inspect.getmodule(frame[0])
-        update_parent_default('prog', removesuffix(os.path.basename(module.__file__), ".py"))
+        # frame = inspect.stack()[1]
+        # module = inspect.getmodule(frame[0])
+        # update_parent_default('prog', removesuffix(os.path.basename(module.__file__), ".py"))
 
         # Disable "add_help", because it won't properly add '-h' to our custom argument groups
         # (We use custom argument groups because of https://stackoverflow.com/a/24181138)

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -15,7 +15,7 @@ import inspect
 
 from enum import Enum
 
-from .sys import check_exe, printv, ANSIColors16
+from .sys import check_exe, printv, removesuffix, ANSIColors16
 from .fs import relpath_or_abspath
 
 logger = logging.getLogger(__name__)
@@ -200,16 +200,14 @@ class SCTArgumentParser(argparse.ArgumentParser):
 
         update_parent_default('formatter_class', SmartFormatter)
 
-        # Update "usage:" message to match how SCT scripts are actually called (no '.py')
-        # frame = inspect.stack()[1]
-        # module = inspect.getmodule(frame[0])
-        # update_parent_default('prog', removesuffix(os.path.basename(module.__file__), ".py"))
-
         # Disable "add_help", because it won't properly add '-h' to our custom argument groups
         # (We use custom argument groups because of https://stackoverflow.com/a/24181138)
         update_parent_default('add_help', False)
 
         super(SCTArgumentParser, self).__init__(*args, **kwargs)
+
+        # Update "usage:" message to match how SCT scripts are actually called (no '.py')
+        self.prog = removesuffix(self.prog, ".py")
 
     def error(self, message):
         """

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -134,7 +134,8 @@ def set_loglevel(verbose):
     logger.setLevel(getattr(logging, log_level))
 
     # Set logging level for the file that called this function
-    caller_module_name = get_caller_module().__name__
+    caller_module_name = "__main__"  # hack to test import times
+    # caller_module_name = get_caller_module().__name__
     caller_logger = logging.getLogger(caller_module_name)
     caller_logger.setLevel(getattr(logging, log_level))
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -19,7 +19,6 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
-import inspect
 
 import tqdm
 
@@ -98,16 +97,7 @@ class ANSIColors16(object):
     BackgroundWhite = "\033[107m"
 
 
-def get_caller_module():
-    """Return the first non-`utils.sys` module in the stack (to see where `utils.sys` is being called from)."""
-    for frame in inspect.stack():
-        mod = inspect.getmodule(frame[0])
-        if mod.__file__ != __file__:
-            break
-    return mod
-
-
-def set_loglevel(verbose):
+def set_loglevel(verbose, caller_module_name):
     """
     Use SCT's verbosity values to set the logging level.
 
@@ -119,6 +109,7 @@ def set_loglevel(verbose):
     one of two schemes:
        - [0, 1, 2], which corresponds to [WARNING, INFO, DEBUG]. (Older scheme)
        - [False, True], which corresponds to [INFO, DEBUG].      (Newer scheme)
+    :caller_module_name: The `__name__` of the caller module
     """
     dict_log_levels = {
         '0': 'WARNING', '1': 'INFO', '2': 'DEBUG',  # Older scheme
@@ -134,8 +125,6 @@ def set_loglevel(verbose):
     logger.setLevel(getattr(logging, log_level))
 
     # Set logging level for the file that called this function
-    caller_module_name = "__main__"  # hack to test import times
-    # caller_module_name = get_caller_module().__name__
     caller_logger = logging.getLogger(caller_module_name)
     caller_logger.setLevel(getattr(logging, log_level))
 
@@ -184,7 +173,7 @@ def init_sct():
         return _format
 
     # Initialize logging
-    set_loglevel(verbose=False)  # False => "INFO". For "DEBUG", must be called again with verbose=True.
+    set_loglevel(verbose=False, caller_module_name=__name__)  # False => "INFO". For "DEBUG", must be called again with verbose=True.
     hdlr = logging.StreamHandler(sys.stdout)
     fmt = logging.Formatter()
     fmt.format = _format_wrap(fmt.format)

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -15,6 +15,7 @@ import time
 import shlex
 import atexit
 import smtplib
+import importlib.util
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
@@ -23,6 +24,16 @@ from email import encoders
 import tqdm
 
 logger = logging.getLogger(__name__)
+
+
+def lazy_import(name):
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
 
 
 def stylize(string, styles):

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -15,7 +15,6 @@ import time
 import shlex
 import atexit
 import smtplib
-import importlib.util
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
@@ -23,17 +22,10 @@ from email import encoders
 
 import tqdm
 
+# Expose Tensorflow's LazyLoader class in `utils.sys` namespace
+from contrib.tensorflow.lazy_loader import LazyLoader  # noqa
+
 logger = logging.getLogger(__name__)
-
-
-def lazy_import(name):
-    spec = importlib.util.find_spec(name)
-    loader = importlib.util.LazyLoader(spec.loader)
-    spec.loader = loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    loader.exec_module(module)
-    return module
 
 
 def stylize(string, styles):

--- a/testing/api/test_centerline.py
+++ b/testing/api/test_centerline.py
@@ -14,7 +14,7 @@ from spinalcordtoolbox.utils.sys import init_sct, sct_test_path, set_loglevel
 
 # Set logger to "DEBUG"
 init_sct()
-set_loglevel(verbose=2)
+set_loglevel(verbose=2, caller_module_name=__name__)
 # Separate setting for get_centerline. Set to 2 to save images ("DEBUG"), 0 otherwise ("INFO")
 VERBOSE = 0
 

--- a/testing/api/test_qmri.py
+++ b/testing/api/test_qmri.py
@@ -11,7 +11,7 @@ from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
 
 # Set logger to "DEBUG"
 init_sct()
-set_loglevel(verbose=2)
+set_loglevel(verbose=2, caller_module_name=__name__)
 
 
 def make_sct_image(data):

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -1,6 +1,7 @@
 # pytest unit tests for spinalcordtoolbox.utils
 
 import os
+import sys
 import pytest
 from stat import S_IEXEC
 
@@ -17,7 +18,7 @@ def test_sct_argument_parser(capsys):
     """Test extra argparse functionality added by SCTArgumentParser subclass."""
     # Check that new defaults are set properly
     parser = shell.SCTArgumentParser(description="A test argument parser.")
-    # assert parser.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
+    assert parser.prog == os.path.basename(sys.argv[0]).rstrip(".py")
     assert parser.formatter_class == shell.SmartFormatter
     assert parser.add_help is False
 

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -1,7 +1,6 @@
 # pytest unit tests for spinalcordtoolbox.utils
 
 import os
-import sys
 import pytest
 from stat import S_IEXEC
 
@@ -18,7 +17,7 @@ def test_sct_argument_parser(capsys):
     """Test extra argparse functionality added by SCTArgumentParser subclass."""
     # Check that new defaults are set properly
     parser = shell.SCTArgumentParser(description="A test argument parser.")
-    assert parser.prog == os.path.basename(sys.argv[0]).rstrip(".py")
+    # assert parser.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
     assert parser.formatter_class == shell.SmartFormatter
     assert parser.add_help is False
 

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -23,7 +23,7 @@ def test_sct_argument_parser(capsys):
 
     # Check that new defaults are set properly
     parser3 = shell.SCTArgumentParser()
-    assert parser3.prog == "test_utils_shell"
+    # assert parser3.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
     assert parser3.formatter_class == shell.SmartFormatter
     assert parser3.add_help is False
 
@@ -36,7 +36,7 @@ def test_sct_argument_parser(capsys):
 
     # Check help message is still output when above error is thrown
     captured = capsys.readouterr()
-    assert "usage: test_utils_shell" in captured.err
+    assert "usage:" in captured.err
 
     # Ensure no error is thrown when help is explicitly called
     with pytest.raises(SystemExit) as e:

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -15,17 +15,23 @@ def test_parse_num_list_inv():
 
 def test_sct_argument_parser(capsys):
     """Test extra argparse functionality added by SCTArgumentParser subclass."""
+    # Check that new defaults can still be overridden (setting add_help via args AND kwargs)
+    parser1 = shell.SCTArgumentParser(None, None, None, None, [], shell.SmartFormatter, '-', None, None, 'error', True)
+    assert parser1.add_help is True
+    parser2 = shell.SCTArgumentParser(add_help=True)
+    assert parser2.add_help is True
+
     # Check that new defaults are set properly
-    parser = shell.SCTArgumentParser(description="A test argument parser.")
-    # assert parser.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
-    assert parser.formatter_class == shell.SmartFormatter
-    assert parser.add_help is False
+    parser3 = shell.SCTArgumentParser()
+    # assert parser3.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
+    assert parser3.formatter_class == shell.SmartFormatter
+    assert parser3.add_help is False
 
     # Check that error is thrown when required argument isn't passed
-    parser.add_argument('-r', '--required', required=True)
-    parser.add_argument('-h', "--help", help="show this message and exit", action="help")
+    parser3.add_argument('-r', '--required', required=True)
+    parser3.add_argument('-h', "--help", help="show this message and exit", action="help")
     with pytest.raises(SystemExit) as e:
-        parser.parse_args()
+        parser3.parse_args()
     assert e.value.code == 2
 
     # Check help message is still output when above error is thrown
@@ -34,7 +40,7 @@ def test_sct_argument_parser(capsys):
 
     # Ensure no error is thrown when help is explicitly called
     with pytest.raises(SystemExit) as e:
-        parser.parse_args(['-h'])
+        parser3.parse_args(['-h'])
     assert e.value.code == 0
 
 

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -15,23 +15,17 @@ def test_parse_num_list_inv():
 
 def test_sct_argument_parser(capsys):
     """Test extra argparse functionality added by SCTArgumentParser subclass."""
-    # Check that new defaults can still be overridden (setting add_help via args AND kwargs)
-    parser1 = shell.SCTArgumentParser(None, None, None, None, [], shell.SmartFormatter, '-', None, None, 'error', True)
-    assert parser1.add_help is True
-    parser2 = shell.SCTArgumentParser(add_help=True)
-    assert parser2.add_help is True
-
     # Check that new defaults are set properly
-    parser3 = shell.SCTArgumentParser()
-    # assert parser3.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
-    assert parser3.formatter_class == shell.SmartFormatter
-    assert parser3.add_help is False
+    parser = shell.SCTArgumentParser(description="A test argument parser.")
+    # assert parser.prog == "test_utils_shell"  this may actually be `pytest`, `sct_testing`, etc. -- hard to test
+    assert parser.formatter_class == shell.SmartFormatter
+    assert parser.add_help is False
 
     # Check that error is thrown when required argument isn't passed
-    parser3.add_argument('-r', '--required', required=True)
-    parser3.add_argument('-h', "--help", help="show this message and exit", action="help")
+    parser.add_argument('-r', '--required', required=True)
+    parser.add_argument('-h', "--help", help="show this message and exit", action="help")
     with pytest.raises(SystemExit) as e:
-        parser3.parse_args()
+        parser.parse_args()
     assert e.value.code == 2
 
     # Check help message is still output when above error is thrown
@@ -40,7 +34,7 @@ def test_sct_argument_parser(capsys):
 
     # Ensure no error is thrown when help is explicitly called
     with pytest.raises(SystemExit) as e:
-        parser3.parse_args(['-h'])
+        parser.parse_args(['-h'])
     assert e.value.code == 0
 
 

--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -1,8 +1,8 @@
 # pytest unit tests for all cli scripts
 
 import pytest
-import importlib
 from importlib.metadata import entry_points
+import subprocess
 
 scripts = [cs.name for cs in entry_points()['console_scripts'] if cs.value.startswith("spinalcordtoolbox")]
 
@@ -20,10 +20,6 @@ scripts_to_test = [s for s in scripts if s not in scripts_where_no_args_is_valid
 def test_calling_scripts_with_no_args_shows_usage(capsys, script):
     """Test that SCT's scripts all return error code 2 and
     show usage descriptions when called with no arguments."""
-    mod = importlib.import_module(f"spinalcordtoolbox.scripts.{script}")
-    with pytest.raises(SystemExit) as system_err:
-        mod.main(argv=[])
-    captured = capsys.readouterr()
-
-    assert system_err.value.code == 2
-    assert 'usage' in captured.err.lower()
+    completed_process = subprocess.run([script], capture_output=True)
+    assert completed_process.returncode == 2
+    assert b'usage' in completed_process.stderr

--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -3,6 +3,7 @@
 import pytest
 from importlib.metadata import entry_points
 import subprocess
+import time
 
 scripts = [cs.name for cs in entry_points()['console_scripts'] if cs.value.startswith("spinalcordtoolbox")]
 
@@ -18,8 +19,13 @@ scripts_to_test = [s for s in scripts if s not in scripts_where_no_args_is_valid
 
 @pytest.mark.parametrize("script", scripts_to_test)
 def test_calling_scripts_with_no_args_shows_usage(capsys, script):
-    """Test that SCT's scripts all return error code 2 and
-    show usage descriptions when called with no arguments."""
+    """
+    Test that SCT's scripts all return error code 2 and show usage descriptions when called with no arguments.
+    Also, ensure that calling the help takes under 2.0 seconds per script.
+    """
+    start_time = time.time()
     completed_process = subprocess.run([script], capture_output=True)
+    duration = time.time() - start_time
     assert completed_process.returncode == 2
     assert b'usage' in completed_process.stderr
+    assert duration < 2.0, f"Expected '{script} -h' to execute in under 2.0s, but took {duration}"


### PR DESCRIPTION
> [!NOTE]
> This PR is largely the same as #4490, however it swaps the use of `importlib`'s [`lazy_import`](https://docs.python.org/3/library/importlib.html#implementing-lazy-imports) for a copy of Tensorflow's `LazyLoader`, which I've found to perform much more predictably. I had been struggling with `lazy_import` for much of the day (https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/57e3bf272e7be5eccf03322f63bedcaa8f7df86c), trying to track down obscure bugs and weird performance issues, until I finally decided to eschew it for something that's a little more battle-tested (https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4493/commits/b265cbf64af41b8d7d673b746c0a725fbaa37887).

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Here is some important background information from my initial research in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4370#issuecomment-2087620810:

<details>
<summary> PEP 690 - Lazy Imports </summary> 

----

I had the question: "Python style guides generally recommend keeping imports at the top of each module. Isn't lazy-loading incompatible with this? What is the "Pythonic" way to reduce import times?"

It turns out that [**PEP 690 – Lazy Imports**](https://peps.python.org/pep-0690/) (as well as [its rejection](https://discuss.python.org/t/pep-690-lazy-imports-again/19661/26)) explicitly references this dilemma:

> Common Python code style [prefers](https://peps.python.org/pep-0008/#imports) imports at module level, so they don’t have to be repeated within each scope the imported object is used in, and to avoid the inefficiency of repeated execution of the import system at runtime. This means that importing the main module of a program typically results in an immediate cascade of imports of most or all of the modules that may ever be needed by the program.
>
> Consider the example of a Python command line program (CLI) with a number of subcommands. Each subcommand may perform different tasks, requiring the import of different dependencies. But a given invocation of the program will only execute a single subcommand, or possibly none (i.e. if just --help usage info is requested). Top-level eager imports in such a program will result in the import of many modules that will never be used at all; the time spent (possibly compiling and) executing these modules is pure waste.

I couldn't have written a more accurate summary of our current issue.

----

</details>

tl;dr: CLI scripts are uniquely susceptible to import slowdowns, because some options may use expensive packages, but other options may not. In the extreme case, a command like `script --help` shouldn't ever need to load packages like `torch`. Yet, because we don't lazy load our expensive packages, our CLI scripts take quite a long time to load!

----

I wrote a quick test that will check the execution time for `script -h`, then fail if it's over a certain threshold (e.g. 2 seconds). Here are all of the scripts that take longer than 2s on `master`, sorted by duration:

<details>

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/080b26d7-e739-43ea-aa9f-cce41c0c022b)

</details>

Here are the times for `script -h` after implementing the fixes in this PR:

<details>

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/2df83b8c-f46f-47e2-b8b9-2425047e25db)

</details>

There are probably more gains to be had (by lazy-loading e.g. `nibabel` and `numpy`), but at this point, with script times at ~1s, I think any changes are likely to be diminishing returns. Plus, our usage of `nibabel` and `numpy` are widespread, which would require a lot of tedious updating for every single usage.

----

Much of the slowdown actually came from `inspect.stack()`, so a refactor to remove calls to this function reduced times across our entire CLI, without needing to do any lazy importing at all. (But, lazy importing took care of much of the remaining slowdowns.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4370.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3077.
