### PR TITLE
Add example commands for the `-custom-url` arg

### DIFF
--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -91,7 +91,8 @@ def get_parser():
              "find release you wish to install, and right-click + copy the URL of the '.zip' listed under 'Assets'.\n"
              "NB: For multi-model tasks, provide multiple URLs. For single models, just provide one URL.\n"
              "Example:\n"
-             "'sct_deepseg -install seg_spinal_rootlets_t2w -custom-url https://github.com/ivadomed/model-spinal-rootlets/releases/download/r20240523/model-spinal-rootlets_ventral_D106_r20240523.zip'\n"
+             "'sct_deepseg -install seg_spinal_rootlets_t2w -custom-url "
+             "https://github.com/ivadomed/model-spinal-rootlets/releases/download/r20240523/model-spinal-rootlets_ventral_D106_r20240523.zip'\n"
              "'sct_deepseg -i sub-amu01_T2w.nii.gz -task seg_spinal_rootlets_t2w'")
 
     misc = parser.add_argument_group('PARAMETERS')

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -90,7 +90,9 @@ def get_parser():
              "install a specific version of a model. To use this option, navigate to the 'Releases' page of the model, "
              "find release you wish to install, and right-click + copy the URL of the '.zip' listed under 'Assets'.\n"
              "NB: For multi-model tasks, provide multiple URLs. For single models, just provide one URL.\n"
-             "Example: '-custom-url github.com/ivadomed/model-sc/releases/download/r20230101/model.zip'")
+             "Example:\n"
+             "'sct_deepseg -install seg_spinal_rootlets_t2w -custom-url https://github.com/ivadomed/model-spinal-rootlets/releases/download/r20240523/model-spinal-rootlets_ventral_D106_r20240523.zip'\n"
+             "'sct_deepseg -i sub-amu01_T2w.nii.gz -task seg_spinal_rootlets_t2w'")
 
     misc = parser.add_argument_group('PARAMETERS')
     misc.add_argument(


### PR DESCRIPTION
This tiny PR updates the `sct_deepseg` `-custom-url` argument help by adding example commands.

The PR addressed the second part of https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4654#issue-2602302169.