### PR TITLE
Fix crashing `sct_analyze_lesion` if there is no midsagittal lesion

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -284,10 +284,17 @@ class AnalyzeLesion:
                         # Get dorsal and ventral tissue bridges for the mid-sagittal slice
                         dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
                         ventral_tissue_bridge = row[f'slice_{midsagittal_slice}_ventral_bridge_width [mm]']
+                    # Note: the following else is for the case when all the lesions are parasagittal and there is thus
+                    # no 'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' column
                     else:
                         dorsal_tissue_bridge = np.nan
                         ventral_tissue_bridge = np.nan
                     # If there are NaN values, print a warning
+                    # Note: for multiple lesions, there might one midsagittal lesion and another parasagittal lesion.
+                    # In such a case, 'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' column exists for both
+                    # lesions (parasagittal lesion contains NaNs) and the previous 'if' is True for both lesions.
+                    # This is why we cannot include the following printv into the previous 'else' statement because it
+                    # would not be printed for the parasagittal lesion.
                     if np.isnan(dorsal_tissue_bridge) or np.isnan(ventral_tissue_bridge):
                         printv(f'WARNING: Lesion #{idx+1} does not exist in the midsagittal slice',
                                self.verbose, type='warning')

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -298,6 +298,10 @@ class AnalyzeLesion:
             min_ventral_bridge = np.nanmin(midsagittal_ventral_bridges)
             printv(f'  Minimum dorsal bridge width [mm]: {np.round(min_dorsal_bridge, 2)}', self.verbose, type='info')
             printv(f'  Minimum ventral bridge width [mm]: {np.round(min_ventral_bridge, 2)}', self.verbose, type='info')
+            # If there are NaN values, print a warning
+            if np.isnan(min_dorsal_bridge) or np.isnan(min_ventral_bridge):
+                printv('WARNING: There are no tissue bridges in the midsagittal slice.',
+                       self.verbose, type='warning')
 
         total_volume = np.round(np.sum(self.measure_pd['volume [mm3]']), 2)
         lesion_count = len(self.measure_pd['volume [mm3]'].values)

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -8,6 +8,7 @@
 import os
 import sys
 import pickle
+import warnings
 from typing import Sequence
 
 import numpy as np
@@ -294,6 +295,8 @@ class AnalyzeLesion:
             # Compute the minimum bridges across all lesions for the midsagittal slice
             # Note: lesion(s) can be located on the parasagittal slices meaning that they do not have bridges in the
             # midsagittal slice, in such case the bridge width is NaN --> use np.nanmin to get the minimum value
+            # Suppress the 'RuntimeWarning for All-NaN axis encountered' warning
+            warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN axis encountered")
             min_dorsal_bridge = np.nanmin(midsagittal_dorsal_bridges)
             min_ventral_bridge = np.nanmin(midsagittal_ventral_bridges)
             printv(f'  Minimum dorsal bridge width [mm]: {np.round(min_dorsal_bridge, 2)}', self.verbose, type='info')

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -292,8 +292,8 @@ class AnalyzeLesion:
                     midsagittal_ventral_bridges.append(ventral_tissue_bridge)
 
             # Compute the minimum bridges across all lesions for the midsagittal slice
-            # Note: lesions can be parasagittal meaning that they do not have bridges in the midsagittal slice, in such
-            # case the bridge width is NaN --> use np.nanmin to get the minimum value
+            # Note: lesion(s) can be located on the parasagittal slices meaning that they do not have bridges in the
+            # midsagittal slice, in such case the bridge width is NaN --> use np.nanmin to get the minimum value
             min_dorsal_bridge = np.nanmin(midsagittal_dorsal_bridges)
             min_ventral_bridge = np.nanmin(midsagittal_ventral_bridges)
             printv(f'  Minimum dorsal bridge width [mm]: {np.round(min_dorsal_bridge, 2)}', self.verbose, type='info')

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -265,7 +265,6 @@ class AnalyzeLesion:
 
         # For the tissue bridges, we get the minimum bridges across all lesions for the midsagittal slice
         if self.fname_sc is not None:
-            printv('\nMinimum tissue bridges across all lesions for the midsagittal slice...', self.verbose, 'normal')
             midsagittal_dorsal_bridges = list()
             midsagittal_ventral_bridges = list()
             # Iterate across lesions to get the bridges for the midsagittal slice
@@ -275,6 +274,9 @@ class AnalyzeLesion:
                     # Note that the midsagittal slice is the same for all lesions as it is based on the spinal cord
                     # segmentation
                     midsagittal_slice = str(int(row['midsagittal_spinal_cord_slice']))
+                    if idx == 0:        # Print only once, not for each lesion
+                        printv(f'\nMinimum tissue bridges across all lesions for the midsagittal slice '
+                               f'(sagittal slice {midsagittal_slice})...', self.verbose, 'normal')
                     # Check whether the lesion has bridges in the midsagittal slice, if not, set the bridge width to NaN
                     if f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' in row and \
                             f'slice_{midsagittal_slice}_ventral_bridge_width [mm]' in row:

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -287,6 +287,10 @@ class AnalyzeLesion:
                     else:
                         dorsal_tissue_bridge = np.nan
                         ventral_tissue_bridge = np.nan
