### PR TITLE
Update redirected citation link

### DIFF
--- a/documentation/source/user_section/citing_sct.rst
+++ b/documentation/source/user_section/citing_sct.rst
@@ -67,7 +67,7 @@ The table below provides individual references for novel methods used in SCT's :
    * - ``sct_get_centerline``
      - `Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018 <https://www.sciencedirect.com/science/article/pii/S136184151730186X>`__
    * - ``sct_label_vertebrae``
-     - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <https://doi.org/10.1155/2014/719520>`__
+     - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <https://onlinelibrary.wiley.com/doi/10.1155/2014/719520>`__
    * - ``sct_process_segmentation -pmj``
      - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
    * - ``sct_process_segmentation -normalize``

--- a/documentation/source/user_section/citing_sct.rst
+++ b/documentation/source/user_section/citing_sct.rst
@@ -67,7 +67,7 @@ The table below provides individual references for novel methods used in SCT's :
    * - ``sct_get_centerline``
      - `Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018 <https://www.sciencedirect.com/science/article/pii/S136184151730186X>`__
    * - ``sct_label_vertebrae``
-     - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <https://downloads.hindawi.com/journals/ijbi/2014/719520.pdf>`__
+     - `Ullmann et al. Automatic labeling of vertebral levels using a robust template-based approach. Int J Biomed Imaging 2014 <https://doi.org/10.1155/2014/719520>`__
    * - ``sct_process_segmentation -pmj``
      - `Bédard S, Cohen-Adad J. Automatic measure and normalization of spinal cord cross-sectional area using the pontomedullary junction. Frontiers in Neuroimaging 2022 <https://doi.org/10.3389/fnimg.2022.1031253>`__
    * - ``sct_process_segmentation -normalize``


### PR DESCRIPTION
Although the current URL works in the browser, every day it shows up as the only broken link in the link checker workflow. This ~~DOI~~ direct link should be more stable.