### PR TITLE
Use faster dilation algorithm when dilating "mostly zero" point label images (`-x label`)

### DIFF
--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -149,7 +149,7 @@ def _dilate_point_labels(data, footprint):
         data_start = data_coords - pre_distances
         fp_start = fp_center - pre_distances
 
-        post_distances = np.min(data_shape - data_coords, fp_shape - fp_center)
+        post_distances = np.minimum(data_shape - data_coords, fp_shape - fp_center)
         data_stop = data_coords + post_distances
         fp_stop = fp_center + post_distances
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -132,8 +132,8 @@ def _dilate_point_labels(data, footprint):
     fp_shape = np.array(footprint.shape)
 
     # For odd-length dimensions, the center of the footprint is unique.
-    # For even-length dimensions, we round down.
-    fp_center = (fp_shape - 1) // 2
+    # For even-length dimensions, we round up.
+    fp_center = (fp_shape - 1 + 1) // 2
 
     data_out = np.zeros_like(data)
     for data_coords in np.argwhere(data):

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -145,7 +145,7 @@ def _dilate_point_labels(data, footprint):
         # truncated version of the footprint. These formulas compute the
         # adjusted slice start and stop coordinates in the data array, and in
         # the footprint array.
-        pre_distances = np.min(data_coords, fp_center)
+        pre_distances = np.minimum(data_coords, fp_center)
         data_start = data_coords - pre_distances
         fp_start = fp_center - pre_distances
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -184,9 +184,8 @@ def _dilate_point_labels(data, footprint):
         # Now we can apply the (possibly truncated) footprint to the right part
         # of the data array, blending in the data value with the "max" function
         np.maximum.at(
-            a=data_out,
-            indices=data_indices,
-            b=data_value*footprint[fp_indices],
+            data_out, data_indices,
+            data_value*footprint[fp_indices],
         )
 
     return data_out

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -54,17 +54,10 @@ def _get_footprint(shape, size, dim):
 
     # If 2d kernel, replicate it along the specified dimension
     if len(footprint.shape) == 2:
-        footprint3d = np.zeros([footprint.shape[0]] * 3)
-        imid = np.floor(footprint.shape[0] / 2).astype(int)
-        if dim == 0:
-            footprint3d[imid, :, :] = footprint
-        elif dim == 1:
-            footprint3d[:, imid, :] = footprint
-        elif dim == 2:
-            footprint3d[:, :, imid] = footprint
-        else:
+        if dim not in [0, 1, 2]:
             raise ValueError("dim can only take values: {0, 1, 2}")
-        footprint = footprint3d
+        footprint = np.expand_dims(footprint, dim)
+
     return footprint
 
 

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -200,7 +200,7 @@ class Transform:
                 path_tmp = tmp_create(basename="apply-transfo-3d-label")
                 fname_dilated_labels = os.path.join(path_tmp, "dilated_data.nii")
                 # dilate points
-                dilate(Image(fname_src), 3, 'ball').save(fname_dilated_labels)
+                dilate(Image(fname_src), 3, 'ball', islabel=True).save(fname_dilated_labels)
                 fname_src = fname_dilated_labels
 
             printv("\nApply transformation and resample to destination space...", verbose)

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -196,7 +196,7 @@ class Transform:
                 dim = '3'
             # if labels, dilate before resampling
             if islabel:
-                printv("\nDilate labels before warping...")
+                printv("\nDilate labels before warping...", verbose)
                 path_tmp = tmp_create(basename="apply-transfo-3d-label")
                 fname_dilated_labels = os.path.join(path_tmp, "dilated_data.nii")
                 # dilate points
@@ -285,7 +285,7 @@ class Transform:
         im_src_reg.save(verbose=0)  # set verbose=0 to avoid warning message about rewriting file
 
         if islabel:
-            printv("\nTake the center of mass of each registered dilated labels...")
+            printv("\nTake the center of mass of each registered dilated labels...", verbose)
             labeled_img = cubic_to_point(im_src_reg)
             labeled_img.save(path=fname_out)
             if remove_temp_files:

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -396,7 +396,7 @@ def main(argv: Sequence[str]):
             im_label_c2c3.save(fname_labelz)
 
         # dilate label so it is not lost when applying warping
