### PR TITLE
Include the SCT version in the straightening.cache

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -22,7 +22,7 @@ from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_loglevel, __version__
 from spinalcordtoolbox.utils.fs import tmp_create, cache_signature, cache_valid, cache_save, copy, extract_fname, rmtree
 from spinalcordtoolbox.math import threshold, laplacian
 
@@ -307,6 +307,7 @@ def main(argv: Sequence[str]):
     # check if warp_curve2straight and warp_straight2curve already exist (i.e. no need to do it another time)
     cache_sig = cache_signature(
         input_files=[fname_in, fname_seg],
+        input_params={"version": __version__},
     )
     if (cache_valid(os.path.join(curdir, "straightening.cache"), cache_sig)
             and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz"))

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -32,8 +32,7 @@ from spinalcordtoolbox.utils.fs import (copy, extract_fname, check_file_exist, r
                                         cache_save, cache_signature, cache_valid, tmp_create)
 from spinalcordtoolbox.utils.shell import (SCTArgumentParser, ActionCreateFolder, Metavar, list_type,
                                            printv, display_viewer_syntax)
-from spinalcordtoolbox.utils.sys import set_loglevel, init_sct, run_proc
-from spinalcordtoolbox.utils.sys import __data_dir__
+from spinalcordtoolbox.utils.sys import set_loglevel, init_sct, run_proc, __data_dir__, __version__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.scripts import sct_apply_transfo, sct_resample
@@ -532,6 +531,7 @@ def main(argv: Sequence[str]):
             ]
         cache_sig = cache_signature(
             input_files=cache_input_files,
+            input_params={"version": __version__},
         )
         if (cache_valid(os.path.join(curdir, "straightening.cache"), cache_sig)
                 and os.path.isfile(fn_warp_curve2straight)

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file, convert, add_suffix
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, __version__
 from spinalcordtoolbox.utils.fs import tmp_create, cache_save, cache_signature, cache_valid, copy, \
     extract_fname, rmtree
 from spinalcordtoolbox.math import smooth
@@ -197,8 +197,10 @@ def main(argv: Sequence[str]):
     # Straighten the spinal cord
     # straighten segmentation
     printv('\nStraighten the spinal cord using centerline/segmentation...', verbose)
-    cache_sig = cache_signature(input_files=[fname_anat_rpi, fname_centerline_rpi],
-                                input_params={"x": "spline"})
+    cache_sig = cache_signature(
+        input_files=[fname_anat_rpi, fname_centerline_rpi],
+        input_params={"x": "spline", "version": __version__},
+    )
     cachefile = os.path.join(curdir, "straightening.cache")
     if (
         cache_valid(cachefile, cache_sig)

--- a/testing/api/test_utils_fs.py
+++ b/testing/api/test_utils_fs.py
@@ -1,0 +1,14 @@
+# pytest unit tests for spinalcordtoolbox.utils.fs
+
+from spinalcordtoolbox.utils import fs
+
+
+def test_cache_signature():
+    """Test that input_params are taken into account in the signature."""
+    signatures = [
+        fs.cache_signature(input_params={}),
+        fs.cache_signature(input_params={"version": "1"}),
+        fs.cache_signature(input_params={"version": "2"}),
+        fs.cache_signature(input_params={"version": "2", "x": "spline"}),
+    ]
+    assert len(signatures) == len(set(signatures))

--- a/testing/api/test_utils_shell.py
+++ b/testing/api/test_utils_shell.py
@@ -1,4 +1,4 @@
-# pytest unit tests for spinalcordtoolbox.utils
+# pytest unit tests for spinalcordtoolbox.utils.shell
 
 import os
 import sys


### PR DESCRIPTION
We recently fixed some bugs in the straightening code (see #4514), so we need to make sure that SCT doesn't re-use cached results from before the fix.

Fixes #4526.