### PR TITLE
Set `norecursedirs` in `setup.cfg` to avoid pytest collecting tests from our dependencies within our `venv`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [tool:pytest]
 addopts = --verbose --show-capture=stderr --tb=native
 python_files = testing/**/test_*.py
+# The parent folder for SCT's conda installation is called `python`.
+norecursedirs = python
 markers =
     sct_testing: marks tests that belonged to previous testing harness (often used by users to verify installation)
 filterwarnings =


### PR DESCRIPTION
## Description

With `pytest==8.3.1`, pytest will recursively search our `conda` environment unless we explicitly set `norecursedirs`.

## Related issues/PRs

Fixes #4570.

For upstream details, see:

- https://github.com/pytest-dev/pytest/issues/12652
