### PR TITLE
Increase timeout of `mutex` to avoid `AlreadyLocked` errors with many concurrent processes

### DIFF
--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -277,7 +277,7 @@ def mutex(name):
     We use a mutex over a lock because the mutex doesn't depend on the destination
     of the locked files, which allows us to avoid locking on e.g. NFS-mounted drives.
     """
-    semaphore = portalocker.BoundedSemaphore(maximum=1, name=name)
+    semaphore = portalocker.BoundedSemaphore(maximum=1, name=name, timeout=60, check_interval=0.1)
     semaphore.acquire()
     try:
         yield semaphore

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -20,13 +20,13 @@ def test_many_qc():
     if multiprocessing.cpu_count() < 2:
         pytest.skip("Can't test parallel behaviour")
 
-    p = multiprocessing.Pool(2)
+    p = multiprocessing.Pool(multiprocessing.cpu_count())
 
     with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
         # This `try, finally` pattern mitigates hanging with pytest-cov
         # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3661#issuecomment-1029057900
         try:
-            p.map(gen_qc, [tmpdir] * 5)
+            p.map(gen_qc, [tmpdir] * (multiprocessing.cpu_count() * 2))
         finally:
             p.close()  # Marks the pool as closed.
             p.join()   # Waits for workers to exit.

--- a/testing/api/test_qc_parallel.py
+++ b/testing/api/test_qc_parallel.py
@@ -2,6 +2,8 @@
 
 from tempfile import TemporaryDirectory
 import pytest
+import logging
+import sys
 
 import multiprocessing
 
@@ -17,6 +19,13 @@ def gen_qc(path_qc):
 
 def test_many_qc():
     """Test many qc images can be made in parallel"""
+    # Turn on debug logging for fs.py to check mutex acquire/release times
+    # To check this output locally, run: `sct_testing -o log_cli=true testing/api/test_qc_parallel.py::test_many_qc`
+    screen_handler = logging.StreamHandler(stream=sys.stderr)
+    logger = logging.getLogger("portalocker.utils")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(screen_handler)
+
     if multiprocessing.cpu_count() < 2:
         pytest.skip("Can't test parallel behaviour")
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When many processes are running (e.g. `sct_run_batch -jobs 32`), we may have many different subjects trying to write to the QC report at one time. To avoid corruption/file overwriting, we limit the QC report to 1 process at a time, while other processes have to wait their turn. By default, the timeout is 5s, after which an `AlreadyLocked` error will occur.

To fix this, I first amended our parallel QC test to try to better catch this issue, since this error only occurs when there are many jobs running, but the test only checked against `jobs=2`. (Anecdotally, 2-8 jobs will be able to acquire the lock on first try, but 16+ jobs will start to back up, causing waits and re-attempts to acquire the lock.) Also, I modified portalocker's logger so that we can see `portalocker`'s internal behavior when run to its limits. To see the new `DEBUG` output locally, run:

```
sct_testing -o log_cli=true testing/api/test_qc_parallel.py::test_many_qc
```

Then, I increased the timeout to allow more time for older processes to eventually acquire the lock.

(Note: I also sped up the check interval a little (`0.25` -> `0.1`) in the hopes of increasing the probability that "waiting" locks will acquire the lock ahead of new processes. That way, we lower the possibility of new processes cutting in line and delaying a single old process that just can't seem to acquire the lock.)

I think ideally, we would try to optimize the code that occurs under the lock (so that processes release the lock quicker). But, I think increasing the timeout is a much easier short-term solution. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4501.
