### PR TITLE
Refactor `qc.py` to use `create_qc_entry`

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -776,10 +776,15 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         p_resample = p_resample_default
     elif p_resample == 0:   # If user specified `-resample 0`, turn off resampling
         p_resample = None
-    qcslice = SliceSubtype(im_list, p_resample=p_resample)
-    qc_report = QcReport(fname_in1, process, args, plane, path_qc, dpi, dataset, subject)
 
-    QcImage(
+    qcslice = object.__new__(SliceSubtype)
+    qcslice.__init__(im_list, p_resample=p_resample)
+
+    qc_report = object.__new__(QcReport)
+    qc_report.__init__(fname_in1, process, args, plane, path_qc, dpi, dataset, subject)
+
+    qc_image = object.__new__(QcImage)
+    qc_image.__init__(
         qc_report=qc_report,
         interpolation='none',
         action_list=action_list,
@@ -787,7 +792,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         stretch_contrast_method='equalized',
         fps=fps,
         draw_text=draw_text,
-    ).layout(
+    )
+    qc_image.layout(
         qcslice_layout=qcslice_layout,
         qcslice=qcslice,
     )

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -5,7 +5,6 @@ Copyright (c) 2017 Polytechnique Montreal <www.neuro.polymtl.ca>
 License: see the file LICENSE
 """
 
-import glob
 import os
 import json
 import logging
@@ -473,16 +472,6 @@ class QcReport:
 
     def abs_overlay_img_path(self):
         return os.path.join(self.path_qc, self.overlay_img_path)
-
-
-def get_json_data_from_path(path_json):
-    """Read all json files present in the given path, and output an aggregated json structure"""
-    results = []
-    for file_json in glob.iglob(os.path.join(path_json, '*.json')):
-        logger.debug('Opening: ' + file_json)
-        with open(file_json, 'r+') as fjson:
-            results.append(json.load(fjson))
-    return results
 
 
 def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None, path_qc=None, dataset=None,

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -109,33 +109,6 @@ class QcImage:
 
         return color_list
 
-    def __init__(self, qc_report, interpolation, action_list, process, stretch_contrast=True,
-                 stretch_contrast_method='contrast_stretching', fps=None, draw_text=True):
-        """
-        :param qc_report: QcReport: The QC report object
-        :param interpolation: str: Type of interpolation used in matplotlib
-        :param action_list: list: List of functions that generates a specific type of images. It can be seen as
-                                  "figures" of matplotlib to be shown. Ex: if 'listed_seg' is in the list, the process
-                                  will generate a figure with red segmentation.
-        :param process: str: Name of SCT function. e.g., sct_propseg
-        :param stretch_contrast: adjust image so as to improve contrast
-        :param stretch_contrast_method: str: {'contrast_stretching', 'equalized'}: Method for stretching contrast
-        :param fps: float: Number of frames per second for output gif images. It is only used for sct_fmri_moco and\
-        sct_dmri_moco
-        """
-        self.qc_report = qc_report
-        self.interpolation = interpolation
-        self.action_list = action_list
-        self.process = process
-        self._stretch_contrast = stretch_contrast
-        self._stretch_contrast_method = stretch_contrast_method
-        if stretch_contrast_method not in ['equalized', 'contrast_stretching']:
-            raise ValueError("Unrecognized stretch_contrast_method: {}.".format(stretch_contrast_method),
-                             "Try 'equalized' or 'contrast_stretching'")
-        self._fps = fps
-        self._draw_text = draw_text
-        self._centermass = None  # center of mass returned by slice.Axial.get_center()
-
     def listed_seg(self, mask, ax):
         """Create figure with red segmentation. Common scenario."""
         img = np.ma.masked_equal(mask, 0)
@@ -790,15 +763,19 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     qc_report.overlay_img_path = os.path.join(dataset, subject, contrast, process, qc_report.mod_date, f"overlay_img.{ext}")
 
     qc_image = object.__new__(QcImage)
-    qc_image.__init__(
-        qc_report=qc_report,
-        interpolation='none',
-        action_list=action_list,
-        process=process,
-        stretch_contrast_method='equalized',
-        fps=fps,
-        draw_text=draw_text,
-    )
+    qc_image.qc_report = qc_report
+    qc_image.interpolation = 'none'
+    qc_image.action_list = action_list
+    qc_image.process = process
+    qc_image._stretch_contrast = True
+    qc_image._stretch_contrast_method = 'equalized'
+    if 'equalized' not in ['equalized', 'contrast_stretching']:
+        raise ValueError("Unrecognized stretch_contrast_method: {}.".format('equalized'),
+                         "Try 'equalized' or 'contrast_stretching'")
+    qc_image._fps = fps
+    qc_image._draw_text = draw_text
+    qc_image._centermass = None  # center of mass returned by slice.Axial.get_center()
+
     qc_image.layout(
         qcslice_layout=qcslice_layout,
         qcslice=qcslice,

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -478,15 +478,6 @@ class QcReport:
     def abs_overlay_img_path(self):
         return os.path.join(self.path_qc, self.overlay_img_path)
 
-    def make_content_path(self):
-        """Creates the whole directory to contain the QC report
-
-        :return: return "root folder of the report" and the "furthest folder path" containing the images
-        """
-        # make a new or update Qc directory
-        target_img_folder = os.path.dirname(self.abs_background_img_path())
-        os.makedirs(target_img_folder, exist_ok=True)
-
     def update_description_file(self):
         """Create the description file with a JSON structure"""
         path_qc = self.path_qc
@@ -763,7 +754,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Get the aspect ratio (height/width) based on pixel size. Consider only the first 2 slices.
     qc_image.aspect_img, qc_image.aspect_mask = qcslice.aspect()[:2]
 
-    qc_image.qc_report.make_content_path()
+    target_img_folder = os.path.dirname(qc_report.abs_background_img_path())
+    os.makedirs(target_img_folder, exist_ok=True)
     logger.info('QcImage: layout with %s slice', qc_image.qc_report.plane)
 
     if qc_image.process in ['sct_fmri_moco', 'sct_dmri_moco']:

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -47,13 +47,14 @@ def create_qc_entry(
     plane: str,
     dataset: Optional[str],
     subject: Optional[str],
+    image_extension: str = 'png',
 ):
     """
     Generate a new QC report entry.
 
-    This context manager yields a tuple of two paths, to be used for the QC report images:
-    1. the path to `background_img.png`, and
-    2. the path to `overlay_img.png`.
+    This context manager yields a dict of two paths, to be used for the QC report images:
+    'path_background_img': the path to `background_img.{image_extension}`, and
+    'path_overlay_img': the path to `overlay_img.{image_extension}`.
 
     The body of the `with` block should create these two image files.
     When the `with` block exits, the QC report is updated, with proper file synchronization.
@@ -80,14 +81,14 @@ def create_qc_entry(
 
     # Ask the caller to generate the image files for the entry
     imgs_to_generate = {
-        'path_background_img': path_img / 'background_img.png',
-        'path_overlay_img':  path_img / 'overlay_img.png',
+        'path_background_img': path_img / f'background_img.{image_extension}',
+        'path_overlay_img':  path_img / f'overlay_img.{image_extension}',
     }
     yield imgs_to_generate
     # Double-check that the images were generated during the 'with:' block
     for img_type, path in imgs_to_generate.items():
         if not path.exists():
-            raise FileNotFoundError(f"Required QC image '{img_type}' was not found at the expected path: '{path}')")
+            raise FileNotFoundError(f"Required QC image '{img_type}' was not found at the expected path: '{path}'")
 
     # Use mutex to ensure that we're only generating shared QC assets using one process at a time
     realpath = path_qc.resolve()
@@ -130,6 +131,8 @@ def update_files(resource: Traversable, destination: Path):
     Make sure that an up-to-date copy of `resource` exists at `destination`,
     by creating or updating files and directories recursively.
     """
+    if resource.name in ['__pycache__']:
+        return  # skip this one
     path = destination / resource.name
     if resource.is_dir():
         path.mkdir(exist_ok=True)

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -8,7 +8,6 @@ License: see the file LICENSE
 # TODO: Replace slice by spinalcordtoolbox.image.Slicer
 
 import os
-import abc
 import logging
 import math
 
@@ -40,8 +39,6 @@ class Slice(object):
     IMPORTANT: Convention for orientation is "SAL"
 
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, images, p_resample=0.6):
         """
@@ -110,9 +107,8 @@ class Slice(object):
         nx, ny, nz, nt, px, py, pz, pt = image.dim
         return px / pz
 
-    @abc.abstractmethod
     def get_aspect(self, image):
-        return
+        raise NotImplementedError
 
     @staticmethod
     def crop(matrix, x, y, width, height):
@@ -185,7 +181,6 @@ class Slice(object):
                 np.nonzero(valid)[0],
                 A[valid])
 
-    @abc.abstractmethod
     def get_slice(self, data, i):
         """Abstract method to obtain a slice of a 3d matrix
 
@@ -193,16 +188,15 @@ class Slice(object):
         :param i: position to slice
         :return: 2D slice
         """
-        return
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def get_dim(self, image):
         """Abstract method to obtain the depth of the 3d matrix.
 
         :param image: input Image
         :returns: numpy.ndarray
         """
-        return
+        raise NotImplementedError
 
     def _axial_center(self, image):
         """Gets the center of mass in the axial plan
@@ -221,10 +215,9 @@ class Slice(object):
         Slice.inf_nan_fill(centers_y)
         return centers_x, centers_y
 
-    @abc.abstractmethod
     def mosaic(self):
         """Obtain matrices of the mosaics"""
-        return
+        raise NotImplementedError
 
     def single(self):
         """Obtain the matrices of the single slices. Flatten

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -160,30 +160,6 @@ class Slice(object):
         """Obtain matrices of the mosaics"""
         raise NotImplementedError
 
-    def single(self):
-        """Obtain the matrices of the single slices. Flatten
-
-        :returns: tuple of numpy.ndarray, matrix of the input 3D MRI
-                  containing the slices and matrix of the transformed 3D MRI
-                  to output containing the slices
-        """
-        if len(set([x.data.shape for x in self._images])) != 1:
-            raise ValueError("Volumes don't have the same size")
-
-        matrices = list()
-        # Retrieve the L-R center of the slice for each row (i.e. in the S-I direction).
-        index = self.get_center_spit()
-        # Loop across images and generate matrices for the image and the overlay
-        for image in self._images:
-            # Initialize matrix with zeros. This matrix corresponds to the 2d slice shown on the QC report.
-            matrix = np.zeros(image.dim[0:2])
-            for row in range(len(index)):
-                # For each slice, translate in the R-L direction to center the cord
-                matrix[row] = self.get_slice(image.data, int(np.round(index[row])))[row]
-            matrices.append(matrix)
-
-        return matrices
-
     def aspect(self):
         if len(self._4d_images) == 0:  # For 3D images
             return [self.get_aspect(x) for x in self._images]
@@ -424,6 +400,30 @@ class Sagittal(Slice):
                 lrslice_cropped = self.get_slice(image_cropped.data, i)
                 # Add the cropped slice to the matrix layout
                 self.add_slice(matrix, i, nb_column, lrslice_cropped)
+            matrices.append(matrix)
+
+        return matrices
+
+    def single(self):
+        """Obtain the matrices of the single slices. Flatten
+
+        :returns: tuple of numpy.ndarray, matrix of the input 3D MRI
+                  containing the slices and matrix of the transformed 3D MRI
+                  to output containing the slices
+        """
+        if len(set([x.data.shape for x in self._images])) != 1:
+            raise ValueError("Volumes don't have the same size")
+
+        matrices = list()
+        # Retrieve the L-R center of the slice for each row (i.e. in the S-I direction).
+        index = self.get_center_spit()
+        # Loop across images and generate matrices for the image and the overlay
+        for image in self._images:
+            # Initialize matrix with zeros. This matrix corresponds to the 2d slice shown on the QC report.
+            matrix = np.zeros(image.dim[0:2])
+            for row in range(len(index)):
+                # For each slice, translate in the R-L direction to center the cord
+                matrix[row] = self.get_slice(image.data, int(np.round(index[row])))[row]
             matrices.append(matrix)
 
         return matrices

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -15,7 +15,7 @@ import numpy as np
 from scipy.ndimage import center_of_mass
 from nibabel.nifti1 import Nifti1Image
 
-from spinalcordtoolbox.image import Image, split_img_data, check_image_kind
+from spinalcordtoolbox.image import Image, split_img_data
 from spinalcordtoolbox.resampling import resample_nib
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
@@ -39,31 +39,6 @@ class Slice(object):
     IMPORTANT: Convention for orientation is "SAL"
 
     """
-
-    def __init__(self, images, p_resample=0.6):
-        """
-        :param images: list of 3D or 4D volumes to be separated into slices.
-        """
-        self._images = list()  # 3d volumes
-        self._4d_images = list()  # 4d volumes
-        self._image_seg = None  # for cropping
-        self._absolute_paths = list()  # Used because change_orientation removes the field absolute_path
-        image_ref = None  # first pass: we don't have a reference image to resample to
-        for i, image in enumerate(images):
-            img = image.copy()
-            self._absolute_paths.append(img.absolutepath)  # change_orientation removes the field absolute_path
-            img.change_orientation('SAL')
-            if p_resample:
-                type_img = 'seg' if ('seg' in check_image_kind(img)) else 'im'  # condense seg/softseg into just 'seg'
-                img_r = self._resample_slicewise(img, p_resample, type_img=type_img, image_ref=image_ref)
-            else:
-                img_r = img.copy()
-            if img_r.dim[3] == 1:   # If image is 3D, nt = 1
-                self._images.append(img_r)
-                image_ref = self._images[0]  # 2nd and next passes: we resample any image to the space of the first one
-            else:
-                self._4d_images.append(img_r)
-                # image_ref = self._4d_images[0]  # img_dest is not covered for 4D volumes in resample_nib()
 
     def get_aspect(self, image):
         raise NotImplementedError

--- a/testing/api/test_reports.py
+++ b/testing/api/test_reports.py
@@ -1,6 +1,5 @@
 # pytest unit tests for spinalcordtoolbox.reports
 
-import os
 import logging
 
 import pytest
@@ -81,14 +80,6 @@ def t2_seg_image():
 def t2_path():
     t2_path = sct_test_path('t2')
     return t2_path
-
-
-def assert_qc_assets(path):
-    files = ('html/index.html', 'css/style.css', 'js/main.js')
-    for file_name in files:
-        assert os.path.exists(os.path.join(path, file_name))
-
-    assert os.path.isdir(os.path.join(path, 'imgs'))
 
 
 def test_label_vertebrae(t2_image, t2_seg_image, tmp_path):

--- a/testing/api/test_reports.py
+++ b/testing/api/test_reports.py
@@ -7,8 +7,8 @@ import pytest
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.reports.slice import Axial, Sagittal
-from spinalcordtoolbox.reports.qc import QcReport, QcImage
+from spinalcordtoolbox.reports.slice import Sagittal
+from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.sys import sct_test_path
 
 
@@ -86,35 +86,36 @@ def assert_qc_assets(path):
 
 
 def test_label_vertebrae(t2_image, t2_seg_image, tmp_path):
-    qc_report = QcReport(t2_image.absolutepath, 'sct_label_vertebrae', ['-a', '-b'], 'Sagittal', str(tmp_path))
-
-    QcImage(
-        qc_report=qc_report,
-        interpolation='spline36',
-        action_list=[QcImage.label_vertebrae],
-        process=qc_report.command,
-    ).layout(
-        qcslice_layout=lambda qcslice: qcslice.single(),
-        qcslice=Sagittal([t2_image, t2_seg_image]),
+    generate_qc(
+        fname_in1=t2_image.absolutepath,
+        fname_seg=t2_seg_image.absolutepath,
+        plane='Sagittal',
+        args=['-a', '-b'],
+        path_qc=str(tmp_path),
+        dataset='dat',
+        subject='sub',
+        process='sct_label_vertebrae',
     )
 
-    assert os.path.isfile(qc_report.abs_background_img_path())
-    assert os.path.isfile(qc_report.abs_overlay_img_path())
+    # check that some files exist
+    assert len(list(tmp_path.glob('dat/sub/*/sct_label_vertebrae/*/background_img.png'))) == 1
+    assert len(list(tmp_path.glob('dat/sub/*/sct_label_vertebrae/*/overlay_img.png'))) == 1
+    assert len(list(tmp_path.glob('_json/qc_*.json'))) == 1
 
 
 def test_propseg(t2_image, t2_seg_image, tmp_path):
-    qc_report = QcReport(t2_image.absolutepath, 'sct_propseg', ['-a'], 'Axial', str(tmp_path))
-
-    QcImage(
-        qc_report=qc_report,
-        interpolation='none',
-        action_list=[QcImage.listed_seg],
-        process=qc_report.command,
-    ).layout(
-        qcslice_layout=lambda qcslice: qcslice.mosaic(),
-        qcslice=Axial([t2_image, t2_seg_image]),
+    generate_qc(
+        fname_in1=t2_image.absolutepath,
+        fname_seg=t2_seg_image.absolutepath,
+        plane='Axial',
+        args=['-a'],
+        path_qc=str(tmp_path),
+        dataset='dat',
+        subject='sub',
+        process='sct_propseg',
     )
 
-    assert os.path.isfile(qc_report.abs_background_img_path())
-    assert os.path.isfile(qc_report.abs_overlay_img_path())
-    assert os.path.isfile(qc_report.qc_results)
+    # check that some files exist
+    assert len(list(tmp_path.glob('dat/sub/*/sct_propseg/*/background_img.png'))) == 1
+    assert len(list(tmp_path.glob('dat/sub/*/sct_propseg/*/overlay_img.png'))) == 1
+    assert len(list(tmp_path.glob('_json/qc_*.json'))) == 1

--- a/testing/api/test_reports.py
+++ b/testing/api/test_reports.py
@@ -7,10 +7,9 @@ import pytest
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.reports.slice import Sagittal
+from spinalcordtoolbox.reports.slice import Axial, Sagittal
+from spinalcordtoolbox.reports.qc import QcReport, QcImage
 from spinalcordtoolbox.utils.sys import sct_test_path
-import spinalcordtoolbox.reports.qc as qc
-import spinalcordtoolbox.reports.slice as qcslice
 
 
 logger = logging.getLogger()
@@ -87,16 +86,16 @@ def assert_qc_assets(path):
 
 
 def test_label_vertebrae(t2_image, t2_seg_image, tmp_path):
-    qc_report = qc.QcReport(t2_image.absolutepath, 'sct_label_vertebrae', ['-a', '-b'], 'Sagittal', str(tmp_path))
+    qc_report = QcReport(t2_image.absolutepath, 'sct_label_vertebrae', ['-a', '-b'], 'Sagittal', str(tmp_path))
 
-    qc.QcImage(
+    QcImage(
         qc_report=qc_report,
         interpolation='spline36',
-        action_list=[qc.QcImage.label_vertebrae],
+        action_list=[QcImage.label_vertebrae],
         process=qc_report.command,
     ).layout(
         qcslice_layout=lambda qcslice: qcslice.single(),
-        qcslice=qcslice.Sagittal([t2_image, t2_seg_image]),
+        qcslice=Sagittal([t2_image, t2_seg_image]),
     )
 
     assert os.path.isfile(qc_report.abs_background_img_path())
@@ -104,16 +103,16 @@ def test_label_vertebrae(t2_image, t2_seg_image, tmp_path):
 
 
 def test_propseg(t2_image, t2_seg_image, tmp_path):
-    qc_report = qc.QcReport(t2_image.absolutepath, 'sct_propseg', ['-a'], 'Axial', str(tmp_path))
+    qc_report = QcReport(t2_image.absolutepath, 'sct_propseg', ['-a'], 'Axial', str(tmp_path))
 
-    qc.QcImage(
+    QcImage(
         qc_report=qc_report,
         interpolation='none',
-        action_list=[qc.QcImage.listed_seg],
+        action_list=[QcImage.listed_seg],
         process=qc_report.command,
     ).layout(
         qcslice_layout=lambda qcslice: qcslice.mosaic(),
-        qcslice=qcslice.Axial([t2_image, t2_seg_image]),
+        qcslice=Axial([t2_image, t2_seg_image]),
     )
 
     assert os.path.isfile(qc_report.abs_background_img_path())

--- a/testing/api/test_reports.py
+++ b/testing/api/test_reports.py
@@ -45,7 +45,13 @@ def labeled_data_test_params(path_in=sct_test_path('t2', 't2.nii.gz'),
 def test_sagittal_slice_get_center_spit(im_in, im_seg):
     """Test that get_center_split returns a valid index list."""
     assert im_in.orientation == im_seg.orientation, "im_in and im_seg aren't in the same orientation"
-    qcslice = Sagittal([im_in, im_seg], p_resample=None)
+
+    # Sagittal.get_center_spit() only uses self._images
+    qcslice = Sagittal()
+    qcslice._images = [
+        im_in.copy().change_orientation('SAL'),
+        im_seg.copy().change_orientation('SAL'),
+    ]
 
     if np.count_nonzero(im_seg.data) == 0:
         # If im_seg contains no labels, get_center_spit should fail


### PR DESCRIPTION
I'm not finished with porting the existing QC reports to the new structure, but I've completed a significant step, and it's coherent enough to be reviewed, so here's a pull request!

My approach is to erode away the old structure by inlining as many function calls as possible, especially when they're only ever called once.

I tried to make a separate commit for each logical change, but the last one was necessarily bigger.

Part of #4204.