### PR TITLE
Debug issues with `dipy==1.9.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #     platform-specific requirements (e.g. sys.platform == 'win32')
 
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
-dipy!=1.6.*,!=1.7.*,<1.9.0
+dipy==1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

We've previously encountered issues with `dipy==1.9.0`, so we quickly pinned `dipy<1.9.0`. However, if we plan to eventually upgrade to `numpy>2.0`, we'll need to actually address these issues (and potentially get fixes merged upstream).

So, this PR is dedicated to debugging issues with `dipy==1.9.0` to ensure we can proceed.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4397
Supersedes https://github.com/spinalcordtoolbox/spinalcordtoolboxpull/4332#discussion_r1526642771

