### PR TITLE
Fix dtype mismatch error when mixing integers and floating point numbers

### DIFF
--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -459,14 +459,16 @@ def main(argv: Sequence[str]):
                         list_data = get_data_arrays(data.shape, arg_value)
                     except ValueError as e:
                         printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                    data += np.sum(list_data, axis=0)
+                    # the addition can't use += because the dtypes could be different
+                    data = data + np.sum(list_data, axis=0)
 
             elif arg_name == "sub":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                data -= np.sum(list_data, axis=0)
+                # the subtraction can't use -= because the dtypes could be different
+                data = data - np.sum(list_data, axis=0)
 
             elif arg_name == "mul":
                 if data.ndim == 4 and not arg_value:
@@ -477,14 +479,16 @@ def main(argv: Sequence[str]):
                         list_data = get_data_arrays(data.shape, arg_value)
                     except ValueError as e:
                         printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                    data *= np.prod(list_data, axis=0)
+                    # the multiplication can't use *= because the dtypes could be different
+                    data = data * np.prod(list_data, axis=0)
 
             elif arg_name == "div":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                data /= np.prod(list_data, axis=0)
+                # the division can't use /= because the dtypes could be different
+                data = data / np.prod(list_data, axis=0)
 
             elif arg_name == "mean":
                 axis = ('x', 'y', 'z', 't').index(arg_value)

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -79,6 +79,38 @@ def test_sct_maths_symmetrize(dim, tmp_path):
                           (im_in.data + np.flip(im_in.data, axis=int(dim))) / 2.0)
 
 
+def test_arithmetic_mixed_dtype(tmp_path):
+    """Test whether arithmetic operations can be performed on images with different dtypes without crashing."""
+    # make a dummy integer image
+    path_im_int = str(tmp_path / "im_int.nii.gz")
+    Image(np.ones((2, 3, 4), dtype=int)).save(path_im_int)
+
+    # make a dummy floating point image
+    path_im_float = str(tmp_path / "im_float.nii.gz")
+    Image(np.ones((2, 3, 4), dtype=float)).save(path_im_float)
+
+    # output filename, will be overwritten several times
+    path_im_out = str(tmp_path / "im_out.nii.gz")
+
+    # for each operation, test various combinations
+    for op in ["-add", "-sub", "-mul", "-div"]:
+        sct_maths.main([
+            "-i", path_im_int,
+            op, path_im_float, path_im_int,
+            "-o", path_im_out,
+        ])
+        sct_maths.main([
+            "-i", path_im_int,
+            op, path_im_int, path_im_float,
+            "-o", path_im_out,
+        ])
+        sct_maths.main([
+            "-i", path_im_float,
+            op, path_im_int,
+            "-o", path_im_out,
+        ])
+
+
 def run_arithmetic_operation(tmp_path, dims, ops):
     """Generate some dummy data, then run -add/-sub/-mul/-div on the data."""
     assert len(dims) > 1  # dim[0] -> -i, dim[1:] -> ops


### PR DESCRIPTION
We can't use in-place operators (like `+=`, `*=`) on numpy arrays for operations that would need to promote the array's dtype (for example, integer += float needs to be stored as float, but the existing array can only store integer).

I added a test which fails with "Cannot cast ufunc output dtype" on `master`, and passes with the fix in this branch.

Fixes #4652.