### PR TITLE
Added T2w dog template

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -82,6 +82,14 @@ DATASET_DICT = {
         "download_type": "Templates",
         "default": False,
     },
+    "template-dog": {
+        "mirrors": [
+            "https://github.com/spinalcordtoolbox/template-dog/releases/download/r20240709/templatedog_r20240709.zip"
+        ],
+        "default_location": os.path.join(__sct_dir__, "data", "template-dog"),
+        "download_type": "Templates",
+        "default": False,
+    },
     "binaries_linux": {
         "mirrors": [
             "https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/r20221109/spinalcordtoolbox-binaries_linux.tar.gz",


### PR DESCRIPTION
Fixes #4560 

This PR makes the latest T2w dog template (released here: "https://github.com/spinalcordtoolbox/template-dog/releases/tag/r20240709) downloadable using `sct_download_data`. Below are the steps to test this PR:

1. Download the template folder:
```
sct_download_data -d template-dog -o <OUTPUT_PATH>
```
2. Download data/test data from here: https://github.com/spinalcordtoolbox/template-dog#data
3. Run registration -- register `sub-HarshmanDobby` to the template:
```
sct_register_to_template -i sub-HarshmanDobby_T2w.nii.gz -s sub-HarshmanDobby_T2w_label-SC_seg.nii.gz -ldisc sub-HarshmanDobby_T2w_labels-disc.nii.gz -t <PATH_TO_DOWLOADED_TEMPLATE_FOLDER> -c t2 -s-template-id 2 -param step=1,type=seg,algo=centermassrot:step=2,type=im,algo=syn,metric=CC,iter=3 -ofolder HB_to_temp -qc qc_HB_to_temp
```