### PR TITLE
Update contrast agnostic model to v2.4 (now improved for lumbar t2w + PSIR/STIR images)

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -139,7 +139,7 @@ MODELS = {
     #       - Binarization is applied within SCT code
     "model_seg_sc_contrast_agnostic_softseg_monai": {
         "url": [
-            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.3/model_soft_bin_20240410-1136.zip"
+            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.4/model_soft_bin_20240425-170840.zip"
         ],
         "description": "Spinal cord segmentation agnostic to MRI contrasts using MONAI-based nnUNet model",
         "contrasts": ["any"],


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The differences between v2.3 and 2.4 seem to be mainly focused on lumbar t2w and PSIR/STIR images: [diff of release body](https://www.diffchecker.com/WSVngW4s/)

This should be a good test for our "keep models up to date" code. If everything works correctly, you should be able to check out this branch, then run the `sct_deepseg -task` command, and the code will automatically verify the version of the model and download the newest version if your local version is out of date.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4509.
