### PR TITLE
Output ANTs syntax in moco functions for easier debugging

### DIFF
--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -201,6 +201,7 @@ def main(argv: Sequence[str]):
     param.remove_temp_files = arguments.r
     if arguments.param is not None:
         param.update(arguments.param)
+    param.verbose = verbose
 
     path_qc = arguments.qc
     qc_fps = arguments.qc_fps

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -165,6 +165,7 @@ def main(argv: Sequence[str]):
         param.fname_mask = arguments.m
     if arguments.param is not None:
         param.update(arguments.param)
+    param.verbose = verbose
 
     path_qc = arguments.qc
     qc_fps = arguments.qc_fps


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Proposed change:

with verbose=1:
```
Register. Loop across Z (note: there is only one Z if orientation is axial)
Z=0/0: 100%|██████████████████████████████████| 60/60 [01:22<00:00,  1.38s/iter]
```

with verbose=2:
```
Z=0/0:   0%|                                           | 0/60 [00:00<?, ?iter/s]Loaded /private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73/datasub-groups_T0000.nii orientation RPI shape (96, 50, 25)
Loaded /private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73/datasub-groups_T0000.nii orientation RPI shape (96, 50, 25)
/Users/julien/code/spinalcordtoolbox/bin/isct_antsSliceRegularizedRegistration --polydegree 0 --transform 'Translation[1]' --metric 'MeanSquares[datasub_0_mean.nii.gz,/private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73/datasub-groups_T0000.nii,1,4,None]' --iterations 10 --shrinkFactors 1 --smoothingSigmas 0 --verbose 1 --output '[mat_groups/mat.Z0000T0000,/private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73/datasub-groups_T0000_moco.nii]' -n Linear --mask /private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73/mask.nii # in /private/var/folders/5f/6n99hhyj5_g5cv_1bbx1q7cr0000gn/T/sct_2024-07-29_15-50-54_moco-wrapper_fo2omc73
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4578
