### PR TITLE
Add an interactive check before deleting output directory when downloading data

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -366,8 +366,27 @@ def install_named_dataset(dataset_name, dest_folder=None, keep=False):
                          f"{sorted(list(DATASET_DICT.keys()), key=str.casefold)}")
 
     urls = DATASET_DICT[dataset_name]["mirrors"]
+
+    # Fetch default location if user doesn't specify output
     if dest_folder is None:
         dest_folder = DATASET_DICT[dataset_name]["default_location"]
+
+    # Otherwise, ensure we don't accidentally overwrite a critical user folder
+    else:
+        if os.path.isdir(dest_folder) and os.listdir(dest_folder) and not keep:
+            logger.warning(f"Output directory '{dest_folder}' exists and is non-empty. Contents will be erased.")
+            while True:
+                answer = input("Do you wish to overwrite this directory? ([Y]es/[N]o): ")
+                if answer.lower() in ["y", "yes"]:
+                    break  # keep = False
+                elif answer.lower() in ["n", "no"]:
+                    keep = True
+                    break
+                else:
+                    logger.warning(f"Invalid input '{answer}'")
+
+            logger.warning("Note: You can suppress this message by specifying `-k` (keep) or by deleting the "
+                           "directory in advance.")
 
     install_data(urls, dest_folder, keep)
 

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -366,27 +366,8 @@ def install_named_dataset(dataset_name, dest_folder=None, keep=False):
                          f"{sorted(list(DATASET_DICT.keys()), key=str.casefold)}")
 
     urls = DATASET_DICT[dataset_name]["mirrors"]
-
-    # Fetch default location if user doesn't specify output
     if dest_folder is None:
         dest_folder = DATASET_DICT[dataset_name]["default_location"]
-
-    # Otherwise, ensure we don't accidentally overwrite a critical user folder
-    else:
-        if os.path.isdir(dest_folder) and os.listdir(dest_folder) and not keep:
-            logger.warning(f"Output directory '{dest_folder}' exists and is non-empty. Contents will be erased.")
-            while True:
-                answer = input("Do you wish to overwrite this directory? ([Y]es/[N]o): ")
-                if answer.lower() in ["y", "yes"]:
-                    break  # keep = False
-                elif answer.lower() in ["n", "no"]:
-                    keep = True
-                    break
-                else:
-                    logger.warning(f"Invalid input '{answer}'")
-
-            logger.warning("Note: You can suppress this message by specifying `-k` (keep) or by deleting the "
-                           "directory in advance.")
 
     install_data(urls, dest_folder, keep)
 

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2015 Polytechnique Montreal <www.neuro.polymtl.ca>
 # License: see the file LICENSE
 
+import os
 import sys
 from typing import Sequence
 import textwrap
@@ -72,7 +73,28 @@ def main(argv: Sequence[str]):
     if arguments.d == "default":
         install_default_datasets(keep=arguments.k)
     else:
-        install_named_dataset(arguments.d, dest_folder=arguments.o, keep=arguments.k)
+        keep = arguments.k
+        dest_folder = arguments.o
+
+        # Make sure we don't accidentally overwrite a critical user folder
+        if os.path.isdir(dest_folder) and os.listdir(dest_folder) and not keep:
+            printv(f"Output directory '{dest_folder}' exists and is non-empty. Contents will be erased.",
+                   type="warning")
+
+            while True:
+                answer = input("Do you wish to overwrite this directory? ([Y]es/[N]o): ")
+                if answer.lower() in ["y", "yes"]:
+                    break  # keep = False
+                elif answer.lower() in ["n", "no"]:
+                    keep = True
+                    break
+                else:
+                    printv(f"Invalid input '{answer}'", type="warning")
+
+            printv("Note: You can suppress this message by specifying `-k` (keep) or by deleting the "
+                   "directory in advance.", type="warning")
+
+        install_named_dataset(arguments.d, dest_folder=dest_folder, keep=keep)
 
     printv('Done!\n', verbose)
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I've followed the logical suggestions from @mguaypaq in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4562#issuecomment-2229691874, however I've added an extra check for non-emptiness, since an empty directory seems OK to remove by default (seeing as it's just going to get remade anyway).

- ~~Note that my changes only provide protection for callers of `install_named_dataset`, meaning that `install_data` by itself is not protected. But, `install_named_dataset` is the only place we do the "default vs. non-default location" check, so I think it's the only place we *can* add this safety valve.~~ EDIT: See below.
   - ~~The only other usage of `install_data` is `install_model` (`sct_deepseg`), however, and sct_deepseg does not allow specifying a custom output directory when installing. So, I think this is suitable?~~
- One other note is that I find it a bit weird to reference CLI args from API functions. Is that a hint that this check should actually be performed in the `sct_download_data` CLI script? (i.e. checking `arguments.o` and `arguments.k` in the layer above)
   - One argument for this is that we probably don't want interactive prompts to occur at an API level. EDIT: In writing this out, I've actually convinced myself, aha. Revising now!  

## Testing

![image](https://github.com/user-attachments/assets/a649f88b-3bff-4629-8223-3b04b49a9bc3)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4562.
