### PR TITLE
Rewrite help for `-x label` to clarify the difference between single-voxel and multi-voxel labels

### DIFF
--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -81,11 +81,13 @@ def get_parser():
         metavar=Metavar.file)
     optional.add_argument(
         "-x",
-        help=""" Interpolation method. The 'label' method is to be used if you would like to apply a transformation
-        on a file that has single-voxel labels (classical interpolation methods won't work, as resampled labels might
-        disappear or their values be altered). The function will dilate each label, apply the transformation using
-        nearest neighbour interpolation, and then take the center-of-mass of each "blob" and output a single voxel per
-        blob.""",
+        help="Interpolation method.\n"
+             "Note: The 'label' method is a special interpolation method designed for single-voxel labels (e.g. disc "
+             "labels used as registration landmarks). This method is necessary because classical interpolation may "
+             "corrupt the values of single-voxel labels, or cause them to disappear entirely. The function works by "
+             "dilating each label, applying the transformation using nearest neighbour interpolation, then extracting "
+             "the center-of-mass of each transformed 'blob' to get a single-voxel output label. Because the output "
+             "is a single-voxel label, the `-x label` method is not appropriate for multi-voxel labeled segmentations.",
         required=False,
         default='spline',
         choices=('nn', 'linear', 'spline', 'label'))

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -83,11 +83,12 @@ def get_parser():
         "-x",
         help="Interpolation method.\n"
              "Note: The 'label' method is a special interpolation method designed for single-voxel labels (e.g. disc "
-             "labels used as registration landmarks). This method is necessary because classical interpolation may "
-             "corrupt the values of single-voxel labels, or cause them to disappear entirely. The function works by "
-             "dilating each label, applying the transformation using nearest neighbour interpolation, then extracting "
-             "the center-of-mass of each transformed 'blob' to get a single-voxel output label. Because the output "
-             "is a single-voxel label, the `-x label` method is not appropriate for multi-voxel labeled segmentations.",
+             "labels used as registration landmarks, compression labels, etc.). This method is necessary because "
+             "classical interpolation may corrupt the values of single-voxel labels, or cause them to disappear "
+             "entirely. The function works by dilating each label, applying the transformation using nearest neighbour "
+             "interpolation, then extracting the center-of-mass of each transformed 'blob' to get a single-voxel "
+             "output label. Because the output is a single-voxel label, the `-x label` method is not appropriate for "
+             "multi-voxel labeled segmentations (such as spinal cord or lesion masks).",
         required=False,
         default='spline',
         choices=('nn', 'linear', 'spline', 'label'))


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

My goal was threefold:

- Fix the formatting of the multi-line string
- Provide an example of what a single-voxel label looks like
- Explicitly state that `-x label` is not appropriate for multi-voxel segmentations

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4497.