### PR TITLE
Bump oldest macOS version used by test runners (12 -> 13)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
     needs: generate-requirements-freeze
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-14, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test batch_processing.sh
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12, windows-2022 ]
+        os: [ ubuntu-20.04, macos-13, windows-2022 ]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,9 +247,9 @@ jobs:
         run: |
           ./.ci.sh -t
 
-  macos-12:
-   name: macOS 12.0 (Monterey)
-   runs-on: macos-12
+  macos-13:
+   name: macOS 13.0 (Ventura)
+   runs-on: macos-13
    steps:
      - uses: actions/checkout@v4
      - name: Install SCT


### PR DESCRIPTION
The macOS 12 image is in the process of being removed from github actions: https://github.com/actions/runner-images/issues/10721

For reference, the last time we bumped the macOS version was in #4353.

As an aside, I wonder whether we should update our uses of `macos-14` to `macos-latest`, so that we automatically pick up new versions when they appear. (Whereas I think it's reasonable to need an explicit action on our part to drop old versions when they disappear. And besides, [there's no convenient label like `macos-oldest`](https://github.com/actions/runner-images).)