### PR TITLE
Properly maintain verbose status for internal ANTs `run_proc` call (to silence logging for `-v 0`)

### DIFF
--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -211,7 +211,9 @@ class Transform:
                       '-i', fname_src,
                       '-o', fname_out,
                       '-t'
-                      ] + fname_warp_list_invert + ['-r', fname_dest] + interp, is_sct_binary=True)
+                      ] + fname_warp_list_invert + ['-r', fname_dest] + interp,
+                     verbose=verbose,
+                     is_sct_binary=True)
 
         # if 4d, loop across the T dimension
         else:


### PR DESCRIPTION
## Description

In SCT CLI scripts, it is very common to want to apply a warping field to an image mid-processing (e.g. during registration, motion correction, etc.). SCT has a separate CLI script for this (`sct_apply_transfo`), which means that we're often calling one CLI script from another CLI script. 

In every single case of this, the sub-call specifies `-v 0` (to silence the logging messages, presumably because the intermediate output would be confusing/distracting from the "main" processing). However, this verbose status is not actually propagated to the call from `sct_apply_transfo` (the SCT wrapper script) to `antsApplyTransfo` (the ANTs binary that does the actual warping).

This means that, for scripts such as MOCO that apply warping fields repeatedly to a 4D image, we get a lot of noisy output that interrupts the pretty TQDM progress bar:

![image](https://github.com/user-attachments/assets/d93fbbb1-502d-428e-90f5-d9ddd3b4217c)

By propagating the `-v 0` status, we get this instead:

![image](https://github.com/user-attachments/assets/9950b780-f1db-456a-b4b0-75d9cd89caa0)

## Concerns

This change will also silence the logging output for registration, straightening, etc. However, I don't think this will have a negative effect, because there is typically always logging prior to the call to `sct_apply_transfo`, and so the blue text is extraneous. For example:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/d151cc390a088bbc3251cc1a3086abd602b24dfd/spinalcordtoolbox/registration/core.py#L169-L178

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4581.