### PR TITLE
Rescale flattened values from `[-1.0, 1.0]` back to their original range and datatype

### DIFF
--- a/spinalcordtoolbox/flattening.py
+++ b/spinalcordtoolbox/flattening.py
@@ -43,11 +43,12 @@ def flatten_sagittal(im_anat, im_centerline, verbose):
 
     # change type to float32 and scale between -1 and 1 as requested by img_as_float(). See #1790, #2069
     im_anat_flattened = change_type(im_anat, np.float32)
-    min_data, max_data = np.min(im_anat_flattened.data), np.max(im_anat_flattened.data)
-    im_anat_flattened.data -= min_data               # [min, max]   -> [ 0, max-min]
-    im_anat_flattened.data /= (max_data - min_data)  # [0, max-min] -> [ 0, 1]
-    im_anat_flattened.data *= 2                      # [0, 1]       -> [ 0, 2]
-    im_anat_flattened.data -= 1                      # [0, 2]       -> [-1, 1]
+    flattened_data = im_anat_flattened.data.copy()
+    min_data, max_data = np.min(flattened_data), np.max(flattened_data)
+    flattened_data -= min_data               # [min, max]   -> [ 0, max-min]
+    flattened_data /= (max_data - min_data)  # [0, max-min] -> [ 0, 1]
+    flattened_data *= 2                      # [0, 1]       -> [ 0, 2]
+    flattened_data -= 1                      # [0, 2]       -> [-1, 1]
 
     # loop and translate each axial slice, such that the flattened centerline is centered in the medial plane (R-L)
     for iz in range(nz):
@@ -57,18 +58,18 @@ def flatten_sagittal(im_anat, im_centerline, verbose):
         # tform = tf.SimilarityTransform(scale=1, rotation=0, translation=(translation_x, 0))
         tform = transform.SimilarityTransform(translation=(0, translation_x))
         # important to force input in float to skikit image, because it will output float values
-        img = img_as_float(im_anat_flattened.data[:, :, iz])
+        img = img_as_float(flattened_data[:, :, iz])
         img_reg = transform.warp(img, tform)
-        im_anat_flattened.data[:, :, iz] = img_reg
+        flattened_data[:, :, iz] = img_reg
 
     # Change [-1, 1] values back to the original range ([min, max])
-    im_anat_flattened.data += 1                      # [-1, 1]       -> [0, 2]
-    im_anat_flattened.data /= 2                      # [ 0, 2]       -> [0, 1]
-    im_anat_flattened.data *= (max_data - min_data)  # [ 0, 1]       -> [0, max-min]
-    im_anat_flattened.data += min_data               # [ 0, max-min] -> [min, max]
+    flattened_data += 1                      # [-1, 1]       -> [0, 2]
+    flattened_data /= 2                      # [ 0, 2]       -> [0, 1]
+    flattened_data *= (max_data - min_data)  # [ 0, 1]       -> [0, max-min]
+    flattened_data += min_data               # [ 0, max-min] -> [min, max]
 
     # change back to native orientation and datatype
     im_anat_flattened.change_orientation(orientation_native)
-    im_anat_flattened.data = im_anat_flattened.data.astype(im_anat.data.dtype)
+    im_anat_flattened.data = flattened_data.astype(im_anat.data.dtype)
 
     return im_anat_flattened

--- a/spinalcordtoolbox/flattening.py
+++ b/spinalcordtoolbox/flattening.py
@@ -61,7 +61,8 @@ def flatten_sagittal(im_anat, im_centerline, verbose):
     # Change [-1, 1] values back to the original range ([min, max])
     im_anat_flattened.data = (im_anat_flattened.data + 1) * (max_data - min_data) / 2
 
-    # change back to native orientation
+    # change back to native orientation and datatype
     im_anat_flattened.change_orientation(orientation_native)
+    im_anat_flattened.data = im_anat_flattened.data.astype(im_anat.data.dtype)
 
     return im_anat_flattened

--- a/spinalcordtoolbox/flattening.py
+++ b/spinalcordtoolbox/flattening.py
@@ -58,6 +58,9 @@ def flatten_sagittal(im_anat, im_centerline, verbose):
         img_reg = transform.warp(img, tform)
         im_anat_flattened.data[:, :, iz] = img_reg
 
+    # Change [-1, 1] values back to the original range ([min, max])
+    im_anat_flattened.data = (im_anat_flattened.data + 1) * (max_data - min_data) / 2
+
     # change back to native orientation
     im_anat_flattened.change_orientation(orientation_native)
 

--- a/spinalcordtoolbox/flattening.py
+++ b/spinalcordtoolbox/flattening.py
@@ -69,7 +69,7 @@ def flatten_sagittal(im_anat, im_centerline, verbose):
     flattened_data += min_data               # [ 0, max-min] -> [min, max]
 
     # change back to native orientation and datatype
-    im_anat_flattened.change_orientation(orientation_native)
     im_anat_flattened.data = flattened_data.astype(im_anat.data.dtype)
+    im_anat_flattened.change_orientation(orientation_native)
 
     return im_anat_flattened


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a very simple PR that restores the flattened image back to its original state to avoid user confusion.

I was uncertain whether to keep the scaled data as `float` or whether to convert back to original datatype (e.g. `int`). Converting back to `int` can cause some small rounding error (e.g. 350.6473 -> 351), but since this image is meant for visualization only, I figured that the rounding errors are not critical.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3737.
