### PR TITLE
Remove `/en/latest/` slugs from `spinalcordtoolbox.com` URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ For macOS and Linux users, the simplest way to install SCT is to download `the l
 
    ./install_sct
 
-For more complex installation setups (Windows users, Docker, FSLeyes integration), see the `Installation <https://spinalcordtoolbox.com/en/latest/user_section/installation.html>`_ page.
+For more complex installation setups (Windows users, Docker, FSLeyes integration), see the `Installation <https://spinalcordtoolbox.com/user_section/installation.html>`_ page.
 
 
 Usage
@@ -105,19 +105,19 @@ For a full overview of the available commands, see the `Command-Line Tools <http
 
 **2. Multi-command pipelines**
 
-To facilitate multi-subject analyses, commands can be chained together to build processing pipelines. The best starting point for constructing a typical pipeline is the `batch_processing.sh <https://spinalcordtoolbox.com/en/latest/user_section/getting-started.html#batch-processing-example>`_ script, which is provided with your installation of SCT.
+To facilitate multi-subject analyses, commands can be chained together to build processing pipelines. The best starting point for constructing a typical pipeline is the `batch_processing.sh <https://spinalcordtoolbox.com/user_section/getting-started.html#batch-processing-example>`_ script, which is provided with your installation of SCT.
 
 **3. GUI (FSLeyes integration)**
 
-SCT provides a graphical user interface via a FSLeyes plugin. For more details, see the `FSLeyes Integration <https://spinalcordtoolbox.com/en/latest/user_section/fsleyes.html>`_ page.
+SCT provides a graphical user interface via a FSLeyes plugin. For more details, see the `FSLeyes Integration <https://spinalcordtoolbox.com/user_section/fsleyes.html>`_ page.
 
 
 Who is using SCT?
 -----------------
 
-SCT is trusted by the research labs of many highly-regarded institutions worldwide. A full list of endorsements can be found on the `Testimonials <https://spinalcordtoolbox.com/en/latest/overview/testimonials.html>`_ page.
+SCT is trusted by the research labs of many highly-regarded institutions worldwide. A full list of endorsements can be found on the `Testimonials <https://spinalcordtoolbox.com/overview/testimonials.html>`_ page.
 
-For a list of neuroimaging studies that depend on SCT, visit the `Studies using SCT <https://spinalcordtoolbox.com/en/latest/overview/studies.html>`_ page.
+For a list of neuroimaging studies that depend on SCT, visit the `Studies using SCT <https://spinalcordtoolbox.com/overview/studies.html>`_ page.
 
 
 Contact

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -69,7 +69,7 @@ def get_parser():
             "\n"
             "The labels used by default are taken from the PAM50 template. To learn about the available PAM50 "
             "white/grey matter atlas labels and their corresponding ID values, please refer to: "
-            "https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas\n"
+            "https://spinalcordtoolbox.com/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas\n"
             "\n"
             "To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
             "`sct_extract_metric -i dti_FA.nii.gz -l 0,2,3 -vert 2:7 -method bin`\n"

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -82,7 +82,7 @@ def get_parser():
               sct_register_to_template -i data.nii.gz -s data_seg.nii.gz -l data_labels.nii.gz
               ```
 
-            If this default command does not produce satisfactory results, the `-param` argument should be tweaked according to the tips given here: https://spinalcordtoolbox.com/en/latest/user_section/command-line.html#sct-register-multimodal
+            If this default command does not produce satisfactory results, the `-param` argument should be tweaked according to the tips given here: https://spinalcordtoolbox.com/user_section/command-line.html#sct-register-multimodal
 
             The default registration method brings the subject image to the template, which can be problematic with highly non-isotropic images as it would induce large interpolation errors during the straightening procedure. Although the default method is recommended, you may want to register the template to the subject (instead of the subject to the template) by skipping the straightening procedure. To do so, use the parameter `-ref subject`. Example below:
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The broken link checker caught these!

SCT's RTD config is _not_ set to the "Multiple versions with translations" option, because we don't have any non-English translations.

![image](https://github.com/user-attachments/assets/956138cb-303d-4548-99b5-3f67af6a1835)

Because of this, the presence of `/en/` breaks our URLs, and so we rely on a custom redirect just to keep these links alive. 

![image](https://github.com/user-attachments/assets/66d17693-006c-4910-a205-aee9fd57c11c)

However, just for future-proofing, it would be better to just use our "base" url, then let RTD's built-in redirects do their magic (i.e. to stable instead of latest). This way, when we change from having "latest" as our default to "stable" (like we've just done recently), the links update appropriately without needing to change the actual slugs.

(Note: Most of the URLs in our project are the "base" urls, but a few had `/en/latest/`, so this PR unifies our docs.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A
