### PR TITLE
Add example command for `-p sct_detect_pmj`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -19,7 +19,7 @@ def get_parser():
         description='Generate Quality Control (QC) report following SCT processing.',
         epilog='Examples:\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc\n'
-               'sct_qc -i t2.nii.gz -s t2_pmj.nii.gz -p sct_detect_pmj'
+               'sct_qc -i t2.nii.gz -s t2_pmj.nii.gz -p sct_detect_pmj\n'
                'sct_qc -i t2.nii.gz -s t2_seg_labeled.nii.gz -p sct_label_vertebrae\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc -qc-dataset mydata -qc-subject sub-45\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -d t2_lesion.nii.gz -p sct_deepseg_lesion -plane axial'

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -19,6 +19,7 @@ def get_parser():
         description='Generate Quality Control (QC) report following SCT processing.',
         epilog='Examples:\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc\n'
+               'sct_qc -i t2.nii.gz -s t2_pmj.nii.gz -p sct_detect_pmj'
                'sct_qc -i t2.nii.gz -s t2_seg_labeled.nii.gz -p sct_label_vertebrae\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc -qc-dataset mydata -qc-subject sub-45\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -d t2_lesion.nii.gz -p sct_deepseg_lesion -plane axial'


### PR DESCRIPTION
This is a super minor PR adding an example for `-p sct_detect_pmj` to the `sct_qc` function.

Why? Because it was not clear whether `-p sct_detect_pmj` requires only `-s` or `-s` and `-d` flags; context: https://github.com/ivadomed/model-spinal-rootlets/pull/53/files#r1652958802.

Inspiration for the example: https://github.com/sct-pipeline/pmj-based-csa/blob/419ece49c81782f23405d89c7b4b15d8e03ed4bd/identify_nerve.sh#L65

