### PR TITLE
Allow error code 406 in broken link checker

### DIFF
--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -33,6 +33,23 @@ if [[ $status_code -ge 200 && $status_code -le 299 ]];then
     exit 0
 fi
 
+# Check for "406 Not Acceptable" error code (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406)
+# From https://http.dev/406: "In practice, this error is rarely used because the server supplies a default
+#                             representation instead."
+# We encountered this error for the 'Radiopaedia.org' domain.
+# After some searching, I believe there are two main causes of this error:
+#   - Overly strict 'Accept-*' headers. (In our case, the default header for curl, wget, etc. specifies "accept: */*",
+#                                        which is about as open as can be. So I don't think this is the culprit.)
+#   - User-agent strings (see e.g. https://stackoverflow.com/a/10043347). (Changing this locally still resulted in 406.)
+#
+# My best guess is that this due to either A) misconfigured CloudFlare B) a way to prevent LLMs from scraping content.
+# So, for now, we just filter out this response, as there's a good chance that this is still accessible via browsers.
+if [[ $status_code -eq 406 ]];then
+    echo "($status_code) $URL ($filename)" >> valid_urls.txt
+    echo -e "$filename: \x1B[32m⚠️  Warning - Not Acceptable - status code: $status_code for domain $URL  \x1B[0m"
+    exit 0
+fi
+
 # Report failure
 echo "($status_code) $URL ($filename)" >> invalid_urls.txt
 echo -e "$filename: \x1B[31m⛔ Error status code: $status_code for URL: $URL \x1B[0m"


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Our "broken link checker" CI workflow started failing a few days ago due to the Radiopaedia.org domain. The links open fine in browser, but they can't be fetched by curl/wget. I also tried using https://http.app/, but got the same error.

I spent an hour or so deep-diving into the error code, but I couldn't identify the source of the error, so my best guess is that this is a configuration issue in Radiopaedia.org's CloudFlare settings, or an attempt to stop crawlers from scraping Radiopaedia's articles (due to recent LLM controversies re: ignoring `robots.txt`).

We could have also filtered the Radiopaedia domain (as we had done in the past with other domains), but due to the limited scope of the 406 error code, I figure that filtering it would allow us to continue checking Radiopaedia for other return codes (in case their config changes again in the future).

> [!NOTE]
> I also took ownership of the notifications for this workflow (by disabling then re-enabling the workflow) that way there are fewer notifications for @mguaypaq to have to manage.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A.
