### PR TITLE
Restrict `numpy<2` to avoid upstream errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ nilearn
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
 nnunetv2!=2.4.0,!=2.4.1,>=2.3.1
-numpy
+# SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later.
+numpy<2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ nilearn
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
 nnunetv2!=2.4.0,!=2.4.1,>=2.3.1
-# SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later.
+# SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later. See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
 numpy<2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Numpy just upgraded to 2.0.0 on Sunday, June 16th. Many of our dependencies are not yet ready for numpy==2.0.0, so we are forced to restrict `numpy<2` for now. (Numpy themselves also recommend this in their error message.)

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses #4535. 

(We should probably keep the issue open as a reminder to periodically check whether `numpy==2.0.0` is viable. I can take care of reporting issues upstream to our more niche medical imaging packages to ensure that this gets fixed in a timely manner.)
