### PR TITLE
Add `-volumewise` to process the individual 3D volumes of 4D input images

### DIFF
--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -423,15 +423,11 @@ def main(argv: Sequence[str]):
     # If volumewise is specified, treat 4D image as a set of 3D volumes
     if arguments.volumewise:
         data_list = [np.squeeze(arr, axis=3) for arr in np.array_split(im.data, im.data.shape[3], 3)]
-        dim = list(im.dim)
-        dim[3] = 1  # Replace 4D dim with 1 (indicating single 3D volume)
-        dim_list = [tuple(dim)] * len(data_list)
     else:
         data_list = [im.data]
-        dim_list = [im.dim]
 
     data_out_list = []
-    for data, dim in zip(data_list.copy(), dim_list.copy()):
+    for data in data_list:
         for arg_name, arg_value in arguments.todo:
             assert data is not None
 

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -101,6 +101,17 @@ def get_parser():
 
     optional = parser.add_argument_group("OPTIONAL ARGUMENTS")
     optional.add_argument(
+        '-volumewise',
+        type=int,
+        help='Specifying this option will process a 4D image in a "volumewise" manner:\n'
+             '  - Split the 4D input into individual 3D volumes\n'
+             '  - Apply the maths operations to each 3D volume\n'
+             '  - Merge the processed 3D volumes back into a single 4D output image',
+        required=False,
+        choices=(0, 1),
+        default=0
+    )
+    optional.add_argument(
         "-h",
         "--help",
         action="help",
@@ -408,152 +419,169 @@ def main(argv: Sequence[str]):
 
     # Actually do the computations
     im = Image(arguments.i)
-    data = im.data
-    for arg_name, arg_value in arguments.todo:
-        assert data is not None
 
-        if arg_name == "add":
-            if data.ndim == 4 and not arg_value:
-                # special case to sum a 4D volume across the t axis
-                data = np.sum(data, axis=3)
-            else:
+    # If volumewise is specified, treat 4D image as a set of 3D volumes
+    if arguments.volumewise:
+        data_list = [np.squeeze(arr, axis=3) for arr in np.array_split(im.data, im.data.shape[3], 3)]
+        dim = list(im.dim)
+        dim[3] = 1  # Replace 4D dim with 1 (indicating single 3D volume)
+        dim_list = [tuple(dim)] * len(data_list)
+    else:
+        data_list = [im.data]
+        dim_list = [im.dim]
+
+    data_out_list = []
+    for data, dim in zip(data_list.copy(), dim_list.copy()):
+        for arg_name, arg_value in arguments.todo:
+            assert data is not None
+
+            if arg_name == "add":
+                if data.ndim == 4 and not arg_value:
+                    # special case to sum a 4D volume across the t axis
+                    data = np.sum(data, axis=3)
+                else:
+                    try:
+                        list_data = get_data_arrays(data.shape, arg_value)
+                    except ValueError as e:
+                        printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
+                    data += np.sum(list_data, axis=0)
+
+            elif arg_name == "sub":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                data += np.sum(list_data, axis=0)
+                data -= np.sum(list_data, axis=0)
 
-        elif arg_name == "sub":
-            try:
-                list_data = get_data_arrays(data.shape, arg_value)
-            except ValueError as e:
-                printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-            data -= np.sum(list_data, axis=0)
+            elif arg_name == "mul":
+                if data.ndim == 4 and not arg_value:
+                    # special case to multiply a 4D volume across the t axis
+                    data = np.prod(data, axis=3)
+                else:
+                    try:
+                        list_data = get_data_arrays(data.shape, arg_value)
+                    except ValueError as e:
+                        printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
+                    data *= np.prod(list_data, axis=0)
 
-        elif arg_name == "mul":
-            if data.ndim == 4 and not arg_value:
-                # special case to multiply a 4D volume across the t axis
-                data = np.prod(data, axis=3)
-            else:
+            elif arg_name == "div":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                data *= np.prod(list_data, axis=0)
+                data /= np.prod(list_data, axis=0)
 
-        elif arg_name == "div":
-            try:
-                list_data = get_data_arrays(data.shape, arg_value)
-            except ValueError as e:
-                printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-            data /= np.prod(list_data, axis=0)
+            elif arg_name == "mean":
+                axis = ('x', 'y', 'z', 't').index(arg_value)
+                if axis >= data.ndim:
+                    # Averaging a 3D image over time, nothing to do
+                    pass
+                else:
+                    data = np.mean(data, axis)
+                    if axis < 3:
+                        # Averaging over a spatial axis, we should preserve it
+                        data = np.expand_dims(data, axis)
 
-        elif arg_name == "mean":
-            axis = ('x', 'y', 'z', 't').index(arg_value)
-            if axis >= data.ndim:
-                # Averaging a 3D image over time, nothing to do
-                pass
+            elif arg_name == "rms":
+                data = data.astype(float)
+                axis = ('x', 'y', 'z', 't').index(arg_value)
+                if axis >= data.ndim:
+                    # Taking the mean across time for a 3D image has no effect.
+                    # Because of this, RMS is just squaring then sqrting (i.e. abs)
+                    data = np.abs(data)
+                else:
+                    data = np.sqrt(np.mean(np.square(data), axis))
+                    if axis < 3:
+                        # Taking RMS over a spatial axis, we should preserve it
+                        data = np.expand_dims(data, axis)
+
+            elif arg_name == "std":
+                axis = ('x', 'y', 'z', 't').index(arg_value)
+                if axis >= data.ndim or data.shape[axis] == 1:
+                    printv("ERROR: Zero division while taking -std along a singleton dimension", 1, 'error')
+                else:
+                    data = np.std(data, axis, ddof=1),
+                    if axis < 3:
+                        # Taking std over a spatial axis, we should preserve it
+                        data = np.expand_dims(data, axis)
+
+            elif arg_name == "bin":
+                bin_thr = arg_value
+                data = sct_math.binarize(data, bin_thr)
+
+            elif arg_name == "otsu":
+                nbins = arg_value
+                data = sct_math.otsu(data, nbins)
+
+            elif arg_name == "adap":
+                block_size, offset = arg_value
+                data = sct_math.adap(data, block_size, offset)
+
+            elif arg_name == "otsu_median":
+                size, n_iter = arg_value
+                data = sct_math.otsu_median(data, size, n_iter)
+
+            elif arg_name == "percent":
+                percentile = arg_value
+                data = sct_math.perc(data, percentile)
+
+            elif arg_name == "thr":
+                threshold = arg_value
+                data = sct_math.threshold(data, lthr=threshold)
+
+            elif arg_name == "uthr":
+                threshold = arg_value
+                data = sct_math.threshold(data, uthr=threshold)
+
+            elif arg_name == "dilate":
+                # This uses the global `shape` and `dim` values
+                size = arg_value
+                data = sct_math.dilate(data, size, shape, dim)
+
+            elif arg_name == "erode":
+                # This uses the global `shape` and `dim` values
+                size = arg_value
+                data = sct_math.erode(data, size, shape, dim)
+
+            elif arg_name in ["smooth", "laplacian"]:
+                # Adjust sigmas from millimeters to voxels
+                # This uses the resolution of the starting value `im`
+                sigmas = [mm/pixdim for mm, pixdim in zip(arg_value, im.dim[4:7])]
+                data = {
+                    "smooth": sct_math.smooth,
+                    "laplacian": sct_math.laplacian,
+                }[arg_name](data, sigmas)
+
+            elif arg_name == "denoise":
+                patch_radius, block_radius = arg_value
+                data = sct_math.denoise_nlmeans(data, patch_radius, block_radius)
+
+            elif arg_name in ["mi", "minorm", "corr"]:
+                # Reuses the header of the starting value `im`
+                compute_similarity(
+                    img1=Image(data, hdr=im.hdr),
+                    img2=Image(arg_value),
+                    fname_out=arguments.o,
+                    metric=arg_name,
+                    metric_full={
+                        'mi': 'Mutual information',
+                        'minorm': 'Normalized Mutual information',
+                        'corr': 'Pearson correlation coefficient',
+                    }[arg_name],
+                    verbose=verbose,
+                )
+                printv(f"\nDone! File created: {arguments.o}", verbose, 'info')
+                return
+
             else:
-                data = np.mean(data, axis)
-                if axis < 3:
-                    # Averaging over a spatial axis, we should preserve it
-                    data = np.expand_dims(data, axis)
+                assert arg_name == "symmetrize"
+                axis = arg_value
+                data = sct_math.symmetrize(data, axis)
 
-        elif arg_name == "rms":
-            data = data.astype(float)
-            axis = ('x', 'y', 'z', 't').index(arg_value)
-            if axis >= data.ndim:
-                # Taking the mean across time for a 3D image has no effect.
-                # Because of this, RMS is just squaring then sqrting (i.e. abs)
-                data = np.abs(data)
-            else:
-                data = np.sqrt(np.mean(np.square(data), axis))
-                if axis < 3:
-                    # Taking RMS over a spatial axis, we should preserve it
-                    data = np.expand_dims(data, axis)
+        data_out_list.append(data)
 
-        elif arg_name == "std":
-            axis = ('x', 'y', 'z', 't').index(arg_value)
-            if axis >= data.ndim or data.shape[axis] == 1:
-                printv("ERROR: Zero division while taking -std along a singleton dimension", 1, 'error')
-            else:
-                data = np.std(data, axis, ddof=1),
-                if axis < 3:
-                    # Taking std over a spatial axis, we should preserve it
-                    data = np.expand_dims(data, axis)
-
-        elif arg_name == "bin":
-            bin_thr = arg_value
-            data = sct_math.binarize(data, bin_thr)
-
-        elif arg_name == "otsu":
-            nbins = arg_value
-            data = sct_math.otsu(data, nbins)
-
-        elif arg_name == "adap":
-            block_size, offset = arg_value
-            data = sct_math.adap(data, block_size, offset)
-
-        elif arg_name == "otsu_median":
-            size, n_iter = arg_value
-            data = sct_math.otsu_median(data, size, n_iter)
-
-        elif arg_name == "percent":
-            percentile = arg_value
-            data = sct_math.perc(data, percentile)
-
-        elif arg_name == "thr":
-            threshold = arg_value
-            data = sct_math.threshold(data, lthr=threshold)
-
-        elif arg_name == "uthr":
-            threshold = arg_value
-            data = sct_math.threshold(data, uthr=threshold)
-
-        elif arg_name == "dilate":
-            # This uses the global `shape` and `dim` values
-            size = arg_value
-            data = sct_math.dilate(data, size, shape, dim)
-
-        elif arg_name == "erode":
-            # This uses the global `shape` and `dim` values
-            size = arg_value
-            data = sct_math.erode(data, size, shape, dim)
-
-        elif arg_name in ["smooth", "laplacian"]:
-            # Adjust sigmas from millimeters to voxels
-            # This uses the resolution of the starting value `im`
-            sigmas = [mm/pixdim for mm, pixdim in zip(arg_value, im.dim[4:7])]
-            data = {
-                "smooth": sct_math.smooth,
-                "laplacian": sct_math.laplacian,
-            }[arg_name](data, sigmas)
-
-        elif arg_name == "denoise":
-            patch_radius, block_radius = arg_value
-            data = sct_math.denoise_nlmeans(data, patch_radius, block_radius)
-
-        elif arg_name in ["mi", "minorm", "corr"]:
-            # Reuses the header of the starting value `im`
-            compute_similarity(
-                img1=Image(data, hdr=im.hdr),
-                img2=Image(arg_value),
-                fname_out=arguments.o,
-                metric=arg_name,
-                metric_full={
-                    'mi': 'Mutual information',
-                    'minorm': 'Normalized Mutual information',
-                    'corr': 'Pearson correlation coefficient',
-                }[arg_name],
-                verbose=verbose,
-            )
-            printv(f"\nDone! File created: {arguments.o}", verbose, 'info')
-            return
-
-        else:
-            assert arg_name == "symmetrize"
-            axis = arg_value
-            data = sct_math.symmetrize(data, axis)
+    # Reconstruct output data array from processed volumes
+    data = np.stack(data_out_list, axis=3) if len(data_out_list) > 1 else data_out_list[0]
 
     # Save the final image with the requested dtype
     Image(data, hdr=im.hdr).save(arguments.o, dtype=arguments.type)

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -422,12 +422,12 @@ def main(argv: Sequence[str]):
 
     # If volumewise is specified, treat 4D image as a set of 3D volumes
     if arguments.volumewise:
-        data_list = [np.squeeze(arr, axis=3) for arr in np.array_split(im.data, im.data.shape[3], 3)]
+        data_in_list = [np.squeeze(arr, axis=3) for arr in np.array_split(im.data, im.data.shape[3], 3)]
     else:
-        data_list = [im.data]
+        data_in_list = [im.data]
 
     data_out_list = []
-    for data in data_list:
+    for data in data_in_list:
         for arg_name, arg_value in arguments.todo:
             assert data is not None
 

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -127,6 +127,30 @@ def test_add_mul_4d_image_with_no_argument(op, tmp_path):
         assert np.all(data_out == val ** n_vol)
 
 
+@pytest.mark.parametrize('op', ['-add', '-mul'])
+def test_add_mul_4d_image_with_volumewise(op, tmp_path):
+    """Test that passing a 4D image with '-volumewise' operates on the 3D volumes."""
+    # Generate input image
+    base_dim = [20, 20, 20]
+    n_vol = 5
+    dim = base_dim + [n_vol]
+    path_im = str(tmp_path / "im.nii.gz")
+    val = 2
+    val_op = 5
+    Image(np.ones(dim) * val).save(path_im)
+    # Generate output image
+    path_out = str(tmp_path / "im_out.nii.gz")
+    sct_maths.main(["-i", path_im, op, str(val_op), "-volumewise", "1", "-o", path_out])
+    # Validate output data
+    data_out = Image(path_out).data
+    dim_out = list(data_out.shape)
+    assert dim_out == dim
+    if op == '-add':
+        assert np.all(data_out == val + val_op)
+    elif op == '-mul':
+        assert np.all(data_out == val * val_op)
+
+
 @pytest.mark.parametrize('similarity_arg', ['-mi', '-minorm', '-corr'])
 def test_similarity_metrics(tmp_path, similarity_arg):
     # Compute similarity between identical images


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR adds a `-volumewise` argument to automate the steps described in issue #4181:

> 1. Run `sct_image -split t my-image.nii.gz` to generate a separate file for each 3D volume.
> 2. Run the actual `sct_maths` transformation in a bash loop over each file.
> 3. Run `sct_image -concat t my-image_t*.nii.gz` to recombine the 3D volumes into a single 4D file.

Instead, in this PR, we split the input data array, run the requested operations on each 3D volume, then recombine the data array.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4181.