+                    # If there are NaN values, print a warning
+                    if np.isnan(dorsal_tissue_bridge) or np.isnan(ventral_tissue_bridge):
+                        printv(f'WARNING: Lesion #{idx+1} does not exist in the midsagittal slice',
+                               self.verbose, type='warning')
 
                     # Store the bridges for the midsagittal slice for the selected lesion
                     midsagittal_dorsal_bridges.append(dorsal_tissue_bridge)
@@ -301,10 +305,6 @@ class AnalyzeLesion:
             min_ventral_bridge = np.nanmin(midsagittal_ventral_bridges)
             printv(f'  Minimum dorsal bridge width [mm]: {np.round(min_dorsal_bridge, 2)}', self.verbose, type='info')
             printv(f'  Minimum ventral bridge width [mm]: {np.round(min_ventral_bridge, 2)}', self.verbose, type='info')
-            # If there are NaN values, print a warning
-            if np.isnan(min_dorsal_bridge) or np.isnan(min_ventral_bridge):
-                printv('WARNING: There are no tissue bridges in the midsagittal slice.',
-                       self.verbose, type='warning')
 
         total_volume = np.round(np.sum(self.measure_pd['volume [mm3]']), 2)
         lesion_count = len(self.measure_pd['volume [mm3]'].values)

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -275,9 +275,15 @@ class AnalyzeLesion:
                     # Note that the midsagittal slice is the same for all lesions as it is based on the spinal cord
                     # segmentation
                     midsagittal_slice = str(int(row['midsagittal_spinal_cord_slice']))
-                    # Get dorsal and ventral tissue bridges for the mid-sagittal slice
-                    dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
-                    ventral_tissue_bridge = row[f'slice_{midsagittal_slice}_ventral_bridge_width [mm]']
+                    # Check whether the lesion has bridges in the midsagittal slice, if not, set the bridge width to NaN
+                    if f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' in row and \
+                            f'slice_{midsagittal_slice}_ventral_bridge_width [mm]' in row:
+                        # Get dorsal and ventral tissue bridges for the mid-sagittal slice
+                        dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
+                        ventral_tissue_bridge = row[f'slice_{midsagittal_slice}_ventral_bridge_width [mm]']
+                    else:
+                        dorsal_tissue_bridge = np.nan
+                        ventral_tissue_bridge = np.nan
 
                     # Store the bridges for the midsagittal slice for the selected lesion
                     midsagittal_dorsal_bridges.append(dorsal_tissue_bridge)


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR fixes the crashing of  `sct_analyze_lesion` if there is no midsagittal lesion; details in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4594. 

Instead of crashing due to the `KeyError`, `sct_analyze_lesion` now prints:

```console
Minimum tissue bridges across all lesions for the midsagittal slice (sagittal slice 9)...
  Minimum dorsal bridge width [mm]: nan
  Minimum ventral bridge width [mm]: nan
WARNING: There are no tissue bridges in the midsagittal slice.
```

<details><summary>master</summary>

```console
valosek@macbook-pro:~/data/sci-olomouc/sub-001/anat$ sct_analyze_lesion -m sub-001_T2w_lesion.nii.gz -s sub-001_T2w_seg.nii.gz -qc qc

--
Spinal Cord Toolbox (git-master-75ef29d3960f0aa6c3fddce5f40f819d4d72753b)

sct_analyze_lesion -m sub-001_T2w_lesion.nii.gz -s sub-001_T2w_seg.nii.gz -qc qc
--

Creating temporary folder (/var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_11-52-53_analyze-lesion_7v373ibv)
cp sub-001_T2w_lesion.nii.gz /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_11-52-53_analyze-lesion_7v373ibv
cp sub-001_T2w_seg.nii.gz /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_11-52-53_analyze-lesion_7v373ibv

Orient input image(s) to RPI orientation...
File sub-001_T2w_lesion.nii.gz already exists. Will overwrite it.
File sub-001_T2w_seg.nii.gz already exists. Will overwrite it.

Label connected regions of the masked image...
Image header specifies datatype 'uint8', but array is of type 'int64'. Header metadata will be overwritten to use 'int64'.
Lesion count = 1

Measures on lesion #1...
  (S-I) length : 16.83 mm
  Max. equivalent diameter : 4.99 mm
  Maximum axial damage ratio : 0.28
  Midsagittal slice of the spinal cord: 9
  Sagittal slice 10, Minimum dorsal tissue bridge width: 0.0 mm (axial slice 518)
  Sagittal slice 10, Minimum ventral tissue bridge width: 0.0 mm (axial slice 539)
  Sagittal slice 10, Total tissue bridge width: 0.0 mm
  Volume : 208.68 mm^3

Orient output image to initial orientation...
File sub-001_T2w_lesion_label.nii.gz already exists. Will overwrite it.


Averaged measures across all lesions...
  volume [mm3] = 208.68 +/- 0.0
  length [mm] = 16.83 +/- 0.0
  max_equivalent_diameter [mm] = 4.99 +/- 0.0
  max_axial_damage_ratio [] = 0.28 +/- 0.0

Minimum tissue bridges across all lesions for the midsagittal slice...
Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.9/site-packages/pandas/core/indexes/base.py", line 3802, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5745, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5753, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'slice_9_dorsal_bridge_width [mm]'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 886, in <module>
    main(sys.argv[1:])
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 844, in main
    lesion_obj.analyze()
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 214, in analyze
    self.show_total_results()
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 279, in show_total_results
    dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.9/site-packages/pandas/core/series.py", line 981, in __getitem__
    return self._get_value(key)
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.9/site-packages/pandas/core/series.py", line 1089, in _get_value
    loc = self.index.get_loc(label)
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.9/site-packages/pandas/core/indexes/base.py", line 3804, in get_loc
    raise KeyError(key) from err
KeyError: 'slice_9_dorsal_bridge_width [mm]'
```

