### PR TITLE
Handle newly-broken links (retries, FSLWiki changes)

### DIFF
--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -14,7 +14,7 @@ CURL_ARGS=(--head --silent --insecure)
 HTTP_CODE_ONLY=(--write-out '%{http_code}' --output /dev/null)
 # Override default behavior (exponential backoff + 10m limit) since we don't need that many retries
 # We still keep a 5m limit, though, because --retry respects the Retry-After field, which may be greater than 30s.
-RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300)
+RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300 --retry-all-errors)
 
 # Make sure to check both URL *and* redirections (--location) for excluded domains
 full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")

--- a/documentation/source/overview/concepts/inspecting-results-qc-fsleyes.rst
+++ b/documentation/source/overview/concepts/inspecting-results-qc-fsleyes.rst
@@ -67,7 +67,7 @@ This workflow is especially useful if you are performing multi-subject batch ana
 FSLeyes
 *******
 
-If you have the `FSLeyes <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_ tool installed, then some of SCT's scripts will also print a ``fsleyes`` command as part of their output.
+If you have the `FSLeyes <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/utilities/fsleyes>`_ tool installed, then some of SCT's scripts will also print a ``fsleyes`` command as part of their output.
 
 .. code:: sh
 

--- a/documentation/source/overview/concepts/inspecting-results-qc-fsleyes.rst
+++ b/documentation/source/overview/concepts/inspecting-results-qc-fsleyes.rst
@@ -67,7 +67,7 @@ This workflow is especially useful if you are performing multi-subject batch ana
 FSLeyes
 *******
 
-If you have the `FSLeyes <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_ tool installed, then some of SCT's scripts will also print a ``fsleyes`` command as part of their output.
+If you have the `FSLeyes <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_ tool installed, then some of SCT's scripts will also print a ``fsleyes`` command as part of their output.
 
 .. code:: sh
 

--- a/documentation/source/overview/concepts/spaces-and-coordinates.rst
+++ b/documentation/source/overview/concepts/spaces-and-coordinates.rst
@@ -78,7 +78,7 @@ References
 - `An introduction to the NIFTI file format. <https://brainder.org/2012/09/23/the-nifti-file-format/>`_
   See *§ Orientation information* and around.
 
-- `Official definition of the nifti1 header <https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h>`_
+- `Official definition of the nifti1 header <https://web.archive.org/web/20241009085040/https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h>`_
   See *§ 3D IMAGE (VOLUME) ORIENTATION AND LOCATION IN SPACE*
 
 - `nipy/nibabel's documentation on coordinate systems

--- a/documentation/source/overview/concepts/warping-fields.rst
+++ b/documentation/source/overview/concepts/warping-fields.rst
@@ -27,7 +27,7 @@ In the broader ecosystem of MRI software, there are two common conventions for r
 
   * Originates from Insight Toolkit (ITK), so it's also referred to as the ITK format.
   * Used by SCT and Advanced Normalization Tools (ANTs).
-  * Defined in the "Vector-Valued Datasets" section of the `NIFTI1 Specification <https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h>`_.
+  * Defined in the "Vector-Valued Datasets" section of the `NIFTI1 Specification <https://web.archive.org/web/20241009085040/https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h>`_.
 
 * **4D vector format**, ``[x, y, z, v]``:
 

--- a/documentation/source/overview/concepts/warping-fields.rst
+++ b/documentation/source/overview/concepts/warping-fields.rst
@@ -32,7 +32,7 @@ In the broader ecosystem of MRI software, there are two common conventions for r
 * **4D vector format**, ``[x, y, z, v]``:
 
   * Used by the FMRIB Software Library (FSL) and Statistical Parametric Mapping (SPM) software packages.
-  * Defined in the "Deformation model" section of the `FSLWiki <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UserGuide#Deformation_model>`_
+  * Defined in the "Deformation model" section of the `FSLWiki <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UserGuide#Deformation_model>`_
 
 For both formats, the ``v`` axis will be of size 3:
 
@@ -43,7 +43,7 @@ For both formats, the ``v`` axis will be of size 3:
 Compatibility with non-ITK software (FSL, SPM)
 ==============================================
 
-SCT generates warping fields in the 5D composite ITK format. This format is not compatible with non-ITK software that expects the 4D vector format (such as the `FSL command applywarp <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UserGuide#Now_what.3F_--_applywarp.21>`_). So, you will need to convert the warping field using :ref:`sct_image`.
+SCT generates warping fields in the 5D composite ITK format. This format is not compatible with non-ITK software that expects the 4D vector format (such as the `FSL command applywarp <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UserGuide#Now_what.3F_--_applywarp.21>`_). So, you will need to convert the warping field using :ref:`sct_image`.
 
 
 

--- a/documentation/source/user_section/fsleyes.rst
+++ b/documentation/source/user_section/fsleyes.rst
@@ -4,18 +4,18 @@
 FSLeyes Integration
 *******************
 
