### PR TITLE
Address deprecation by manually performing previous RTD Sphinx context injection 

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -140,6 +140,15 @@ html_context = {
     "page_source_suffix": "rst",
 }
 
+# Set canonical URL from the Read the Docs Domain
+# NB: This was previously defined by RTD, but RTD no longer performs Sphinx context injection.
+# See also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4565
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

These code changes are copied from https://about.readthedocs.com/blog/2024/07/addons-by-default/.

I've also manually enabled the new RTD Addons feature as a way of preempting the future switch described in the above link and also https://docs.readthedocs.io/en/stable/addons.html#enabling-read-the-docs-addons:

> Note
>
> Read the Docs Addons will be enabled by default for all Read the Docs projects some time in the second half of 2024.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4565.
