### PR TITLE
Remove faulty `zip()` that breaks `-install` option

### DIFF
--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -189,7 +189,7 @@ def main(argv: Sequence[str]):
             for name_model, custom_url in zip(models_to_install, arguments.custom_url):
                 models.install_model(name_model, custom_url)
         else:
-            for name_model in zip(models_to_install):
+            for name_model in models_to_install:
                 models.install_model(name_model)
         exit(0)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a small follow-up to PR #4616. A bug slipped through -- `zip` will produce the output `(model_name,)` instead of `model_name`.

See: `sct_deepseg`: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4618/files#r1779289565

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A