### PR TITLE
Align the lock names for `qc.py` and `qc2.py`

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -585,7 +585,7 @@ class QcReport:
         logger.debug('Description file: %s', self.qc_results)
 
         # Use a mutex on a hash of the QC path, so that we use a unique mutex per target QC report
-        with mutex(f"sct_qc-{os.path.basename(path_qc)}-{md5(self.path_qc.encode('utf-8')).hexdigest()}"):
+        with mutex(f"sct_qc-{md5(os.path.realpath(path_qc).encode('utf-8')).hexdigest()}"):
             # results = []
             # Create path to store json files
             path_json, _ = os.path.split(self.qc_results)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -585,7 +585,9 @@ class QcReport:
         logger.debug('Description file: %s', self.qc_results)
 
         # Use a mutex on a hash of the QC path, so that we use a unique mutex per target QC report
-        with mutex(f"sct_qc-{md5(os.path.realpath(path_qc).encode('utf-8')).hexdigest()}"):
+        realpath = os.path.realpath(path_qc)
+        basename = os.path.basename(realpath)
+        with mutex(f"sct_qc-{basename}-{md5(realpath.encode('utf-8')).hexdigest()}"):
             # results = []
             # Create path to store json files
             path_json, _ = os.path.split(self.qc_results)

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -7,6 +7,7 @@ License: see the file LICENSE
 
 from contextlib import contextmanager
 import datetime
+from hashlib import md5
 import importlib.resources
 from importlib.abc import Traversable
 import json
@@ -89,7 +90,7 @@ def create_qc_entry(
             raise FileNotFoundError(f"Required QC image '{img_type}' was not found at the expected path: '{path}')")
 
     # Use mutex to ensure that we're only generating shared QC assets using one process at a time
-    with mutex(name="sct_qc"):
+    with mutex(f"sct_qc-{md5(str(path_qc.resolve()).encode('utf-8')).hexdigest()}"):
         # Create a json file for the new QC report entry
         path_json = path_qc / '_json'
         path_json.mkdir(parents=True, exist_ok=True)

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -90,7 +90,8 @@ def create_qc_entry(
             raise FileNotFoundError(f"Required QC image '{img_type}' was not found at the expected path: '{path}')")
 
     # Use mutex to ensure that we're only generating shared QC assets using one process at a time
-    with mutex(f"sct_qc-{md5(str(path_qc.resolve()).encode('utf-8')).hexdigest()}"):
+    realpath = path_qc.resolve()
+    with mutex(f"sct_qc-{realpath.name}-{md5(str(realpath).encode('utf-8')).hexdigest()}"):
         # Create a json file for the new QC report entry
         path_json = path_qc / '_json'
         path_json.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
They're locking the same thing, so they should use the same lock name.

* ~~It's not very useful to have `os.path.basename(path_qc)` in the name, since it will most likely just be `qc` for all reports, which is not informative.~~
* Using `os.path.realpath` instead of `os.path.abspath` (or nothing at all) will resolve any potential symlinks in the path, and return a "canonical" name for the qc report path.
* Also, `os.path.realpath` should align well with `pathlib.Path.resolve`, whereas `os.path.abspath` **doesn't** behave the same way as `pathlib.Path.abspath`: the former normalizes path components like `/./` and `/../`, but the latter keeps them unchanged.

Fixes #4539.