-`FSLeyes <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_
-is part of the larger `FSL <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki>`_ package, which is a library
+`FSLeyes <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/utilities/fsleyes>`_
+is part of the larger `FSL <https://fsl.fmrib.ox.ac.uk/fsl/docs>`_ package, which is a library
 containing tools for FMRI, MRI, and DTI brain imaging data. ``FSLeyes`` is the image viewer for this package, and can
 be installed as either part of the ``FSL`` package, or as a standalone app.
 
-Previously, SCT provided instructions on how to install FSLeyes into the SCT environment. However, we now request that you install FSLeyes separately and manage the installation on your own. You can find installation instructions for FSLeyes at `this link <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_.
+Previously, SCT provided instructions on how to install FSLeyes into the SCT environment. However, we now request that you install FSLeyes separately and manage the installation on your own. You can find installation instructions for FSLeyes at `this link <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/utilities/fsleyes>`_.
 
 .. warning::
 
    If you choose to install FSLeyes via a complete FSL installation, you will need to update 'wxpython' (an internal package used by FSLeyes). This is because the version of 'wxpython' that comes with FSL is out of date (`more info here <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661>`_).
 
-   To update, please run one of the the following commands (`depending on your FSL version <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_):
+   To update, please run one of the the following commands (`depending on your FSL version <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/utilities/fsleyes>`_):
 
    .. note:: The terminal commands in these instructions may require administrative privileges, depending on where you have installed FSL.
 

--- a/documentation/source/user_section/fsleyes.rst
+++ b/documentation/source/user_section/fsleyes.rst
@@ -5,7 +5,7 @@ FSLeyes Integration
 *******************
 
 `FSLeyes <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/utilities/fsleyes>`_
-is part of the larger `FSL <https://fsl.fmrib.ox.ac.uk/fsl/docs>`_ package, which is a library
+is part of the larger `FSL <https://fsl.fmrib.ox.ac.uk/fsl/docs/#/>`_ package, which is a library
 containing tools for FMRI, MRI, and DTI brain imaging data. ``FSLeyes`` is the image viewer for this package, and can
 be installed as either part of the ``FSL`` package, or as a standalone app.
 

--- a/documentation/source/user_section/fsleyes.rst
+++ b/documentation/source/user_section/fsleyes.rst
@@ -4,18 +4,18 @@
 FSLeyes Integration
 *******************
 
-`FSLeyes <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_
-is part of the larger `FSL <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki>`_ package, which is a library
+`FSLeyes <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_
+is part of the larger `FSL <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki>`_ package, which is a library
 containing tools for FMRI, MRI, and DTI brain imaging data. ``FSLeyes`` is the image viewer for this package, and can
 be installed as either part of the ``FSL`` package, or as a standalone app.
 
-Previously, SCT provided instructions on how to install FSLeyes into the SCT environment. However, we now request that you install FSLeyes separately and manage the installation on your own. You can find installation instructions for FSLeyes at `this link <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_.
+Previously, SCT provided instructions on how to install FSLeyes into the SCT environment. However, we now request that you install FSLeyes separately and manage the installation on your own. You can find installation instructions for FSLeyes at `this link <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_.
 
 .. warning::
 
    If you choose to install FSLeyes via a complete FSL installation, you will need to update 'wxpython' (an internal package used by FSLeyes). This is because the version of 'wxpython' that comes with FSL is out of date (`more info here <https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3988#issuecomment-1373918661>`_).
 
-   To update, please run one of the the following commands (`depending on your FSL version <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_):
+   To update, please run one of the the following commands (`depending on your FSL version <https://web.archive.org/web/20230130154018/https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes>`_):
 
    .. note:: The terminal commands in these instructions may require administrative privileges, depending on where you have installed FSL.
 

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -160,7 +160,7 @@ class Transform:
                     and Image(list_warp[idx_warp]).header.get_intent()[0] != 'vector':
                 raise ValueError("Displacement field in {} is invalid: should be encoded"
                                  " in a 5D file with vector intent code"
-                                 " (see https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h"
+                                 " (see https://web.archive.org/web/20241009085040/https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h"
                                  .format(path_warp))
         # need to check if last warping field is an affine transfo
         isLastAffine = False

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -61,7 +61,7 @@ def main(argv: Sequence[str]):
                 and Image(fname_warp_list[idx_warp]).header.get_intent()[0] != 'vector':
             raise ValueError("Displacement field in {} is invalid: should be encoded"
                              " in a 5D file with vector intent code"
-                             " (see https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h"
+                             " (see https://web.archive.org/web/20241009085040/https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h"
                              .format(path_warp))
 
     # check if destination file is 3d


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR is meant to handle the broken links from the latest CI run: https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/11477585088/job/31939986634

- The `nifti1.h` link is more of an intermittent network issue; the link [does pass](https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/11477585088/job/31939986634#step:3:988) in other checks. So, I think we may need to be a little more aggressive with our retries. (570f2ca55fd25a92250eeff776f00eba9625fdd1)
- The FSL links are due to the change from the old FSLWiki to the new docs. No links were preserved, so we need to either update them to their new docs where applicable, or use the Wayback Machine when there is no analog. (FSL also provides https://fsl.fmrib.ox.ac.uk/fsl/oldwiki/, but all of the page links 404 at the moment.)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4653.
