### PR TITLE
Add `matplotlib-inline` backend for compatibility with Jupyter notebooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,11 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
 ivadomed
 matplotlib
+# `matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive.
+# However, if the user runs `jupyter` from a separate environment and sets '%matplotlib inline', then SCT's
+# environment will be missing this backend, and SCT scripts will crash when trying to import matplotlib. So, we install
+# `matplotlib-inline` in our env by default to ensure that SCT scripts can be run in Jupyter notebooks without error.
+matplotlib-inline
 monai[nibabel]
 # Fresh Windows installations may be missing the C++ runtime library required by scikit-image.
 # Installing "Microsoft Visual C++ Redistributable for Visual Studio" will fix this too, but

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -68,7 +68,11 @@ def resolve_module(framework_name):
         'pytest-cov': ('pytest_cov', False),
         'urllib3[secure]': ('urllib3', False),
         'pytest-xdist': ('xdist', False),
-        'protobuf': ('google.protobuf', False)
+        'protobuf': ('google.protobuf', False),
+        # Importing `matplotlib_inline` requires IPython, but we don't install IPython (on purpose). This is because
+        # `matplotlib_inline` is only needed to run SCT scripts in Jupyter notebooks, and IPython would already be
+        # installed in the parent context. So, we map `matplotlib-inline` to None to skip import (which would fail).
+        'matplotlib-inline': (None, False)
     }
 
     try:

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -359,6 +359,10 @@ def main(argv: Sequence[str]):
 
         try:
             module_name, suppress_stderr = resolve_module(dep_pkg)
+            # If a module cannot be imported, then its `dep_pkg` name should be resolved to `module_name=None`
+            if module_name is None:
+                print_ok()
+                continue
             module = module_import(module_name, suppress_stderr)
             version = get_version(module)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

`matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive. However, if a user runs `jupyter` from a separate environment and sets '%matplotlib inline', then SCT's environment will be missing this backend, and SCT scripts will crash when trying to import matplotlib.

So, we install `matplotlib-inline` in our env by default to ensure that SCT scripts can be run in Jupyter notebooks without error. (The package is very light, and only adds one small additional sub-dependency `traitlets`.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4523.
