### PR TITLE
Adjust QC canvas size by physical resolution to avoid tiny QC with anisotropic T2* images

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -313,7 +313,7 @@ class QcImage:
         #  - Sagittal mosaic: e.g. WxH = 3x20 slice images
         #  So, we want to scale the fig height to match this.
         #  NB: `size_fig` is in inches. So, dpi=300 --> 1500px, dpi=100 --> 500px, etc.
-        size_fig = [5, 5 * img.shape[0] / img.shape[1]]
+        size_fig = [5, 5 * img.shape[0] / img.shape[1] * float(self.aspect_img)]
 
         fig = mpl_figure.Figure()
         fig.set_size_inches(size_fig[0], size_fig[1], forward=True)


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Previously, we adjusted the canvas height by the image dimensions. However, for highly anisotropic images with thick axial slices, we also need to make sure to adjust by the pixel resolution. Otherwise, because there are so few axial slices, the canvas will get squished to a very small height.

Before:

![image](https://github.com/user-attachments/assets/0cdd81b5-293f-4f8d-a736-05cbff40c221)

After:

![image](https://github.com/user-attachments/assets/93480360-cb63-4d77-953c-0ddae6c8ab38)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4563.
