### PR TITLE
Add `-perslice` option (plus performance improvements to make it feasible)

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -627,10 +627,11 @@ class AnalyzeLesion:
     def _measure_totLesion_distribution(self, im_lesion, atlas_data, im_vert, p_lst):
 
         sheet_name = 'ROI_occupied_by_lesion'
+        total_row = f'total % (all {self.row_name})'
         rows_with_total = {
             **self.rows,
             # numpy array index equivalent to [:, :, :]
-            f'total % (all {self.row_name})': (slice(None), slice(None), slice(None)),
+            total_row: (slice(None), slice(None), slice(None)),
         }
         self.distrib_matrix_dct[sheet_name] = pd.DataFrame.from_dict({'row': [str(r) for r in rows_with_total]})
 
@@ -642,7 +643,7 @@ class AnalyzeLesion:
         # loop over slices/vertlevels
         for row, indices_to_keep in sct_progress_bar(rows_with_total.items(), unit=self.row_name,
                                                      desc="  Computing ROI distribution for all lesions"):
-            if row.startswith('total') or np.count_nonzero(im_vert_and_lesion[indices_to_keep]):
+            if row == total_row or np.count_nonzero(im_vert_and_lesion[indices_to_keep]):
                 res_perTract_dct = {}  # for each tract compute the volume occupied by lesion and the volume of the tract
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # loop over the tracts

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -548,8 +548,7 @@ class AnalyzeLesion:
             image_out[:, :, indices] = image[:, :, indices]
         return image_out
 
-    def __relative_ROIvol_in_mask(self, im_mask_data, im_atlas_roi_data, p_lst, im_template_vert_data,
-                                  indices_to_keep):
+    def __relative_ROIvol_in_mask(self, im_mask_data, im_atlas_roi_data, p_lst, indices_to_keep):
         #
         #   Goal:
         #         This function computes the percentage of ROI occupied by binary mask
@@ -560,11 +559,11 @@ class AnalyzeLesion:
         #   Inputs:
         #           - im_mask_data - type=NumPyArray - binary mask (eg lesions)
         #           - im_atlas_roi_data - type=NumPyArray - ROI in the same space as im_mask
-        #                        - p_lst - type=list of float
-        #           - im_template_vert_data - type=NumPyArray - vertebral template in the same space as im_mask
-        #           - vert_level - type=int - vertebral level ID to restrict the ROI
+        #           - p_lst - type=list of float
+        #           - indices_to_keep - type=(anything that can be used to index numpy arrays)
+        #                               anything outside this mask will be set to 0
         #
-        if im_template_vert_data is not None and indices_to_keep:
+        if indices_to_keep:
             im_atlas_roi_data = self.__keep_only_indices(im_atlas_roi_data, indices_to_keep)
             im_mask_data = self.__keep_only_indices(im_mask_data, indices_to_keep)
 
@@ -594,7 +593,6 @@ class AnalyzeLesion:
                     res_lst = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
                                                              im_atlas_roi_data=np.copy(atlas_data[tract_id]),
                                                              p_lst=p_lst,
-                                                             im_template_vert_data=np.copy(im_vert_cur),
                                                              indices_to_keep=indices_to_keep)
                     self.distrib_matrix_dct[sheet_name].loc[idx, 'PAM50_' + str(tract_id).zfill(2)] = res_lst[0]
                     vol_mask_tot += res_lst[0]
@@ -656,7 +654,6 @@ class AnalyzeLesion:
                     res_perTract_dct[tract_id] = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
                                                                                 im_atlas_roi_data=np.copy(atlas_data[tract_id]),
                                                                                 p_lst=p_lst,
-                                                                                im_template_vert_data=np.copy(im_vert_cur),
                                                                                 indices_to_keep=indices_to_keep)
 
                 # group tracts to compute involvement in CombinedLabels (GM, WM, DC, VF, LF)

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -579,12 +579,11 @@ class AnalyzeLesion:
             self.distrib_matrix_dct[sheet_name]['PAM50_' + str(tract_id).zfill(2)] = [0] * len(self.rows)
 
         vol_mask_tot = 0.0  # vol tot of this lesion through the vertebral levels and PAM50 tracts
