### PR TITLE
Avoid buggy version of `nnunetv2` that produces empty output predictions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,10 @@ monai[nibabel]
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
+# 2.4.2 causes empty predictions (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4556)
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
-nnunetv2!=2.4.0,!=2.4.1,>=2.3.1
+nnunetv2==2.3.1
 # SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later. See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
 numpy<2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Given the comments in `requirements.txt`, it seems like 2.3.1 is the only safe version of `nnunetv2` we can rely on for now.

Action item for myself: 

- [ ] Report this upstream and help debug why this issue is occurring in the first place. (Maybe after SCT v6.4, since I have a backlog I need to work through before I can spend time digging into a tricky upstream issue.)

## Testing

Testing this is a bit tricky, because our test (on cropped input) still works fine on 2.4.2? The problem only reveals itself on a full test image. 

Maybe we could write a test similar to the mouse test, and stick the large image in the new testing dataset?

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4556.
