### PR TITLE
Add more intuitive feedback when no metrics can be extracted from input data

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -567,9 +567,9 @@ def save_as_csv(agg_metric, fname_out, fname_in=None, append=False):
         with open(fname_out, 'w', newline='') as csvfile:
             # spamwriter = csv.writer(csvfile, delimiter=',')
             header = ['Timestamp', 'SCT Version', 'Filename', 'Slice (I->S)', 'VertLevel', 'DistancePMJ']
-            agg_metric_key = [v for i, (k, v) in enumerate(agg_metric.items())][0]
+            first_metric_group = list(agg_metric.values())[0]
             for item in list_item:
-                for key in agg_metric_key:
+                for key in first_metric_group.keys():
                     if item in key:
                         header.append(key)
                         break

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -567,7 +567,7 @@ def save_as_csv(agg_metric, fname_out, fname_in=None, append=False):
         with open(fname_out, 'w', newline='') as csvfile:
             # spamwriter = csv.writer(csvfile, delimiter=',')
             header = ['Timestamp', 'SCT Version', 'Filename', 'Slice (I->S)', 'VertLevel', 'DistancePMJ']
-            first_metric_group = list(agg_metric.values())[0]
+            first_metric_group = list(agg_metric.values())[0] if agg_metric else {}
             for item in list_item:
                 for key in first_metric_group.keys():
                     if item in key:

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -317,11 +317,14 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], distan
             slicegroups = [tuple(slices)]
     agg_metric = {}
     # loop across slice group
-    for slicegroup in slicegroups:
+    for i, slicegroup in enumerate(slicegroups):
         # Skip empty slicegroups. This can occur if, for example, the user requests vertlevels that are not in the
         # data. e.g. -vert 4:7 but data only has 5+6. In that case, vertgroups = [(4,), (5,), (6,), (7,)] but
         # slicegroups = [(), (2,), (1,), ()].
         if not slicegroup:
+            warning_msg_vert = f" (vertebral level {vertgroups[i]})" if vertgroups else ""
+            logging.warning(f"WARNING: No slices present in slicegroup {i}{warning_msg_vert}. "
+                            f"Please check that your requested slices/levels are present in the input data files.")
             continue
 
         # initialize slicegroup entry

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -570,7 +570,7 @@ def save_as_csv(agg_metric, fname_out, fname_in=None, append=False):
         with open(fname_out, 'w', newline='') as csvfile:
             # spamwriter = csv.writer(csvfile, delimiter=',')
             header = ['Timestamp', 'SCT Version', 'Filename', 'Slice (I->S)', 'VertLevel', 'DistancePMJ']
-            first_metric_group = list(agg_metric.values())[0] if agg_metric else {}
+            first_metric_group = next(iter(agg_metric.values()), {})
             for item in list_item:
                 for key in first_metric_group.keys():
                     if item in key:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #4552, @jcohenadad tried extracting metrics from a user's data, but the template/atlas files were empty. This meant that the specified vertlevels had no corresponding slices, and thus no metrics could be extracted.

We already have a conditional for when this occurs:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/a7a3f8dd021b6b7f8d2b9fa2680002ed4b1c5f2c/spinalcordtoolbox/aggregate_slicewise.py#L321-L325

Yet, we don't provide any feedback to the user when this happening. Even worse, when _all_ of the slicegroups are empty, the `save_as_csv` function fails in an ugly way.

So, this PR ensures that warnings are thrown + no crash occurs, making it easier for the user to debug their own data:

![image](https://github.com/user-attachments/assets/9bc1ada9-d07f-4ebb-a450-b7942ba65e0e)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4552.