### PR TITLE
Expose `space` API parameter in centerline CLI to allow user to specify `-space phys`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -85,6 +85,15 @@ def get_parser():
         help="Binary or soft centerline. 0 = binarized, 1 = soft. Only relevant with -method fitseg."
     )
     optional.add_argument(
+        "-space",
+        metavar=Metavar.str,
+        type=str,
+        choices=["pix", "phys"],
+        default="pix",
+        help="The coordinate space to use for units when outputting the centerline coordinates to a .csv file."
+             "'pix'=pixel dimensions, 'phys'=physical dimensions."
+    )
+    optional.add_argument(
         "-extrapolation",
         metavar=Metavar.int,
         type=int,
@@ -207,6 +216,7 @@ def main(argv: Sequence[str]):
     # Extrapolate and regularize (or detect if optic) cord centerline
     im_centerline, arr_centerline, _, _ = get_centerline(im_labels,
                                                          param=param_centerline,
+                                                         space=arguments.space,
                                                          verbose=verbose,
                                                          remove_temp_files=arguments.r)
 

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_get_centerline_output_file_exists(tmp_path):
+@pytest.mark.parametrize('space', ["pix", "phys"])
+def test_sct_get_centerline_output_file_exists(tmp_path, space):
     """This test checks the output file using default usage of the CLI script.
 
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)
@@ -22,7 +23,8 @@ def test_sct_get_centerline_output_file_exists(tmp_path):
     'unit_testing/test_centerline.py'. For more details, see:
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774/commits/5e6bd57abf6bcf825cd110e0d74b8e465d298409
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774#discussion_r450546434"""
-    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-qc', str(tmp_path)])
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-space', space,
+                                  '-qc', str(tmp_path)])
     for file in [sct_test_path('t2s', 't2s_centerline.nii.gz'), sct_test_path('t2s', 't2s_centerline.csv')]:
         assert os.path.exists(file)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

For sample T2* data...

`pix`:

![image](https://github.com/user-attachments/assets/2e056e0c-74ff-4373-9a22-2647ddeaa5e8)

`phys`:

![image](https://github.com/user-attachments/assets/4a1337c0-c87c-4f08-bf4b-6a1be8e1bd4c)

> [!NOTE]
> The affine for the test `t2s.nii.gz` has non-diagonal values (i.e. rotation), hence the different `phys` coordinates for the same `x` `pix` coordinates.
> 
> ![image](https://github.com/user-attachments/assets/88764b6f-e25f-408a-b1d1-c812ca01e3c3)


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4619.