### PR TITLE
Add `--use-pep517` to install scripts to silence warning

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -664,7 +664,7 @@ fi
   # https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4352
   SYSTEM_VERSION_COMPAT=0 python/envs/venv_sct/bin/pip install -r "$REQUIREMENTS_FILE" --ignore-installed certifi &&
   print info "Installing spinalcordtoolbox..." &&
-  python/envs/venv_sct/bin/pip install -e .
+  python/envs/venv_sct/bin/pip install -e . --use-pep517
 ) ||
   die "Failed running pip install: $?"
 

--- a/install_sct.bat
+++ b/install_sct.bat
@@ -182,7 +182,7 @@ echo ### Installing SCT and its dependencies from %requirements_file%...
 rem Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)
 python\envs\venv_sct\python -m pip install -U "pip^!=21.2.*" || goto error
 python\envs\venv_sct\Scripts\pip install -r %requirements_file% || goto error
-python\envs\venv_sct\Scripts\pip install -e . || goto error
+python\envs\venv_sct\Scripts\pip install -e . --use-pep517 || goto error
 
 rem Install external dependencies
 echo:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Pip has started throwing a deprecation warning for `setup.py develop` behavior that gets invoked when we run `pip install -e .`. From what I can tell, though, the upcoming change in `pip==25.0` is mainly a backend change that will be largely invisible.

Since the core Python part (`spinalcordtoolbox`) is a very straightforward package, with no C++ extensions or other complicated build requirements, I think that the switch from `setup.py develop` to the new wheel-building behavior should have no effect. And in fact, it's probably fine to leave `pip install -e .` as-is and let the upgrade to `pip==25.0` happen silently in the background (meaning that I don't think this PR is urgent?). But, I'm seeking clarity on this here: https://github.com/pypa/pip/issues/11457#issuecomment-2276205988

But, I'm manually invoking here to A) silence the warnings and B) test to see if it has any effect. In case `pip==25.0` causes an error, we'll need to backport this change, but I would be very surprised if `pip` did something so destructive, so I think we should be fine.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4599.
