### PR TITLE
Preserve integer dtype when warping an image using `NearestNeighbour` interpolation

### DIFF
--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -127,7 +127,6 @@ def isct_antsApplyTransforms(dimensionality,
     missing behavior/options in the ANTs source code. This wrapper should more
     or less function like the original binary (with only minor tweaks added).
     """
-    dtype_in = Image(fname_input).data.dtype
     run_proc(['isct_antsApplyTransforms',
               '-d', dimensionality,
               '-i', fname_input,
@@ -137,12 +136,11 @@ def isct_antsApplyTransforms(dimensionality,
              interpolation_args,  # list of ['-n', interp_type]
              verbose=verbose,
              is_sct_binary=True)
-    # Preserve input datatype if output data can be safely cast to it
-    # Note: This is mostly relevant for integer input images + NearestNeighbour
-    #       interpolation, since ANTs will automatically cast to float, but
-    #       we usually want to preserve the integer datatype.
+    # Preserve integer datatype when interpolation is NearestNeighour to 
+    # counter ANTs behavior of always outputting float64 images
     im_out = Image(fname_output)
-    if np.array_equal(im_out.data, im_out.data.astype(dtype_in)):
+    input_is_int = issubclass(Image(fname_input).data.dtype.type, np.integer)
+    if input_is_int and 'NearestNeighbour' in interpolation_args:
         im_out.data = im_out.data.astype(dtype_in)
         im_out.save(verbose=0)
     # FIXME: Consider returning an `Image` type if the extra save/loads

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -140,7 +140,7 @@ def isct_antsApplyTransforms(dimensionality,
     # counter ANTs behavior of always outputting float64 images
     im_out = Image(fname_output)
     input_is_int = issubclass(Image(fname_input).data.dtype.type, np.integer)
-    if input_is_int and 'NearestNeighbour' in interpolation_args:
+    if input_is_int and 'NearestNeighbor' in interpolation_args:
         im_out.data = im_out.data.astype(dtype_in)
         im_out.save(verbose=0)
     # FIXME: Consider returning an `Image` type if the extra save/loads

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -136,10 +136,11 @@ def isct_antsApplyTransforms(dimensionality,
              interpolation_args,  # list of ['-n', interp_type]
              verbose=verbose,
              is_sct_binary=True)
-    # Preserve integer datatype when interpolation is NearestNeighour to 
+    # Preserve integer datatype when interpolation is NearestNeighour to
     # counter ANTs behavior of always outputting float64 images
     im_out = Image(fname_output)
-    input_is_int = issubclass(Image(fname_input).data.dtype.type, np.integer)
+    dtype_in = Image(fname_input).data.dtype
+    input_is_int = issubclass(dtype_in.type, np.integer)
     if input_is_int and 'NearestNeighbor' in interpolation_args:
         im_out.data = im_out.data.astype(dtype_in)
         im_out.save(verbose=0)

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -14,8 +14,6 @@ import functools
 from typing import Sequence
 import textwrap
 
-import numpy as np
-
 from spinalcordtoolbox.image import Image, generate_output_file, add_suffix
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -140,8 +140,7 @@ def isct_antsApplyTransforms(dimensionality,
     # counter ANTs behavior of always outputting float64 images
     im_out = Image(fname_output)
     dtype_in = Image(fname_input).data.dtype
-    input_is_int = issubclass(dtype_in.type, np.integer)
-    if input_is_int and 'NearestNeighbor' in interpolation_args:
+    if 'NearestNeighbor' in interpolation_args:
         im_out.data = im_out.data.astype(dtype_in)
         im_out.save(verbose=0)
     # FIXME: Consider returning an `Image` type if the extra save/loads

--- a/testing/cli/test_cli_sct_apply_transfo.py
+++ b/testing/cli/test_cli_sct_apply_transfo.py
@@ -3,6 +3,8 @@
 import pytest
 import logging
 
+import numpy as np
+
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.scripts import sct_apply_transfo
 from spinalcordtoolbox.utils.sys import sct_test_path
@@ -35,7 +37,11 @@ logger = logging.getLogger(__name__)
     (sct_test_path('dmri', 'dmri.nii.gz'),
      sct_test_path('t2', 't2.nii.gz'),
      sct_test_path('mt', 'warp_t22mt1.nii.gz'),
-     'PAM50_small_t2_reg-4Din.nii', [])
+     'PAM50_small_t2_reg-4Din.nii', []),
+    (sct_test_path('t2', 'labels.nii.gz'),
+     sct_test_path('mt', 'mt1.nii.gz'),
+     sct_test_path('mt', 'warp_t22mt1.nii.gz'),
+     'labels_mt1.nii', ['-x', 'nn'])
 ])
 def test_sct_apply_transfo_output_image_attributes(path_in, path_dest, path_warp, path_out, remaining_args):
     """Run the CLI script and verify transformed images have expected attributes."""
@@ -51,3 +57,9 @@ def test_sct_apply_transfo_output_image_attributes(path_in, path_dest, path_warp
     assert img_ref.dim[0:3] == img_output.dim[0:3]
     # Checking the 4th dim (which should be the same as the input image, not the reference image)
     assert img_src.dim[3] == img_output.dim[3]
+    # Make sure that integer labels are preserved, but only for NearestNeighbours interp
+    if issubclass(img_src.data.dtype.type, np.integer):
+        if remaining_args == ['-x', 'nn']:
+            assert img_output.data.dtype == img_src.data.dtype
+        else:
+            assert img_output.data.dtype != img_src.data.dtype


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This will preserve integer images when `-x nn` is used (which I've explicitly referenced in my test).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4572.