+        im_vert_and_lesion = im_vert * im_lesion  # to check which vertebral levels have lesions
         # Loop over slices or vertebral levels
         for row, indices_to_keep in sct_progress_bar(self.rows.items(), unit=self.row_name,
                                                      desc="  Computing lesion distribution (volume values)"):
-            # Set everything but the current vertlevel (or slice) to 0
-            im_vert_cur = self.__keep_only_indices(im_vert, indices_to_keep)
-            if np.count_nonzero(im_vert_cur * im_lesion):  # if there is lesion in this vertebral level
+            if np.count_nonzero(im_vert_and_lesion[indices_to_keep]):  # if there is lesion in this vertebral level
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # Loop over PAM50 tracts
                     res_lst = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
@@ -639,15 +638,11 @@ class AnalyzeLesion:
         for tract_id in atlas_data:
             self.distrib_matrix_dct[sheet_name]['PAM50_' + str(tract_id).zfill(2)] = [0] * len(rows_with_total)
 
+        im_vert_and_lesion = im_vert * im_lesion  # to check which vertebral levels have lesions
         # loop over slices/vertlevels
         for row, indices_to_keep in sct_progress_bar(rows_with_total.items(), unit=self.row_name,
                                                      desc="  Computing ROI distribution for all lesions"):
-            if row != f'total % (all {self.row_name})':
-                # Set everything but the current vertlevel (or slice) to 0
-                im_vert_cur = self.__keep_only_indices(im_vert, indices_to_keep)
-            else:
-                im_vert_cur = None
-            if im_vert_cur is None or np.count_nonzero(im_vert_cur * im_lesion):
+            if row.startswith('total') or np.count_nonzero(im_vert_and_lesion[indices_to_keep]):
                 res_perTract_dct = {}  # for each tract compute the volume occupied by lesion and the volume of the tract
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # loop over the tracts

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -548,8 +548,8 @@ class AnalyzeLesion:
             image_out[:, :, indices] = image[:, :, indices]
         return image_out
 
-    def __relative_ROIvol_in_mask(self, im_mask_data, im_atlas_roi_data, p_lst, im_template_vert_data=None,
-                                  indices_to_keep=None):
+    def __relative_ROIvol_in_mask(self, im_mask_data, im_atlas_roi_data, p_lst, im_template_vert_data,
+                                  indices_to_keep):
         #
         #   Goal:
         #         This function computes the percentage of ROI occupied by binary mask

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -584,7 +584,7 @@ class AnalyzeLesion:
                                                      desc="  Computing lesion distribution (volume values)"):
             # Set everything but the current vertlevel (or slice) to 0
             im_vert_cur = self.__keep_only_indices(im_vert, indices_to_keep)
-            if np.count_nonzero(im_vert_cur * np.copy(im_lesion)):  # if there is lesion in this vertebral level
+            if np.count_nonzero(im_vert_cur * im_lesion):  # if there is lesion in this vertebral level
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # Loop over PAM50 tracts
                     res_lst = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
@@ -647,7 +647,7 @@ class AnalyzeLesion:
                 im_vert_cur = self.__keep_only_indices(im_vert, indices_to_keep)
             else:
                 im_vert_cur = None
-            if im_vert_cur is None or np.count_nonzero(im_vert_cur * np.copy(im_lesion)):
+            if im_vert_cur is None or np.count_nonzero(im_vert_cur * im_lesion):
                 res_perTract_dct = {}  # for each tract compute the volume occupied by lesion and the volume of the tract
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # loop over the tracts

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -560,9 +560,8 @@ class AnalyzeLesion:
         #           - indices_to_keep - type=(anything that can be used to index numpy arrays)
         #                               anything outside this mask will be set to 0
         #
-        if indices_to_keep is not None:
-            im_atlas_roi_data = self.__keep_only_indices(im_atlas_roi_data, indices_to_keep)
-            im_mask_data = self.__keep_only_indices(im_mask_data, indices_to_keep)
+        im_atlas_roi_data = self.__keep_only_indices(im_atlas_roi_data, indices_to_keep)
+        im_mask_data = self.__keep_only_indices(im_mask_data, indices_to_keep)
 
         im_mask_roi_data_wa = self.___pve_weighted_avg(im_mask_data=im_mask_data, im_atlas_data=im_atlas_roi_data)
         vol_tot_roi = np.sum(im_atlas_roi_data) * p_lst[0] * p_lst[1] * p_lst[2]
