### PR TITLE
Be good netizens when checking broken links (HEAD request only, 30s retries, respect `Retry-All`)

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -36,11 +36,10 @@ jobs:
     # so this only checks for new/changed links in the PR
     - name: Check for broken links
       run: |
-        set -eu -o pipefail
-        git diff origin/master... |
-          sed '/^diff.*CHANGES.md/,/^diff/ d' |
-          (grep '^+' || (($? == 1)) ) |
-          (grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
-          sed 's/^/diff;/' |
-          xargs -rn 1 .github/workflows/check-url.sh
+        touch valid_urls.txt redirected_urls.txt invalid_urls.txt
+        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
+          \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) |
+          xargs grep -Eio "\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]" |
+          sed 's/:/;/' |
+          xargs -n 1 ./.github/workflows/check-url.sh
         test ! -s invalid_urls.txt

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -36,10 +36,11 @@ jobs:
     # so this only checks for new/changed links in the PR
     - name: Check for broken links
       run: |
-        touch valid_urls.txt redirected_urls.txt invalid_urls.txt
-        find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) \
-          \( \! -name 'CHANGES.md' \) \( \! -name 'requirements.txt' \) \( \! -name 'requirements-freeze.txt' \) |
-          xargs grep -Eio "\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]" |
-          sed 's/:/;/' |
-          xargs -n 1 ./.github/workflows/check-url.sh
+        set -eu -o pipefail
+        git diff origin/master... |
+          sed '/^diff.*CHANGES.md/,/^diff/ d' |
+          (grep '^+' || (($? == 1)) ) |
+          (grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' || (($? == 1)) ) |
+          sed 's/^/diff;/' |
+          xargs -rn 1 .github/workflows/check-url.sh
         test ! -s invalid_urls.txt

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -17,12 +17,12 @@ HTTP_CODE_ONLY=(--write-out '%{http_code}' --output /dev/null)
 RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300)
 
 # Make sure to check both URL *and* redirections (--location) for excluded domains
-# full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
+full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
 LOCATION=$(curl "${CURL_ARGS[@]}" -- "$URL" | perl -n -e '/^[Ll]ocation: (.*)$/ && print "$1\n"')
-#if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'journals.lww.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'archive.ph'|'mirror.centos.org'|'vault.centos.org'|'%s' ]]; then
-#    echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
-#    exit 0
-#fi
+if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'journals.lww.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'archive.ph'|'mirror.centos.org'|'vault.centos.org'|'%s' ]]; then
+    echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
+    exit 0
+fi
 
 # Get the status code for the original URL
 status_code=$(curl "${CURL_ARGS[@]}" "${HTTP_CODE_ONLY[@]}" "${RETRY_ARGS[@]}" -- "$URL")

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -19,7 +19,7 @@ RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300)
 # Make sure to check both URL *and* redirections (--location) for excluded domains
 full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
 LOCATION=$(curl "${CURL_ARGS[@]}" -- "$URL" | perl -n -e '/^[Ll]ocation: (.*)$/ && print "$1\n"')
-if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'journals.lww.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'archive.ph'|'mirror.centos.org'|'vault.centos.org'|'%s' ]]; then
+if [[ "$full_info + $URL" =~ 'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'%s' ]]; then
     echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
     exit 0
 fi

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -19,7 +19,7 @@ RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300)
 # Make sure to check both URL *and* redirections (--location) for excluded domains
 full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
 LOCATION=$(curl "${CURL_ARGS[@]}" -- "$URL" | perl -n -e '/^[Ll]ocation: (.*)$/ && print "$1\n"')
-if [[ "$full_info + $URL" =~ 'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'%s' ]]; then
+if [[ "$full_info + $URL" =~ 'twitter.com'|'spiedigitallibrary.org'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'%s' ]]; then
     echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
     exit 0
 fi

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -16,13 +16,13 @@ if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.
 fi
 
 # Get the status code for the original URL
-status_code=$(curl --write-out '%{http_code}' --silent --insecure --output /dev/null -- "$URL")
+status_code=$(curl --write-out '%{http_code}' -I --silent --insecure --output /dev/null -- "$URL")
 
 # If there is a redirection, then re-run curl with --location, then continue to check success/failure
 if [[ $status_code -ge 300 && $status_code -le 399 ]];then
     echo "($status_code) $URL ($filename)" >> redirected_urls.txt
     echo -e "$filename: \x1B[33m⚠️  Warning - Redirection - code: $status_code for URL $URL --> $LOCATION \x1B[0m"
-    status_code=$(curl --write-out '%{http_code}' --silent --insecure --location --output /dev/null -- "$URL")
+    status_code=$(curl --write-out '%{http_code}' -I --silent --insecure --location --output /dev/null -- "$URL")
     URL=$LOCATION
 fi
 

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -17,12 +17,12 @@ HTTP_CODE_ONLY=(--write-out '%{http_code}' --output /dev/null)
 RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300)
 
 # Make sure to check both URL *and* redirections (--location) for excluded domains
-full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
+# full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
 LOCATION=$(curl "${CURL_ARGS[@]}" -- "$URL" | perl -n -e '/^[Ll]ocation: (.*)$/ && print "$1\n"')
-if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'journals.lww.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'archive.ph'|'mirror.centos.org'|'vault.centos.org'|'%s' ]]; then
-    echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
-    exit 0
-fi
+#if [[ "$full_info + $URL" =~ 'drive.google.com'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'journals.lww.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'archive.ph'|'mirror.centos.org'|'vault.centos.org'|'%s' ]]; then
+#    echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
+#    exit 0
+#fi
 
 # Get the status code for the original URL
 status_code=$(curl "${CURL_ARGS[@]}" "${HTTP_CODE_ONLY[@]}" "${RETRY_ARGS[@]}" -- "$URL")


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

curl was returning error code 429 when testing arxiv links. Initially, I thought to retry requests with a delay, but on further investigation, I found that we were missing `-I`/`--head` (i.e. a HEAD request), meaning we were fetching the full text when we checked for broken links. D:

To fix this, I've made sure we use a standard set of args for all of our curl requests. 

Still, I wanted to keep the retry arguments, since curl implements them in a respectful way (https://github.com/curl/curl/commit/640b9733de74d629af68afcad0ff8bb658e80eff), and this may help to avoid noise from one-off network issues.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4648 