</details>

<details><summary>this branch</summary>

```console
valosek@macbook-pro:~/data/sci-olomouc/sub-001/anat$ sct_analyze_lesion -m sub-001_T2w_lesion.nii.gz -s sub-001_T2w_seg.nii.gz -qc qc

--
Spinal Cord Toolbox (git-jv/4594_sct_analyze_lesion-a4bdbc7c9ba88e3ff3e9360c0a5e245103a20d9d)

sct_analyze_lesion -m sub-001_T2w_lesion.nii.gz -s sub-001_T2w_seg.nii.gz -qc qc
--

Creating temporary folder (/var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm)
cp sub-001_T2w_lesion.nii.gz /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm
cp sub-001_T2w_seg.nii.gz /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm

Orient input image(s) to RPI orientation...
File sub-001_T2w_lesion.nii.gz already exists. Will overwrite it.
File sub-001_T2w_seg.nii.gz already exists. Will overwrite it.

Label connected regions of the masked image...
Image header specifies datatype 'uint8', but array is of type 'int64'. Header metadata will be overwritten to use 'int64'.
Lesion count = 1

Measures on lesion #1...
  (S-I) length : 16.83 mm
  Max. equivalent diameter : 4.99 mm
  Maximum axial damage ratio : 0.28
  Midsagittal slice of the spinal cord: 9
  Sagittal slice 10, Minimum dorsal tissue bridge width: 0.0 mm (axial slice 518)
  Sagittal slice 10, Minimum ventral tissue bridge width: 0.0 mm (axial slice 539)
  Sagittal slice 10, Total tissue bridge width: 0.0 mm
  Volume : 208.68 mm^3

Orient output image to initial orientation...
File sub-001_T2w_lesion_label.nii.gz already exists. Will overwrite it.


Averaged measures across all lesions...
  volume [mm3] = 208.68 +/- 0.0
  length [mm] = 16.83 +/- 0.0
  max_equivalent_diameter [mm] = 4.99 +/- 0.0
  max_axial_damage_ratio [] = 0.28 +/- 0.0

Minimum tissue bridges across all lesions for the midsagittal slice (sagittal slice 9)...
  Minimum dorsal bridge width [mm]: nan
  Minimum ventral bridge width [mm]: nan
WARNING: There are no tissue bridges in the midsagittal slice.

Total volume = 208.68 mm^3
Lesion count = 1

Save results files...

... measures saved in the files:

  - ./sub-001_T2w_lesion_label.nii.gz
cp /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm/sub-001_T2w_lesion_label.nii.gz ./sub-001_T2w_lesion_label.nii.gz

  - ./sub-001_T2w_lesion_analysis.xls
cp /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm/sub-001_T2w_lesion_analysis.xls ./sub-001_T2w_lesion_analysis.xls

  - ./sub-001_T2w_lesion_analysis.pkl
cp /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm/sub-001_T2w_lesion_analysis.pkl ./sub-001_T2w_lesion_analysis.pkl

*** Generating Quality Control (QC) html report ***
Successfully generated the QC results in qc/_json/qc_2024_08_06_140955.862908.json

To see the results in a browser, type:
open qc/index.html

rm -rf /var/folders/w6/bnzr2qls11l69w0_8q95ghtr0000gn/T/sct_2024-08-06_14-09-52_analyze-lesion_4u8u4jzm

Done! To view results, run one of the following commands (depending on your preferred viewer):
fsleyes sub-001_T2w_lesion_label.nii.gz -cm YlOrRd -a 70.0 &

itksnap -g sub-001_T2w_lesion_label.nii.gz
```

</details>

## Linked issues
Resolves https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4594
