### PR TITLE
Fix slice numbering in `sct_analyze_lesion` QC and CLI output

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -59,43 +59,22 @@ def rpi_slice_to_orig_orientation(dim, orig_orientation, slice_number, axis):
     """
     Convert slice number from RPI (right-posterior-inferior) to original orientation, e.g., AIL
     (anterior-inferior-left).
-    :param dim: tuple, dimensions of the image in RPI orientation.
-    :param orig_orientation: str, original image e.g., AIL.
+    :param dim: tuple, dimensions of the image in RPI orientation, e.g., (20, 640, 640).
+    :param orig_orientation: str, original image orientation, e.g., AIL.
     :param slice_number: str, slice number in RPI orientation, e.g., 9.
-    :param axis: str, axis of the slice in the RPI orientation. 'x' corresponds to the R-L axis,
-    'y' to the A-P axis, and 'z' to the I-S axis.
+    :param axis: int, axis of the slice in the RPI orientation. '0' corresponds to the x (R-L) axis,
+    '1' to the y (A-P) axis, and '2' to the z (I-S) axis.
     :return: int, slice number in original orientation, e.g., 6.
 
     Example: considering an image with 20 sagittal slices (0-19) and sagittal slice number 13 in the AIL orientation,
     the corresponding slice number in the RPI orientation is 6:
-            rpi_slice_to_orig_orientation((20, 640, 640), 'AIL', 13, 'x') -> 6
-    Note: we use 'x' in this example as it corresponds to the R-L direction (first in RPI --> 'x')
+            rpi_slice_to_orig_orientation((20, 640, 640), 'AIL', 13, 0) -> 6
+    Note: we use 0 as the last arg in this example as it corresponds to the R-L direction (first axis in RPI)
     """
-    # Ensure slice_number is an integer
-    slice_number = int(slice_number)
-
-    # Get dimensions of the image in RPI orientation
-    nx, ny, nz = dim
-
-    # Define axis index mapping
-    axis_map = {'x': 0, 'y': 1, 'z': 2}
-    axis_index = axis_map[axis]
-
-    # Get the permutations and inversions
+    # Get the inversions
     _, inversion = _get_permutations('RPI', orig_orientation)
 
-    # Calculate the corresponding slice number in the original orientation
-    if inversion[axis_index] == 1:
-        orig_slice_number = slice_number
-    else:
-        if axis_index == 0:
-            orig_slice_number = nx - 1 - slice_number
-        elif axis_index == 1:
-            orig_slice_number = ny - 1 - slice_number
-        elif axis_index == 2:
-            orig_slice_number = nz - 1 - slice_number
-
-    return orig_slice_number
+    return (dim[axis] - 1 - slice_number) if inversion[axis] == -1 else slice_number
 
 
 class Slicer(object):

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -71,10 +71,7 @@ def rpi_slice_to_orig_orientation(dim, orig_orientation, slice_number, axis):
             rpi_slice_to_orig_orientation((20, 640, 640), 'AIL', 13, 0) -> 6
     Note: we use 0 as the last arg in this example as it corresponds to the R-L direction (first axis in RPI)
     """
-    # Get the inversions
-    _, inversion = _get_permutations('RPI', orig_orientation)
-
-    return (dim[axis] - 1 - slice_number) if inversion[axis] == -1 else slice_number
+    return (dim[axis] - 1 - slice_number) if orig_orientation[axis] in orig_orientation else slice_number
 
 
 class Slicer(object):

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -71,7 +71,10 @@ def rpi_slice_to_orig_orientation(dim, orig_orientation, slice_number, axis):
             rpi_slice_to_orig_orientation((20, 640, 640), 'AIL', 13, 0) -> 6
     Note: we use 0 as the last arg in this example as it corresponds to the R-L direction (first axis in RPI)
     """
-    return (dim[axis] - 1 - slice_number) if orig_orientation[axis] in orig_orientation else slice_number
+    # Get the inversions
+    _, inversion = _get_permutations('RPI', orig_orientation)
+
+    return (dim[axis] - 1 - slice_number) if inversion[axis] == -1 else slice_number
 
 
 class Slicer(object):

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -55,6 +55,49 @@ def _get_permutations(im_src_orientation, im_dst_orientation):
     return perm, inversion
 
 
