### PR TITLE
Simplify calls to `np.einsum`

### DIFF
--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -327,10 +327,10 @@ class Centerline:
         return coordinates - unit_derivatives * dot_products
 
     def get_in_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,nr->rm', rollaxis(self.inverse_matrices[indexes], 0, 3), (coordinates - self.points[indexes]).transpose())
+        return einsum('mnr,rn->rm', rollaxis(self.inverse_matrices[indexes], 0, 3), coordinates - self.points[indexes])
 
     def get_inverse_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,nr->rm', rollaxis(self.matrices[indexes], 0, 3), coordinates.transpose()) + self.points[indexes]
+        return einsum('mnr,rn->rm', rollaxis(self.matrices[indexes], 0, 3), coordinates) + self.points[indexes]
 
     def compute_vertebral_distribution(self, discs_levels, label_reference='C1'):
         """

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -327,10 +327,10 @@ class Centerline:
         return coordinates - unit_derivatives * dot_products
 
     def get_in_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,nr->mr', rollaxis(self.inverse_matrices[indexes], 0, 3), (coordinates - self.points[indexes]).transpose()).transpose()
+        return einsum('mnr,nr->rm', rollaxis(self.inverse_matrices[indexes], 0, 3), (coordinates - self.points[indexes]).transpose())
 
     def get_inverse_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,nr->mr', rollaxis(self.matrices[indexes], 0, 3), coordinates.transpose()).transpose() + self.points[indexes]
+        return einsum('mnr,nr->rm', rollaxis(self.matrices[indexes], 0, 3), coordinates.transpose()) + self.points[indexes]
 
     def compute_vertebral_distribution(self, discs_levels, label_reference='C1'):
         """

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -327,10 +327,14 @@ class Centerline:
         return coordinates - unit_derivatives * dot_products
 
     def get_in_plans_coordinates(self, coordinates, indexes):
-        return einsum('rmn,rn->rm', self.inverse_matrices[indexes], coordinates - self.points[indexes])
+        return einsum('rmn,rn->rm',  # matmul Rx2D and Rx1D to get Rx1D
+                      self.inverse_matrices[indexes],      # [r, m, n]
+                      coordinates - self.points[indexes])  # [r, n]
 
     def get_inverse_plans_coordinates(self, coordinates, indexes):
-        return einsum('rmn,rn->rm', self.matrices[indexes], coordinates) + self.points[indexes]
+        return einsum('rmn,rn->rm',  # matmul Rx2D and Rx1D to get Rx1D
+                      self.matrices[indexes],              # [r, m, n]
+                      coordinates) + self.points[indexes]  # [r, n]
 
     def compute_vertebral_distribution(self, discs_levels, label_reference='C1'):
         """

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -7,7 +7,7 @@ License: see the file LICENSE
 
 from operator import itemgetter
 
-from numpy import dot, cross, array, einsum, stack, rollaxis, zeros
+from numpy import dot, cross, array, einsum, stack, zeros
 from numpy.linalg import norm, inv
 import numpy as np
 from scipy.spatial import cKDTree
@@ -327,10 +327,10 @@ class Centerline:
         return coordinates - unit_derivatives * dot_products
 
     def get_in_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,rn->rm', rollaxis(self.inverse_matrices[indexes], 0, 3), coordinates - self.points[indexes])
+        return einsum('rmn,rn->rm', self.inverse_matrices[indexes], coordinates - self.points[indexes])
 
     def get_inverse_plans_coordinates(self, coordinates, indexes):
-        return einsum('mnr,rn->rm', rollaxis(self.matrices[indexes], 0, 3), coordinates) + self.points[indexes]
+        return einsum('rmn,rn->rm', self.matrices[indexes], coordinates) + self.points[indexes]
 
     def compute_vertebral_distribution(self, discs_levels, label_reference='C1'):
         """


### PR DESCRIPTION
This is a tiny refactor to simplify two lines of code in `types.py`, since I recently had to dig through this file for debugging.

The reason is that:
- `np.transpose` is generally a little confusing to the reader, so it's best to set up proper conventions up-front and avoid transposes if possible. (It's not always possible, though.)
- `np.einsum` is a powerful tool, but it's a bit hard to read. Let's not make it harder than it needs to be.
- `np.rollaxis` is massively confusing, so it's really best to avoid it.

And in the case of `np.einsum`, we have complete control over the ordering of axes for the inputs and the outputs, so we really can avoid transposes and rollaxes. (This is the equivalent of getting rid of double negatives: it makes things easier to read!)