### PR TITLE
Properly detect softsegs for QC when binary values are *not* the most common values.

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1876,7 +1876,7 @@ def check_image_kind(img):
     zero_percentage = np.sum(counts[0]) / np.sum(counts)
     if binary_percentage == 1.0:
         return 'seg'
-    if binary_percentage > 0.95:
+    if 0.0 <= min(unique) <= max(unique) <= 1.0 and binary_percentage > 0.95:
         return 'softseg'
     if is_whole_only and zero_most_common and zero_percentage > 0.50:
         return 'seg-labeled'

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1866,19 +1866,18 @@ def check_image_kind(img):
     unique, counts = np.unique(np.round(img.data, decimals=1), return_counts=True)
     unique, counts = unique[np.argsort(counts)[::-1]], counts[np.argsort(counts)[::-1]]  # Sort by counts
     # This heuristic helps to detect binary and soft segmentations
-    binary_most_common = set(unique[0:2].astype(float)) == {0.0, 1.0}
-    binary_percentage = np.sum(counts[0:2]) / np.sum(counts)
+    idx_zero = np.where(unique == 0.0)[0]
+    idx_ones = np.where(unique == 1.0)[0]
+    binary_percentage = ((counts[idx_zero[0]] if idx_zero.size > 0 else 0) +
+                         (counts[idx_ones[0]] if idx_ones.size > 0 else 0)) / np.sum(counts)
     # This heuristic helps to distinguish between PSIR images and label images (2-10% zero vs. 99% zero)
     is_whole_only = np.equal(np.mod(unique, 1), 0).all()
     zero_most_common = float(unique[0]) == 0.0
     zero_percentage = np.sum(counts[0]) / np.sum(counts)
-    if binary_most_common:
-        if binary_percentage == 1.0:
-            return 'seg'
-        elif binary_percentage > 0.95:
-            return 'softseg'
-        else:  # binary_percentage <= 0.95
-            pass  # may be 'seg-labeled' or 'anat'
+    if binary_percentage == 1.0:
+        return 'seg'
+    if binary_percentage > 0.95:
+        return 'softseg'
     if is_whole_only and zero_most_common and zero_percentage > 0.50:
         return 'seg-labeled'
     else:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Normally, I expect soft segmentations to be similar to binary segmentations (0.0/1.0), but with some nonbinary values in the range [0.0, 1.0] to represent the "soft" regions.

However, In #4491, the lesion softseg is low resolution, making the soft perimeter very thick:

![image](https://github.com/spinalcordtoolbox/spinalcordtoolbox/assets/16181459/48ec32d4-2eda-4ee1-8f4a-73996101f94c)

This means that, while 0.0 is the most common value, 1.0 is _not_ the second-most common value, and the softseg heuristic fails. Upon reflection, I think this "`binary_most_common`" heuristic is too strict; it should be sufficient to just check the overall percentage of 0.0 and 1.0 voxels.

Additionally, this PR adds a condition to ensure that softsegs are in the range `[0, 1]`, which should have been there from the start.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4491.
