### PR TITLE
Silence `pandas` warning by explicitly using `copy` to remove view/copy ambiguity

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -468,7 +468,7 @@ class AnalyzeLesion:
         # distance from cerebrospinal fluid to the lesion boundary
         for sagittal_slice in sagittal_lesion_slices:
             # Get df for the selected sagittal slice
-            df_temp = tissue_bridges_df[tissue_bridges_df['sagittal_slice'] == sagittal_slice]
+            df_temp = tissue_bridges_df[tissue_bridges_df['sagittal_slice'] == sagittal_slice].copy()
 
             # Get the width of the tissue bridges in mm (by multiplying by p_lst[1]) and use np.cos(self.angles_sagittal[SLICE])
             # to correct for the angle of the spinal cord with respect to the axial slice


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

As per https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4591#issuecomment-2271973627:

> But we are not explicit about whether we want a "view" (i.e. changes the original dataframe) or a "copy" (independent of the original dataframe). Because we are not explicit, there is potential ambiguity, hence why pandas throws this warning. To fix this warning, we just need to be explicit about what we want, and there are multiple ways to do this (not just `.loc`).

I think in this case, because we only ever access the newly-added columns from df_temp and not from the original `tissue_bridges_df` DataFrame, we don't need a "view", and so I think it should be fine to denote df_temp as a copy:

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4591.
