### PR TITLE
Unpin `numpy<2.0` to test ivadomed's `pandas` update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy!=1.6.*,!=1.7.*,<1.9.0
+dipy!=1.6.*,!=1.7.*
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
-ivadomed
+git+https://github.com/ivadomed/ivadomed.git@ijn/1317-update-pandas-and-remove-pd.append
 matplotlib
 # `matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive.
 # However, if the user runs `jupyter` from a separate environment and sets '%matplotlib inline', then SCT's
@@ -28,8 +28,7 @@ nilearn
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
 nnunetv2==2.3.1
-# SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later. See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
-numpy<2
+numpy
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
-git+https://github.com/ivadomed/ivadomed.git@ijn/1317-update-pandas-and-remove-pd.append
+git+https://github.com/ivadomed/ivadomed.git@jn/1317-update-pandas-and-remove-pd.append
 matplotlib
 # `matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive.
 # However, if the user runs `jupyter` from a separate environment and sets '%matplotlib inline', then SCT's


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR tests the changes in https://github.com/ivadomed/ivadomed/pull/1318 to make sure that SCT can safely update to `numpy>2.0` and `pandas>2.0`. 

This isn't an urgent PR, but because the Python 3.9 EOL is coming up within the year, I want to get the ball rolling to make sure that we can safely upgrade where necessary. (If we're holding back packages like `pandas`, it may stop us from updating Python versions in the future.)

Draft PR until the CI passes.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4535.
