### PR TITLE
Skip `-h` duration test on macOS CI runners due to sporadic runtimes

### DIFF
--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -1,5 +1,7 @@
 # pytest unit tests for all cli scripts
 
+import os
+import sys
 import pytest
 from importlib.metadata import entry_points
 import subprocess
@@ -28,4 +30,8 @@ def test_calling_scripts_with_no_args_shows_usage(capsys, script):
     duration = time.time() - start_time
     assert completed_process.returncode == 2
     assert b'usage' in completed_process.stderr
-    assert duration < 2.0, f"Expected '{script} -h' to execute in under 2.0s, but took {duration}"
+    # NB: macOS GitHub Actions runners are inconsistent in their processing speed. Sometimes our requirement is met,
+    #     and other times scripts take significantly longer. It's possible to just "retry" the GHA run, but to save
+    #     development headache, we just skip this check if we're on a macOS GitHub Actions runner.
+    if not (sys.platform.startswith("darwin") and "CI" in os.environ):
+        assert duration < 2.0, f"Expected '{script} -h' to execute in under 2.0s, but took {duration}"


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The problem described in #4515 turned out to not be a "one in a blue moon" kind of slowdown. I'd figure it's more a 50/50 chance to get a slow macOS runner, and so I've been having to repeatedly restart the cron jobs to ensure passing runs.

We could go with a fancier solution (checking the runner hardware, having a different "passing" time for macOS, etc.) but given that our other platforms (Ubuntu, Windows) have _never_ failed this check, I think it should be OK to rely on them as a signal for whether a PR is adding a slow import.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4515.