### PR TITLE
Update contrast agnostic model to r20241024 (improved for SCI and whole-spine T1/T2 images)

### DIFF
--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -168,6 +168,8 @@ def segment_monai(path_img, tmpdir, predictor, device: torch.device):
     # define inference patch size and center crop size
     crop_size = (64, 192, -1)
     inference_roi_size = (64, 192, 320)
+    # NOTE: this is hard-coded to "edge" based on extensive experiments comparing "edge" vs "zero" padding
+    # at test-time. 
     pad_mode = "edge"
 
     # define the dataset and dataloader

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -118,7 +118,7 @@ def segment_non_ivadomed(path_model, model_type, input_filenames, threshold, kee
     device = torch.device("cuda" if use_gpu else "cpu")
 
     # load model from checkpoint
-    net = create_net(path_model, device)
+    net = create_net(path_model, model_type, device)
 
     im_lst, target_lst = [], []
     for fname_in in input_filenames:

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -118,7 +118,7 @@ def segment_non_ivadomed(path_model, model_type, input_filenames, threshold, kee
     device = torch.device("cuda" if use_gpu else "cpu")
 
     # load model from checkpoint
-    net = create_net(path_model, model_type, device)
+    net = create_net(path_model, device)
 
     im_lst, target_lst = [], []
     for fname_in in input_filenames:

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -169,7 +169,7 @@ def segment_monai(path_img, tmpdir, predictor, device: torch.device):
     crop_size = (64, 192, -1)
     inference_roi_size = (64, 192, 320)
     # NOTE: this is hard-coded to "edge" based on extensive experiments comparing "edge" vs "zero" padding
-    # at test-time. 
+    # at test-time.
     pad_mode = "edge"
 
     # define the dataset and dataloader

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -122,7 +122,7 @@ MODELS = {
     #       - Binarization is applied within SCT code
     "model_seg_sc_contrast_agnostic_softseg_monai": {
         "url": [
-            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.4/model_soft_bin_20240425-170840.zip"
+            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.5/model_contrast-agnostic_20240930-1002.zip"
         ],
         "description": "Spinal cord segmentation agnostic to MRI contrasts using MONAI-based nnUNet model",
         "contrasts": ["any"],

--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -94,7 +94,7 @@ def create_nnunet_from_plans(path_model, model_type, device: torch.device):
     }
 
     if model_type == 'monai':
-        # NOTE: starting from contrast-agnostic v2.5, the monai-based nnunet model has more features at 
+        # NOTE: starting from contrast-agnostic v2.5, the monai-based nnunet model has more features at
         # the deeper layers of the network, hence update the max features in the `plans` dict
         plans["unet_max_num_features"] = 384
 

--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -43,7 +43,7 @@ nnunet_plans = {
 }
 
 
-def create_nnunet_from_plans(path_model, model_type, device: torch.device):
+def create_nnunet_from_plans(path_model, device: torch.device):
     """
     Adapted from nnUNet's source code:
     https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/utilities/get_network_from_plans.py#L9
@@ -92,11 +92,6 @@ def create_nnunet_from_plans(path_model, model_type, device: torch.device):
         if network_class != ResidualEncoderUNet else 'n_blocks_per_stage': plans["n_conv_per_stage_encoder"],
         'n_conv_per_stage_decoder': plans["n_conv_per_stage_decoder"]
     }
-
-    if model_type == 'monai':
-        # NOTE: starting from contrast-agnostic v2.5, the monai-based nnunet model has more features at
-        # the deeper layers of the network, hence update the max features in the `plans` dict
-        plans["unet_max_num_features"] = 384
 
     # network class name!!
     model = network_class(

--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -43,7 +43,7 @@ nnunet_plans = {
 }
 
 
-def create_nnunet_from_plans(path_model, device: torch.device):
+def create_nnunet_from_plans(path_model, model_type, device: torch.device):
     """
     Adapted from nnUNet's source code:
     https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/utilities/get_network_from_plans.py#L9
@@ -92,6 +92,11 @@ def create_nnunet_from_plans(path_model, device: torch.device):
         if network_class != ResidualEncoderUNet else 'n_blocks_per_stage': plans["n_conv_per_stage_encoder"],
         'n_conv_per_stage_decoder': plans["n_conv_per_stage_decoder"]
     }
+
+    if model_type == 'monai':
+        # NOTE: starting from contrast-agnostic v2.5, the monai-based nnunet model has more features at 
+        # the deeper layers of the network, hence update the max features in the `plans` dict
+        plans["unet_max_num_features"] = 384
 
     # network class name!!
     model = network_class(

--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -39,7 +39,9 @@ nnunet_plans = {
         [3, 3, 3],
         [3, 3, 3]
     ],
-    "unet_max_num_features": 320,
+    # NOTE: starting from contrast-agnostic v2.5, the monai-based nnunet model has more features at
+    # the deeper layers of the network, hence update the max features in the `plans` dict
+    "unet_max_num_features": 384,
 }
 
 

--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -172,7 +172,7 @@ def inference_transforms_single_image(crop_size, padding='edge'):
         LoadImaged(keys=["image"], image_only=False),
         EnsureChannelFirstd(keys=["image"]),
         Orientationd(keys=["image"], axcodes="RPI"),
-        Spacingd(keys=["image"], pixdim=(1.0, 1.0, 1.0), mode=2),
+        Spacingd(keys=["image"], pixdim=(1.0, 1.0, 1.0), mode=2),   # "2" refers to spline interpolation
         ResizeWithPadOrCropd(keys=["image"], spatial_size=crop_size, mode=padding),
         DivisiblePadd(keys=["image"], k=2 ** 5, mode=padding),
         # pad inputs to ensure divisibility by no. of layers nnUNet has (5)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR aims to update the `contrast-agnostic` MONAI model to v2.5. This model should work well on SCI images and whole-spine T1w/T2w images in addition to previous pathologies and contrasts. 

The model architecture (specifically, the number of features in the network) was updated between v2.4 and v2.5 to account for the increasing size of the training dataset. Accordingly, the code has been slightly updated to set the correct number of maximum features in the network when this model is chosen. 

## Testing the PR

1. Check out to the branch `nk/update-contrast-agnostic-to-v2.5`
3. Run `sct_deepseg -task seg_sc_contrast_agnostic -i <path-to-the-image>.nii.gz` to segment an image (this should automatically download the latest version replacing the existing one)