-        dilate(Image(fname_labelz), 3, 'ball').save(fname_labelz)
+        dilate(Image(fname_labelz), 3, 'ball', islabel=True).save(fname_labelz)
 
         # Apply straightening to z-label
         printv('\nAnd apply straightening to label...', verbose)

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -281,7 +281,7 @@ def create_label_z(fname_seg, z, value, fname_labelz='labelz.nii.gz'):
     nii.data[:, :, :] = 0
     nii.data[x, y, z] = value
     # dilate label to prevent it from disappearing due to nearestneighbor interpolation
-    nii.data = dilate(nii.data, 3, 'ball')
+    nii.data = dilate(nii.data, 3, 'ball', islabel=True)
     nii.change_orientation(orientation_origin)  # put back in original orientation
     nii.save(fname_labelz)
     return fname_labelz

--- a/testing/api/test_math.py
+++ b/testing/api/test_math.py
@@ -5,6 +5,7 @@ import datetime
 
 import numpy as np
 import nibabel as nib
+import pytest
 
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
@@ -43,7 +44,8 @@ def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None):
     return img
 
 
-def test_dilate():
+@pytest.mark.parametrize('islabel', [False, True])
+def test_dilate(islabel):
 
     # Create dummy image with single pixel in the middle
     im = dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))
@@ -51,31 +53,31 @@ def test_dilate():
         im.save('tmp_dummy_im_' + datetime.now().strftime("%Y%m%d%H%M%S%f") + '.nii.gz')
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = sct_math.dilate(im.data, size=1, shape='cube')
+    data_dil = sct_math.dilate(im.data, size=1, shape='cube', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sct_math.dilate(im.data, size=2, shape='cube')
+    data_dil = sct_math.dilate(im.data, size=2, shape='cube', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
-    data_dil = sct_math.dilate(im.data, size=3, shape='cube')
+    data_dil = sct_math.dilate(im.data, size=3, shape='cube', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
     # ball (only asserting along one dimension for convenience)
-    data_dil = sct_math.dilate(im.data, size=0, shape='ball')
+    data_dil = sct_math.dilate(im.data, size=0, shape='ball', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sct_math.dilate(im.data, size=1, shape='ball')
+    data_dil = sct_math.dilate(im.data, size=1, shape='ball', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
-    data_dil = sct_math.dilate(im.data, size=2, shape='ball')
+    data_dil = sct_math.dilate(im.data, size=2, shape='ball', islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    data_dil = sct_math.dilate(im.data, size=1, shape='disk', dim=1)
+    data_dil = sct_math.dilate(im.data, size=1, shape='disk', dim=1, islabel=islabel)
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[4, 4, 2:7], np.array([0, 1, 1, 1, 0]))
-    data_dil = sct_math.dilate(im.data, size=1, shape='disk', dim=2)
+    data_dil = sct_math.dilate(im.data, size=1, shape='disk', dim=2, islabel=islabel)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
 
     # test with Image as input
-    im_dil = sct_math.dilate(im, size=1, shape='cube')
+    im_dil = sct_math.dilate(im, size=1, shape='cube', islabel=islabel)
     assert np.array_equal(im_dil.data[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
 
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Since 99.99% of voxels are 0 when `islabel=True`, we don't *need* to run dilation on every single voxel, which is what skimage will do by default. Instead, we can fetch the nonzero voxels, extract an area the size of the footprint, run dilation on that area, and then put it back.

I was concerned that this might behave differently in cases where we have two labels very close together. But, I think it ends up working identically, with the larger label dominating the smaller label (thanks to the use of `maximum` internally).

There's an even faster approach (just multiplying `footprint` by the label value, then setting the area centered on the nonzero voxel equal to this). I've implemented that as well in a follow-up approach.

## Testing

On my (fast) laptop, dilation time for a typical image went from 7s to 0.15s to <0.01s, thanks to minimizing the area we call `skimage.dilation` on, and ultimately removing `skimage.dilation` entirely.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4663.