+def rpi_slice_to_orig_orientation(dim, orig_orientation, slice_number, axis):
+    """
+    Convert slice number from RPI (right-posterior-inferior) to original orientation, e.g., AIL
+    (anterior-inferior-left).
+    :param dim: tuple, dimensions of the image in RPI orientation.
+    :param orig_orientation: str, original image e.g., AIL.
+    :param slice_number: str, slice number in RPI orientation, e.g., 9.
+    :param axis: str, axis of the slice in the RPI orientation. 'x' corresponds to the R-L axis,
+    'y' to the A-P axis, and 'z' to the I-S axis.
+    :return: int, slice number in original orientation, e.g., 6.
+
+    Example: considering an image with 20 sagittal slices (0-19) and sagittal slice number 13 in the AIL orientation,
+    the corresponding slice number in the RPI orientation is 6:
+            rpi_slice_to_orig_orientation((20, 640, 640), 'AIL', 13, 'x') -> 6
+    Note: we use 'x' in this example as it corresponds to the R-L direction (first in RPI --> 'x')
+    """
+    # Ensure slice_number is an integer
+    slice_number = int(slice_number)
+
+    # Get dimensions of the image in RPI orientation
+    nx, ny, nz = dim
+
+    # Define axis index mapping
+    axis_map = {'x': 0, 'y': 1, 'z': 2}
+    axis_index = axis_map[axis]
+
+    # Get the permutations and inversions
+    _, inversion = _get_permutations('RPI', orig_orientation)
+
+    # Calculate the corresponding slice number in the original orientation
+    if inversion[axis_index] == 1:
+        orig_slice_number = slice_number
+    else:
+        if axis_index == 0:
+            orig_slice_number = nx - 1 - slice_number
+        elif axis_index == 1:
+            orig_slice_number = ny - 1 - slice_number
+        elif axis_index == 2:
+            orig_slice_number = nz - 1 - slice_number
+
+    return orig_slice_number
+
+
 class Slicer(object):
     """
     Provides a sliced view onto original image data.

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -22,7 +22,7 @@ from scipy.ndimage import center_of_mass
 import skimage.exposure
 
 from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline
-from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.image import Image, rpi_slice_to_orig_orientation
 import spinalcordtoolbox.reports
 from spinalcordtoolbox.reports.assets._assets.py import refresh_qc_entries
 from spinalcordtoolbox.resampling import resample_nib
@@ -468,6 +468,7 @@ def sct_analyze_lesion(
     fname_input: str,
     fname_label: str,
     fname_sc: str,
+    orig_orientation: str,
     measure_pd: pd.DataFrame,
     argv: Sequence[str],
     path_qc: str,
@@ -544,6 +545,11 @@ def sct_analyze_lesion(
                 # Get spinal cord and lesion masks data for the selected sagittal slice
                 slice_sc = im_sc_data[sagittal_slice]
                 slice_lesion = im_label_data_cur[sagittal_slice]
+
+                # Convert the sagittal slice to the original orientation
+                # 'x' because R-L direction (first in RPI --> 'x')
+                sagittal_slice = rpi_slice_to_orig_orientation(im_lesion.dim[0:3], orig_orientation,
+                                                               sagittal_slice, 'x')
 
                 # Plot spinal cord and lesion masks
                 axes[idx_row, idx_col].imshow(np.swapaxes(slice_sc, 1, 0),

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -468,7 +468,6 @@ def sct_analyze_lesion(
     fname_input: str,
     fname_label: str,
     fname_sc: str,
-    orig_orientation: str,
     measure_pd: pd.DataFrame,
     argv: Sequence[str],
     path_qc: str,
@@ -499,6 +498,8 @@ def sct_analyze_lesion(
 
         # Load the labeled lesion mask
         im_lesion = Image(fname_label)
+        # Store the original orientation of the lesion mask before reorienting it to RPI
+        orig_orientation = im_lesion.orientation
         im_lesion.change_orientation("RPI")
         im_lesion_data = im_lesion.data
         label_lst = [label for label in np.unique(im_lesion.data) if label]

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -548,9 +548,9 @@ def sct_analyze_lesion(
                 slice_lesion = im_label_data_cur[sagittal_slice]
 
                 # Convert the sagittal slice to the original orientation
-                # 'x' because R-L direction (first in RPI --> 'x')
-                sagittal_slice = rpi_slice_to_orig_orientation(im_lesion.dim[0:3], orig_orientation,
-                                                               sagittal_slice, 'x')
+                # '0' because of the R-L direction (first in RPI)
+                sagittal_slice = rpi_slice_to_orig_orientation(im_lesion.dim, orig_orientation,
+                                                               sagittal_slice, 0)
 
                 # Plot spinal cord and lesion masks
                 axes[idx_row, idx_col].imshow(np.swapaxes(slice_sc, 1, 0),

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -890,6 +890,7 @@ def main(argv: Sequence[str]):
                 fname_input=fname_mask,
                 fname_label=lesion_obj.fname_label,
                 fname_sc=fname_sc,
+                orig_orientation=Image(fname_mask).orientation,
                 measure_pd=lesion_obj.measure_pd,
                 argv=argv,
                 path_qc=arguments.qc,

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -890,7 +890,6 @@ def main(argv: Sequence[str]):
                 fname_input=fname_mask,
                 fname_label=lesion_obj.fname_label,
                 fname_sc=fname_sc,
-                orig_orientation=Image(fname_mask).orientation,
                 measure_pd=lesion_obj.measure_pd,
                 argv=argv,
                 path_qc=arguments.qc,

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -8,6 +8,7 @@
 import os
 import sys
 import pickle
+import warnings
 from typing import Sequence
 
 import numpy as np
@@ -265,7 +266,6 @@ class AnalyzeLesion:
 
         # For the tissue bridges, we get the minimum bridges across all lesions for the midsagittal slice
         if self.fname_sc is not None:
-            printv('\nMinimum tissue bridges across all lesions for the midsagittal slice...', self.verbose, 'normal')
             midsagittal_dorsal_bridges = list()
             midsagittal_ventral_bridges = list()
             # Iterate across lesions to get the bridges for the midsagittal slice
@@ -275,17 +275,39 @@ class AnalyzeLesion:
                     # Note that the midsagittal slice is the same for all lesions as it is based on the spinal cord
                     # segmentation
                     midsagittal_slice = str(int(row['midsagittal_spinal_cord_slice']))
-                    # Get dorsal and ventral tissue bridges for the mid-sagittal slice
-                    dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
-                    ventral_tissue_bridge = row[f'slice_{midsagittal_slice}_ventral_bridge_width [mm]']
+                    if idx == 0:        # Print only once, not for each lesion
+                        printv(f'\nMinimum tissue bridges across all lesions for the midsagittal slice '
+                               f'(sagittal slice {midsagittal_slice})...', self.verbose, 'normal')
+                    # Check whether the lesion has bridges in the midsagittal slice, if not, set the bridge width to NaN
+                    if f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' in row and \
+                            f'slice_{midsagittal_slice}_ventral_bridge_width [mm]' in row:
+                        # Get dorsal and ventral tissue bridges for the mid-sagittal slice
+                        dorsal_tissue_bridge = row[f'slice_{midsagittal_slice}_dorsal_bridge_width [mm]']
+                        ventral_tissue_bridge = row[f'slice_{midsagittal_slice}_ventral_bridge_width [mm]']
+                    # Note: the following else is for the case when all the lesions are parasagittal and there is thus
+                    # no 'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' column
+                    else:
+                        dorsal_tissue_bridge = np.nan
+                        ventral_tissue_bridge = np.nan
+                    # If there are NaN values, print a warning
+                    # Note: for multiple lesions, there might one midsagittal lesion and another parasagittal lesion.
+                    # In such a case, 'slice_{midsagittal_slice}_dorsal_bridge_width [mm]' column exists for both
+                    # lesions (parasagittal lesion contains NaNs) and the previous 'if' is True for both lesions.
+                    # This is why we cannot include the following printv into the previous 'else' statement because it
+                    # would not be printed for the parasagittal lesion.
+                    if np.isnan(dorsal_tissue_bridge) or np.isnan(ventral_tissue_bridge):
+                        printv(f'WARNING: Lesion #{idx+1} does not exist in the midsagittal slice',
+                               self.verbose, type='warning')
 
                     # Store the bridges for the midsagittal slice for the selected lesion
                     midsagittal_dorsal_bridges.append(dorsal_tissue_bridge)
                     midsagittal_ventral_bridges.append(ventral_tissue_bridge)
 
             # Compute the minimum bridges across all lesions for the midsagittal slice
-            # Note: lesions can be parasagittal meaning that they do not have bridges in the midsagittal slice, in such
-            # case the bridge width is NaN --> use np.nanmin to get the minimum value
+            # Note: lesion(s) can be located on the parasagittal slices meaning that they do not have bridges in the
+            # midsagittal slice, in such case the bridge width is NaN --> use np.nanmin to get the minimum value
+            # Suppress the 'RuntimeWarning for All-NaN axis encountered' warning
+            warnings.filterwarnings("ignore", category=RuntimeWarning, message="All-NaN axis encountered")
             min_dorsal_bridge = np.nanmin(midsagittal_dorsal_bridges)
             min_ventral_bridge = np.nanmin(midsagittal_ventral_bridges)
             printv(f'  Minimum dorsal bridge width [mm]: {np.round(min_dorsal_bridge, 2)}', self.verbose, type='info')

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -425,8 +425,8 @@ class AnalyzeLesion:
         #  all lesions. This would require moving the print statement outside the loop across lesions.
         # Convert the mid-sagittal slice from RPI to the original orientation
         dim = im_lesion_data.shape
-        # 'x' because R-L direction (first in RPI --> 'x')
-        mid_sagittal_sc_slice = rpi_slice_to_orig_orientation(dim, self.orientation, mid_sagittal_sc_slice, 'x')
+        # '0' because of the R-L direction (first in RPI)
+        mid_sagittal_sc_slice = rpi_slice_to_orig_orientation(dim, self.orientation, mid_sagittal_sc_slice, 0)
         self.measure_pd.loc[idx, 'midsagittal_spinal_cord_slice'] = mid_sagittal_sc_slice
         printv('  Midsagittal slice of the spinal cord: ' + str(mid_sagittal_sc_slice), self.verbose, type='info')
 
@@ -441,8 +441,9 @@ class AnalyzeLesion:
         sagittal_lesion_slices = np.unique(np.where(im_lesion_data)[0])
         if self.verbose == 2:
             # Convert the sagittal slices from RPI to the original orientation
-            # 'x' because R-L direction (first in RPI --> 'x')
-            sagittal_lesion_slices_print = [rpi_slice_to_orig_orientation(dim, self.orientation, slice, 'x') for slice in sagittal_lesion_slices]
+            # '0' because of the R-L direction (first in RPI)
+            sagittal_lesion_slices_print = [rpi_slice_to_orig_orientation(dim, self.orientation, slice, 0)
+                                            for slice in sagittal_lesion_slices]
             # Reverse ordering
             sagittal_lesion_slices_print = sagittal_lesion_slices_print[::-1]
             printv('  Slices with lesion: ' + str(sagittal_lesion_slices_print), self.verbose, type='info')
@@ -533,13 +534,13 @@ class AnalyzeLesion:
             min_total_bridge_width_mm = min_dorsal_bridge_width_mm + min_ventral_bridge_width_mm
 
             # Convert the sagittal and axial slices from RPI to the original orientation
-            # 'x' because R-L direction (first in RPI --> 'x')
-            sagittal_slice = rpi_slice_to_orig_orientation(dim, self.orientation, sagittal_slice, 'x')
-            # 'z' because S-I direction (third in RPI --> 'z')
+            # '0' because of the R-L direction (first in RPI)
+            sagittal_slice = rpi_slice_to_orig_orientation(dim, self.orientation, sagittal_slice, 0)
+            # '2' because of the S-I direction (third in RPI)
             min_dorsal_bridge_width_slice = rpi_slice_to_orig_orientation(dim, self.orientation,
-                                                                          min_dorsal_bridge_width_slice, 'z')
+                                                                          min_dorsal_bridge_width_slice, 2)
             min_ventral_bridge_width_slice = rpi_slice_to_orig_orientation(dim, self.orientation,
-                                                                           min_ventral_bridge_width_slice, 'z')
+                                                                           min_ventral_bridge_width_slice, 2)
 
             # Save the minimum tissue bridges
             self.measure_pd.loc[idx, f'slice_{sagittal_slice}_dorsal_bridge_width [mm]'] = min_dorsal_bridge_width_mm

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -14,7 +14,7 @@ from typing import Sequence
 import numpy as np
 from skimage.measure import label
 
-from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.image import Image, rpi_slice_to_orig_orientation
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, LazyLoader
@@ -423,6 +423,10 @@ class AnalyzeLesion:
         # Note: as the midsagittal slice is computed from the spinal cord mask, it is the same for all lesions (all idx)
         # TODO: consider whether it is necessary to print the midsagittal slice for each lesion as it is the same for
         #  all lesions. This would require moving the print statement outside the loop across lesions.
+        # Convert the mid-sagittal slice from RPI to the original orientation
+        dim = im_lesion_data.shape
+        # 'x' because R-L direction (first in RPI --> 'x')
+        mid_sagittal_sc_slice = rpi_slice_to_orig_orientation(dim, self.orientation, mid_sagittal_sc_slice, 'x')
         self.measure_pd.loc[idx, 'midsagittal_spinal_cord_slice'] = mid_sagittal_sc_slice
         printv('  Midsagittal slice of the spinal cord: ' + str(mid_sagittal_sc_slice), self.verbose, type='info')
 
@@ -436,7 +440,12 @@ class AnalyzeLesion:
         # Note: we use [0] for the R-L direction as the orientation is RPI
         sagittal_lesion_slices = np.unique(np.where(im_lesion_data)[0])
         if self.verbose == 2:
-            printv('  Slices with lesion: ' + str(sagittal_lesion_slices), self.verbose, type='info')
+            # Convert the sagittal slices from RPI to the original orientation
+            # 'x' because R-L direction (first in RPI --> 'x')
+            sagittal_lesion_slices_print = [rpi_slice_to_orig_orientation(dim, self.orientation, slice, 'x') for slice in sagittal_lesion_slices]
+            # Reverse ordering
+            sagittal_lesion_slices_print = sagittal_lesion_slices_print[::-1]
+            printv('  Slices with lesion: ' + str(sagittal_lesion_slices_print), self.verbose, type='info')
 
         # --------------------------------------
         # Compute tissue bridges for each sagittal slice containing the lesion
@@ -522,6 +531,15 @@ class AnalyzeLesion:
             min_dorsal_bridge_width_mm = float(df_temp['dorsal_bridge_width_mm'].min())
             min_ventral_bridge_width_mm = float(df_temp['ventral_bridge_width_mm'].min())
             min_total_bridge_width_mm = min_dorsal_bridge_width_mm + min_ventral_bridge_width_mm
+
+            # Convert the sagittal and axial slices from RPI to the original orientation
+            # 'x' because R-L direction (first in RPI --> 'x')
+            sagittal_slice = rpi_slice_to_orig_orientation(dim, self.orientation, sagittal_slice, 'x')
+            # 'z' because S-I direction (third in RPI --> 'z')
+            min_dorsal_bridge_width_slice = rpi_slice_to_orig_orientation(dim, self.orientation,
+                                                                          min_dorsal_bridge_width_slice, 'z')
+            min_ventral_bridge_width_slice = rpi_slice_to_orig_orientation(dim, self.orientation,
+                                                                           min_ventral_bridge_width_slice, 'z')
 
             # Save the minimum tissue bridges
             self.measure_pd.loc[idx, f'slice_{sagittal_slice}_dorsal_bridge_width [mm]'] = min_dorsal_bridge_width_mm


### PR DESCRIPTION
## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Just a first prototype to solve https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4592

<details><summary>master</summary>

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/dbb8ba74-f686-498e-a652-e41919378cbf">

</details>

<details><summary>this branch</summary>

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/560d4246-dc11-402c-b4ce-debdf7aa9206">

Notice that the slice numbers now correspond to the original image orientation (and not to RPI used by `sct_analyze_lesion`).

</details>

## How to test the PR

```console
cd sci-zurich/derivatives/labels/sub-zh102/ses-01/anat
sct_analyze_lesion.py -m sub-zh102_ses-01_acq-sag_T2w_lesion-manual.nii.gz -s sub-zh102_ses-01_acq-sag_T2w_seg-manual.nii.gz -qc qc
```

## Linked issues

Resolves https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4592
