### PR TITLE
Clarify that `sct_label_utils -disc` does not involve orthogonal projection

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -122,7 +122,7 @@ def get_parser():
     func_group.add_argument(
         '-disc',
         metavar=Metavar.file,
-        help="Project disc labels ('-disc') onto a spinal cord segmentation ('-i') to create a labeled segmentation.\n"
+        help="Project disc labels ('-disc') onto a spinal cord segmentation ('-i') within the axial plane to create a labeled segmentation.\n"
              "Note: Unlike 'sct_label_vertebrae -discfile', this function does NOT involve cord straightening.\n"
              "Note: This method does NOT involve orthogonal projection onto the cord centerline. "
              "Details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3395#issuecomment-1478435265\n"

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -122,8 +122,10 @@ def get_parser():
     func_group.add_argument(
         '-disc',
         metavar=Metavar.file,
-        help="Project disc labels (-disc) onto a spinal cord segmentation (-i) to create a labeled segmentation. "
-             "Note: Unlike 'sct_label_vertebrae -discfile', this function does not involve cord straightening. "
+        help="Project disc labels ('-disc') onto a spinal cord segmentation ('-i') to create a labeled segmentation.\n"
+             "Note: Unlike 'sct_label_vertebrae -discfile', this function does NOT involve cord straightening.\n"
+             "Note: This method does NOT involve orthogonal projection onto the cord centerline. "
+             "Details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3395#issuecomment-1478435265\n"
              "The disc labeling follows the convention: "
              "https://spinalcordtoolbox.com/user_section/tutorials/vertebral-labeling/labeling-conventions.html"
     )


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This is a minor PR clarifying that `sct_label_utils -disc` does NOT involve the orthogonal projection of the discs onto the cord centerline. Instead, it just takes the slice corresponding to the disc. Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3395#issuecomment-1478435265

We had a discussion about `sct_label_utils -disc` with @naga-karthik and @NathanMolinier and it was not intuitively clear whether the orthogonal projection is done or not.