@@ -586,8 +585,8 @@ class AnalyzeLesion:
             if np.count_nonzero(im_vert_and_lesion[indices_to_keep]):  # if there is lesion in this vertebral level
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # Loop over PAM50 tracts
-                    res_lst = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
-                                                             im_atlas_roi_data=np.copy(atlas_data[tract_id]),
+                    res_lst = self.__relative_ROIvol_in_mask(im_mask_data=im_lesion,
+                                                             im_atlas_roi_data=atlas_data[tract_id],
                                                              p_lst=p_lst,
                                                              indices_to_keep=indices_to_keep)
                     self.distrib_matrix_dct[sheet_name].loc[idx, 'PAM50_' + str(tract_id).zfill(2)] = res_lst[0]
@@ -630,7 +629,8 @@ class AnalyzeLesion:
         sheet_name = 'ROI_occupied_by_lesion'
         rows_with_total = {
             **self.rows,
-            f'total % (all {self.row_name})': None,
+            # numpy array index equivalent to [:, :, :]
+            f'total % (all {self.row_name})': (slice(None), slice(None), slice(None)),
         }
         self.distrib_matrix_dct[sheet_name] = pd.DataFrame.from_dict({'row': [str(r) for r in rows_with_total]})
 
@@ -646,8 +646,8 @@ class AnalyzeLesion:
                 res_perTract_dct = {}  # for each tract compute the volume occupied by lesion and the volume of the tract
                 idx = self.distrib_matrix_dct[sheet_name][self.distrib_matrix_dct[sheet_name].row == str(row)].index
                 for tract_id in atlas_data:  # loop over the tracts
-                    res_perTract_dct[tract_id] = self.__relative_ROIvol_in_mask(im_mask_data=np.copy(im_lesion),
-                                                                                im_atlas_roi_data=np.copy(atlas_data[tract_id]),
+                    res_perTract_dct[tract_id] = self.__relative_ROIvol_in_mask(im_mask_data=im_lesion,
+                                                                                im_atlas_roi_data=atlas_data[tract_id],
                                                                                 p_lst=p_lst,
                                                                                 indices_to_keep=indices_to_keep)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This was a tricky refactor, because `-perslice` goes against the default behavior of `sct_analyze_lesion` (aggregating by vertebral levels), and there are a lot of hardcoded `vert` variable names. It took quite a few changes of (vert -> row) to avoid a complete rewrite.

That said, big-picture "aggregating by vertebral levels" basically boils down to this:

- Iterate over vertebral levels.
- For each vertebral level, set all other voxels equal to 0, then compute percentages.

The general structure of this code still works if you substitute "vertebral level" for slice; You can instead iterate over slices and still set all other voxels equal to 0. To do this, I used "rows" to represent either vertebral levels *or* slices, and kept a separate variable "row_name" to track whether we have vertlevels or slices. This mostly gets the job done.

Note: While the previous performance improvements help, this is still a slow process for any image with a large number of slices:

- `-perslice 0`, no optimization: ~300s (~5m)
- `-perslice 0`, with optimization: ~50s (~1m)
- `-perslice 1`, no optimization: Did not finish (est. 3600s, or 1hr)
- `-perslice 1`, with optimization: ~600s (10m)

So, perhaps there is more optimization work to be done. Here is the `tuna` profile for `-perslice 1` on the same image I used to test #4584:

![image](https://github.com/user-attachments/assets/02581f30-333b-45ac-bf61-b08a18196037)

It's a lot of calls to `np.sum`, `np.count_nonzero`, etc. I think this is because we've got naive `for` loops over both slices (~500) and tracts (~36). I'm sure there's some sort of smart numpy array operations we could be doing, but it's hard to implement that without a full rewrite.

It may also be worth just... skipping the slices that don't have lesion values? With large images, this results in a large output spreadsheet with many empty rows. But, if we exclude the empty rows, then perhaps we can save on processing time as well.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4567 
Fixes #2677 
