### PR TITLE
Add model gallery for current version of DeepSeg (`-task` syntax)

### DIFF
--- a/documentation/source/user_section/command-line/deepseg/seg_exvivo_gm_wm_t2.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_exvivo_gm_wm_t2.rst
@@ -1,0 +1,11 @@
+
+                
+seg_exvivo_gm_wm_t2
+===================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_gm_sc_7t_t2star.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_gm_sc_7t_t2star.rst
@@ -1,0 +1,11 @@
+
+                
+seg_gm_sc_7t_t2star
+===================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_lumbar_sc_t2w.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_lumbar_sc_t2w.rst
@@ -1,0 +1,11 @@
+
+                
+seg_lumbar_sc_t2w
+=================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_mice_gm.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_mice_gm.rst
@@ -1,0 +1,11 @@
+
+                
+seg_mice_gm
+===========
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_mice_sc.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_mice_sc.rst
@@ -1,0 +1,11 @@
+
+                
+seg_mice_sc
+===========
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_mouse_gm_wm_t1w.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_mouse_gm_wm_t1w.rst
@@ -1,0 +1,11 @@
+
+                
+seg_mouse_gm_wm_t1w
+===================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_ms_lesion_mp2rage.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_ms_lesion_mp2rage.rst
@@ -1,0 +1,11 @@
+
+                
+seg_ms_lesion_mp2rage
+=====================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_ms_sc_mp2rage.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_ms_sc_mp2rage.rst
@@ -1,0 +1,11 @@
+
+                
+seg_ms_sc_mp2rage
+=================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_sc_contrast_agnostic.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_sc_contrast_agnostic.rst
@@ -1,0 +1,11 @@
+
+                
+seg_sc_contrast_agnostic
+========================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_sc_epi.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_sc_epi.rst
@@ -1,0 +1,11 @@
+
+                
+seg_sc_epi
+==========
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_sc_lesion_t2w_sci.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_sc_lesion_t2w_sci.rst
@@ -1,0 +1,11 @@
+
+                
+seg_sc_lesion_t2w_sci
+=====================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_sc_ms_lesion_stir_psir.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_sc_ms_lesion_stir_psir.rst
@@ -1,0 +1,11 @@
+
+                
+seg_sc_ms_lesion_stir_psir
+==========================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_spinal_rootlets_t2w.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_spinal_rootlets_t2w.rst
@@ -1,0 +1,11 @@
+
+                
+seg_spinal_rootlets_t2w
+=======================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_tumor_edema_cavity_t1_t2.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_tumor_edema_cavity_t1_t2.rst
@@ -1,0 +1,11 @@
+
+                
+seg_tumor_edema_cavity_t1_t2
+============================
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/deepseg/seg_tumor_t2.rst
+++ b/documentation/source/user_section/command-line/deepseg/seg_tumor_t2.rst
@@ -1,0 +1,11 @@
+
+                
+seg_tumor_t2
+============
+                
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
+   :prog: sct_deepseg -h
+   :markdownhelp:
+   :noepilog:
+                

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -8,19 +8,19 @@ Here we provide a gallery of each model available in the ``sct_deepseg`` CLI too
 Spinal cord
 -----------
 
-.. |seg_sc_contrast_agnostic| image:: https://i.imgur.com/1QXBTWf.png
+.. |seg_sc_contrast_agnostic| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/contrast_agnostic.png
    :target: deepseg/seg_sc_contrast_agnostic.html
 
-.. |seg_lumbar_sc_t2w| image:: https://i.imgur.com/aVJNqp1.png
+.. |seg_lumbar_sc_t2w| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/lumbar_t2.png
    :target: deepseg/seg_lumbar_sc_t2w.html
 
-.. |seg_sc_epi| image:: https://i.imgur.com/zj9idbJ.png
+.. |seg_sc_epi| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/epi_bold.png
    :target: deepseg/seg_sc_epi.html
 
-.. |ms_sc_mp2rage| image:: https://i.imgur.com/cqsrFWF.png
+.. |ms_sc_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_sc_mp2rage.png
    :target: deepseg/seg_ms_sc_mp2rage.html
 
-.. |mice_sc| image:: https://i.imgur.com/MaajGC2.png
+.. |mice_sc| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/mouse_t1.png
    :target: deepseg/mice_sc.html
 
 Spinal cord segmentation can be performed by running the following sample command:
@@ -46,16 +46,16 @@ You can replace "``seg_sc_contrast_agnostic``" with any of the task names in the
 Gray matter
 -----------
 
-.. |seg_gm_sc_7t_t2star| image:: https://i.imgur.com/EQ6cEsv.png
+.. |seg_gm_sc_7t_t2star| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/gm_sc_7t_t2star.png
    :target: deepseg/seg_gm_sc_7t_t2star.html
 
-.. |seg_exvivo_gm_wm_t2| image:: https://i.imgur.com/m4wB6Lk.png
+.. |seg_exvivo_gm_wm_t2| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/exvivo_gm_t2.png
    :target: deepseg/seg_exvivo_gm_wm_t2.html
 
-.. |seg_mouse_gm_wm_t1w| image:: https://i.imgur.com/BMAHSD0.png
+.. |seg_mouse_gm_wm_t1w| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/gm_wm_mouse_t1.png
    :target: deepseg/seg_mouse_gm_wm_t1w.html
 
-.. |mice_gm| image:: https://i.imgur.com/oooqyjh.png
+.. |mice_gm| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/gm_mouse_t1.png
    :target: deepseg/seg_mice_gm.html
 
 Gray matter segmentation can be performed by running the following sample command:
@@ -81,19 +81,19 @@ You can replace "``seg_gm_sc_7t_t2star``" with any of the task names in the tabl
 Pathologies
 -----------
 
-.. |seg_sc_lesion_t2w_sci| image:: https://i.imgur.com/fZncKDj.png
+.. |seg_sc_lesion_t2w_sci| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/sci_lesion_sc_t2.png
    :target: deepseg/seg_sc_lesion_t2w_sci.html
 
-.. |seg_sc_ms_lesion_stir_psir| image:: https://i.imgur.com/1U8LgQ0.png
+.. |seg_sc_ms_lesion_stir_psir| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_sc_stir_psir.png
    :target: deepseg/seg_sc_ms_lesion_stir_psir.html
 
-.. |seg_ms_lesion_mp2rage| image:: https://i.imgur.com/1mP1IYt.png
+.. |seg_ms_lesion_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_mp2rage.png
    :target: deepseg/seg_ms_lesion_mp2rage.html
 
-.. |seg_tumor_edema_cavity_t1_t2| image:: https://i.imgur.com/dFq8gkq.png
+.. |seg_tumor_edema_cavity_t1_t2| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/tumor_edema_cavity_t1_t2.png
    :target: deepseg/seg_tumor_edema_cavity_t1_t2.html
 
-.. |tumor_t2| image:: https://i.imgur.com/CbYVizW.png
+.. |tumor_t2| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/tumor_t2.png
    :target: deepseg/seg_tumor_t2.html
 
 Pathology segmentation can be performed by running the following sample command:
@@ -120,7 +120,7 @@ You can replace "``seg_sc_lesion_t2w_sci``" with any of the task names in the ta
 Other structures
 ----------------
 
-.. |seg_spinal_rootlets_t2w| image:: https://i.imgur.com/bQBFKVs.png
+.. |seg_spinal_rootlets_t2w| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/spinal_rootlets_t2.png
    :target: deepseg/seg_spinal_rootlets_t2w.html
 
 Rootlets segmentation can be performed by running the following sample command:

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -44,13 +44,13 @@ Gray matter segmentation
    :target: deepseg/seg_gm_sc_7t_t2star.html
 
 .. |seg_exvivo_gm_wm_t2| image:: https://i.imgur.com/m4wB6Lk.png
-   :target: deepseg/seg_exvivo_gm_wm_t2
+   :target: deepseg/seg_exvivo_gm_wm_t2.html
 
 .. |seg_mouse_gm_wm_t1w| image:: https://i.imgur.com/BMAHSD0.png
-   :target: deepseg/seg_mouse_gm_wm_t1w
+   :target: deepseg/seg_mouse_gm_wm_t1w.html
 
 .. |mice_gm| image:: https://i.imgur.com/oooqyjh.png
-   :target: deepseg/seg_mice_gm
+   :target: deepseg/seg_mice_gm.html
 
 .. list-table::
    :align: center
@@ -69,16 +69,16 @@ Tumors/lesions
    :target: deepseg/seg_sc_lesion_t2w_sci.html
 
 .. |seg_sc_ms_lesion_stir_psir| image:: https://i.imgur.com/1U8LgQ0.png
-   :target: deepseg/seg_sc_ms_lesion_stir_psir
+   :target: deepseg/seg_sc_ms_lesion_stir_psir.html
 
 .. |seg_ms_lesion_mp2rage| image:: https://i.imgur.com/1mP1IYt.png
-   :target: deepseg/seg_ms_lesion_mp2rage
+   :target: deepseg/seg_ms_lesion_mp2rage.html
 
 .. |seg_tumor_edema_cavity_t1_t2| image:: https://i.imgur.com/dFq8gkq.png
-   :target: deepseg/seg_tumor_edema_cavity_t1_t2
+   :target: deepseg/seg_tumor_edema_cavity_t1_t2.html
 
 .. |tumor_t2| image:: https://i.imgur.com/CbYVizW.png
-   :target: deepseg/seg_tumor_t2
+   :target: deepseg/seg_tumor_t2.html
 
 .. list-table::
    :align: center
@@ -98,7 +98,7 @@ Vertebrae
 ---------
 
 .. |seg_spinal_rootlets_t2w| image:: https://i.imgur.com/bQBFKVs.png
-   :target: deepseg/seg_spinal_rootlets_t2w
+   :target: deepseg/seg_spinal_rootlets_t2w.html
 
 .. list-table::
    :align: center

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -25,15 +25,13 @@ Spinal cord segmentation
 
 .. list-table::
    :align: center
-   :widths: 25 25 25 25
+   :widths: 25 25 25
 
    * - |seg_sc_contrast_agnostic| ``seg_sc_contrast_agnostic``
      - |seg_lumbar_sc_t2w| ``seg_lumbar_sc_t2w``
      - |seg_sc_epi| ``seg_sc_epi``
-     - |ms_sc_mp2rage| ``ms_sc_mp2rage``
-   * - |mice_sc| ``mice_sc``
-     -
-     -
+   * - |ms_sc_mp2rage| ``ms_sc_mp2rage``
+     - |mice_sc| ``mice_sc``
      -
 
 
@@ -54,12 +52,14 @@ Gray matter segmentation
 
 .. list-table::
    :align: center
-   :widths: 25 25 25 25
+   :widths: 25 25 25
 
    * - |seg_gm_sc_7t_t2star| ``seg_gm_sc_7t_t2star``
      - |seg_exvivo_gm_wm_t2| ``seg_exvivo_gm_wm_t2``
      - |seg_mouse_gm_wm_t1w| ``seg_mouse_gm_wm_t1w``
-     - |mice_gm| ``mice_gm``
+   * - |mice_gm| ``mice_gm``
+     -
+     -
 
 
 Tumors/lesions
@@ -82,15 +82,13 @@ Tumors/lesions
 
 .. list-table::
    :align: center
-   :widths: 25 25 25 25
+   :widths: 25 25 25
 
    * - |seg_sc_lesion_t2w_sci| ``seg_sc_lesion_t2w_sci``
      - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
      - |seg_ms_lesion_mp2rage| ``seg_ms_lesion_mp2rage``
-     - |seg_tumor_edema_cavity_t1_t2| ``seg_tumor_edema_cavity_t1_t2``
-   * - |tumor_t2| ``tumor_t2``
-     -
-     -
+   * - |seg_tumor_edema_cavity_t1_t2| ``seg_tumor_edema_cavity_t1_t2``
+     - |tumor_t2| ``tumor_t2``
      -
 
 
@@ -102,12 +100,12 @@ Vertebrae
 
 .. list-table::
    :align: center
-   :widths: 25 25 25 25
+   :widths: 25 25 25
 
    * - |seg_spinal_rootlets_t2w| ``seg_spinal_rootlets_t2w``
      -
      -
-     -
+
 
 .. toctree::
    :hidden:

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -5,8 +5,8 @@ sct_deepseg
 
 Here we provide a gallery of each model available in the ``sct_deepseg`` CLI tool.
 
-Spinal cord segmentation
-------------------------
+Spinal cord
+-----------
 
 .. |seg_sc_contrast_agnostic| image:: https://i.imgur.com/1QXBTWf.png
    :target: deepseg/seg_sc_contrast_agnostic.html
@@ -35,8 +35,8 @@ Spinal cord segmentation
      -
 
 
-Gray matter segmentation
-------------------------
+Gray matter
+-----------
 
 .. |seg_gm_sc_7t_t2star| image:: https://i.imgur.com/EQ6cEsv.png
    :target: deepseg/seg_gm_sc_7t_t2star.html
@@ -62,8 +62,8 @@ Gray matter segmentation
      -
 
 
-Tumors/lesions
---------------
+Pathologies
+-----------
 
 .. |seg_sc_lesion_t2w_sci| image:: https://i.imgur.com/fZncKDj.png
    :target: deepseg/seg_sc_lesion_t2w_sci.html
@@ -92,8 +92,8 @@ Tumors/lesions
      -
 
 
-Vertebrae
----------
+Other structures
+----------------
 
 .. |seg_spinal_rootlets_t2w| image:: https://i.imgur.com/bQBFKVs.png
    :target: deepseg/seg_spinal_rootlets_t2w.html

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -23,6 +23,14 @@ Spinal cord
 .. |mice_sc| image:: https://i.imgur.com/MaajGC2.png
    :target: deepseg/mice_sc.html
 
+Spinal cord segmentation can be performed by running the following sample command:
+
+.. code::
+
+   sct_deepseg -task seg_sc_contrast_agnostic -i input.nii.gz
+
+You can replace "``seg_sc_contrast_agnostic``" with any of the task names in the table below to perform different tasks. Click on a task below for more information.
+
 .. list-table::
    :align: center
    :widths: 25 25 25
@@ -49,6 +57,14 @@ Gray matter
 
 .. |mice_gm| image:: https://i.imgur.com/oooqyjh.png
    :target: deepseg/seg_mice_gm.html
+
+Gray matter segmentation can be performed by running the following sample command:
+
+.. code::
+
+   sct_deepseg -task seg_gm_sc_7t_t2star -i input.nii.gz
+
+You can replace "``seg_gm_sc_7t_t2star``" with any of the task names in the table below to perform different tasks. Click on a task below for more information.
 
 .. list-table::
    :align: center
@@ -80,6 +96,15 @@ Pathologies
 .. |tumor_t2| image:: https://i.imgur.com/CbYVizW.png
    :target: deepseg/seg_tumor_t2.html
 
+Pathology segmentation can be performed by running the following sample command:
+
+.. code::
+
+   sct_deepseg -task seg_sc_lesion_t2w_sci -i input.nii.gz
+
+You can replace "``seg_sc_lesion_t2w_sci``" with any of the task names in the table below to perform different tasks. Click on a task below for more information.
+
+
 .. list-table::
    :align: center
    :widths: 25 25 25
@@ -97,6 +122,13 @@ Other structures
 
 .. |seg_spinal_rootlets_t2w| image:: https://i.imgur.com/bQBFKVs.png
    :target: deepseg/seg_spinal_rootlets_t2w.html
+
+Rootlets segmentation can be performed by running the following sample command:
+
+.. code::
+
+   sct_deepseg -task seg_spinal_rootlets_t2w -i input.nii.gz
+
 
 .. list-table::
    :align: center

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -23,12 +23,6 @@ Spinal cord segmentation
 .. |mice_sc| image:: https://www.hfsp.org/sites/default/files/webfm/Articles/Kathe2021b.jpg
    :target: deepseg/mice_sc.html
 
-.. |seg_gm_sc_7t_t2star| image:: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRZGptCJRlgdsQCEL5T0T2Djoa1XPRWHLg51A&s
-   :target: deepseg/seg_gm_sc_7t_t2star.html
-
-.. |seg_sc_lesion_t2w_sci| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
-   :target: deepseg/seg_sc_lesion_t2w_sci.html
-
 .. list-table::
    :align: center
    :widths: 25 25 25 25
@@ -36,18 +30,18 @@ Spinal cord segmentation
    * - |seg_sc_contrast_agnostic| Contrast agnostic
      - |seg_lumbar_sc_t2w| Lumbar (T2)
      - |seg_sc_epi| EPI
-     - |seg_sc_lesion_t2w_sci| SCI (T2)
-   * - |seg_gm_sc_7t_t2star| 7T (T2*)
      - |ms_sc_mp2rage| MS (MP2RAGE)
-     - |mice_sc| Mice
+   * - |mice_sc| Mice
+     -
+     -
      -
 
 
 Gray matter segmentation
 ------------------------
 
-.. |mice_gm| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
-   :target: deepseg/seg_mice_gm
+.. |seg_gm_sc_7t_t2star| image:: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRZGptCJRlgdsQCEL5T0T2Djoa1XPRWHLg51A&s
+   :target: deepseg/seg_gm_sc_7t_t2star.html
 
 .. |seg_exvivo_gm_wm_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
    :target: deepseg/seg_exvivo_gm_wm_t2
@@ -55,39 +49,50 @@ Gray matter segmentation
 .. |seg_mouse_gm_wm_t1w| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
    :target: deepseg/seg_mouse_gm_wm_t1w
 
+.. |mice_gm| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_mice_gm
+
 .. list-table::
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_exvivo_gm_wm_t2| Ex-vivo GM/WM (T2)
-     - |mice_gm| Mice GM
+   * - |seg_gm_sc_7t_t2star| 7T GM (T2*)
+     - |seg_exvivo_gm_wm_t2| Ex-vivo GM/WM (T2)
      - |seg_mouse_gm_wm_t1w| Mice GM/WM
-     -
+     - |mice_gm| Mice GM
 
 
 Tumors/lesions
 --------------
 
-.. |tumor_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
-   :target: deepseg/seg_tumor_t2
+.. |seg_sc_lesion_t2w_sci| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_sc_lesion_t2w_sci.html
 
-.. |seg_tumor_edema_cavity_t1_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
-   :target: deepseg/seg_tumor_edema_cavity_t1_t2
+.. |seg_sc_ms_lesion_stir_psir| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_sc_ms_lesion_stir_psir
 
 .. |seg_ms_lesion_mp2rage| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
    :target: deepseg/seg_ms_lesion_mp2rage
 
-.. |seg_sc_ms_lesion_stir_psir| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
-   :target: deepseg/seg_sc_ms_lesion_stir_psir
+.. |seg_tumor_edema_cavity_t1_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_tumor_edema_cavity_t1_t2
+
+.. |tumor_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_tumor_t2
 
 .. list-table::
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_ms_lesion_mp2rage| MS lesions (MP2RAGE)
+   * - |seg_sc_lesion_t2w_sci| SCI lesions (T2)
      - |seg_sc_ms_lesion_stir_psir| MS lesions (STIR/PSIR)
+     - |seg_ms_lesion_mp2rage| MS lesions (MP2RAGE)
      - |seg_tumor_edema_cavity_t1_t2| Tumor/edema/cavity
-     - |tumor_t2| Tumor (T2)
+   * - |tumor_t2| Tumor (T2)
+     -
+     -
+     -
+
 
 Vertebrae
 ---------
@@ -108,18 +113,18 @@ Vertebrae
    :hidden:
    :maxdepth: 2
 
+   deepseg/seg_sc_contrast_agnostic
+   deepseg/seg_ms_sc_mp2rage
+   deepseg/seg_sc_epi
+   deepseg/seg_mice_sc
+   deepseg/seg_lumbar_sc_t2w
    deepseg/seg_exvivo_gm_wm_t2
    deepseg/seg_gm_sc_7t_t2star
-   deepseg/seg_lumbar_sc_t2w
    deepseg/seg_mice_gm
-   deepseg/seg_mice_sc
    deepseg/seg_mouse_gm_wm_t1w
-   deepseg/seg_ms_lesion_mp2rage
-   deepseg/seg_ms_sc_mp2rage
-   deepseg/seg_sc_contrast_agnostic
-   deepseg/seg_sc_epi
    deepseg/seg_sc_lesion_t2w_sci
    deepseg/seg_sc_ms_lesion_stir_psir
-   deepseg/seg_spinal_rootlets_t2w
+   deepseg/seg_ms_lesion_mp2rage
    deepseg/seg_tumor_edema_cavity_t1_t2
    deepseg/seg_tumor_t2
+   deepseg/seg_spinal_rootlets_t2w

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -8,19 +8,19 @@ Here we provide a gallery of each model available in the ``sct_deepseg`` CLI too
 Spinal cord segmentation
 ------------------------
 
-.. |seg_sc_contrast_agnostic| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/spinalcord-segmentation/image_contrasts.png
+.. |seg_sc_contrast_agnostic| image:: https://i.imgur.com/1QXBTWf.png
    :target: deepseg/seg_sc_contrast_agnostic.html
 
-.. |seg_lumbar_sc_t2w| image:: https://cdn.flintrehab.com/uploads/2020/12/lumbar-spinal-cord-injury-1.jpg
+.. |seg_lumbar_sc_t2w| image:: https://i.imgur.com/aVJNqp1.png
    :target: deepseg/seg_lumbar_sc_t2w.html
 
-.. |seg_sc_epi| image:: https://www.researchgate.net/profile/Lawrence-Tanenbaum/publication/236636641/figure/fig3/AS:720460652236801@1548782613891/Metastatic-disease-to-the-cord-FSE-T2-weighted-image-left-and-EPI-DWI-show-a_Q320.jpg
+.. |seg_sc_epi| image:: https://i.imgur.com/zj9idbJ.png
    :target: deepseg/seg_sc_epi.html
 
-.. |ms_sc_mp2rage| image:: https://www.ajnr.org/content/ajnr/early/2023/08/10/ajnr.A7964/F5.large.jpg?width=800&height=600&carousel=1
+.. |ms_sc_mp2rage| image:: https://i.imgur.com/cqsrFWF.png
    :target: deepseg/seg_ms_sc_mp2rage.html
 
-.. |mice_sc| image:: https://www.hfsp.org/sites/default/files/webfm/Articles/Kathe2021b.jpg
+.. |mice_sc| image:: https://i.imgur.com/MaajGC2.png
    :target: deepseg/mice_sc.html
 
 .. list-table::
@@ -40,16 +40,16 @@ Spinal cord segmentation
 Gray matter segmentation
 ------------------------
 
-.. |seg_gm_sc_7t_t2star| image:: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRZGptCJRlgdsQCEL5T0T2Djoa1XPRWHLg51A&s
+.. |seg_gm_sc_7t_t2star| image:: https://i.imgur.com/EQ6cEsv.png
    :target: deepseg/seg_gm_sc_7t_t2star.html
 
-.. |seg_exvivo_gm_wm_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_exvivo_gm_wm_t2| image:: https://i.imgur.com/m4wB6Lk.png
    :target: deepseg/seg_exvivo_gm_wm_t2
 
-.. |seg_mouse_gm_wm_t1w| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_mouse_gm_wm_t1w| image:: https://i.imgur.com/BMAHSD0.png
    :target: deepseg/seg_mouse_gm_wm_t1w
 
-.. |mice_gm| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |mice_gm| image:: https://i.imgur.com/oooqyjh.png
    :target: deepseg/seg_mice_gm
 
 .. list-table::
@@ -65,19 +65,19 @@ Gray matter segmentation
 Tumors/lesions
 --------------
 
-.. |seg_sc_lesion_t2w_sci| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_sc_lesion_t2w_sci| image:: https://i.imgur.com/fZncKDj.png
    :target: deepseg/seg_sc_lesion_t2w_sci.html
 
-.. |seg_sc_ms_lesion_stir_psir| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_sc_ms_lesion_stir_psir| image:: https://i.imgur.com/1U8LgQ0.png
    :target: deepseg/seg_sc_ms_lesion_stir_psir
 
-.. |seg_ms_lesion_mp2rage| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_ms_lesion_mp2rage| image:: https://i.imgur.com/1mP1IYt.png
    :target: deepseg/seg_ms_lesion_mp2rage
 
-.. |seg_tumor_edema_cavity_t1_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_tumor_edema_cavity_t1_t2| image:: https://i.imgur.com/dFq8gkq.png
    :target: deepseg/seg_tumor_edema_cavity_t1_t2
 
-.. |tumor_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |tumor_t2| image:: https://i.imgur.com/CbYVizW.png
    :target: deepseg/seg_tumor_t2
 
 .. list-table::
@@ -97,7 +97,7 @@ Tumors/lesions
 Vertebrae
 ---------
 
-.. |seg_spinal_rootlets_t2w| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+.. |seg_spinal_rootlets_t2w| image:: https://i.imgur.com/bQBFKVs.png
    :target: deepseg/seg_spinal_rootlets_t2w
 
 .. list-table::

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -1,10 +1,125 @@
-.. _sct_deepseg: 
+.. _sct_deepseg:
 
 sct_deepseg
 ===========
 
-.. argparse::
-   :ref: spinalcordtoolbox.scripts.sct_deepseg.get_parser
-   :prog: sct_deepseg
-   :markdownhelp:
-   :noepilog:
+Here we provide a gallery of each model available in the ``sct_deepseg`` CLI tool.
+
+Spinal cord segmentation
+------------------------
+
+.. |seg_sc_contrast_agnostic| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/spinalcord-segmentation/image_contrasts.png
+   :target: deepseg/seg_sc_contrast_agnostic.html
+
+.. |seg_lumbar_sc_t2w| image:: https://cdn.flintrehab.com/uploads/2020/12/lumbar-spinal-cord-injury-1.jpg
+   :target: deepseg/seg_lumbar_sc_t2w.html
+
+.. |seg_sc_epi| image:: https://www.researchgate.net/profile/Lawrence-Tanenbaum/publication/236636641/figure/fig3/AS:720460652236801@1548782613891/Metastatic-disease-to-the-cord-FSE-T2-weighted-image-left-and-EPI-DWI-show-a_Q320.jpg
+   :target: deepseg/seg_sc_epi.html
+
+.. |ms_sc_mp2rage| image:: https://www.ajnr.org/content/ajnr/early/2023/08/10/ajnr.A7964/F5.large.jpg?width=800&height=600&carousel=1
+   :target: deepseg/seg_ms_sc_mp2rage.html
+
+.. |mice_sc| image:: https://www.hfsp.org/sites/default/files/webfm/Articles/Kathe2021b.jpg
+   :target: deepseg/mice_sc.html
+
+.. |seg_gm_sc_7t_t2star| image:: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRZGptCJRlgdsQCEL5T0T2Djoa1XPRWHLg51A&s
+   :target: deepseg/seg_gm_sc_7t_t2star.html
+
+.. |seg_sc_lesion_t2w_sci| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_sc_lesion_t2w_sci.html
+
+.. list-table::
+   :align: center
+   :widths: 25 25 25 25
+
+   * - |seg_sc_contrast_agnostic| Contrast agnostic
+     - |seg_lumbar_sc_t2w| Lumbar (T2)
+     - |seg_sc_epi| EPI
+     - |seg_sc_lesion_t2w_sci| SCI (T2)
+   * - |seg_gm_sc_7t_t2star| 7T (T2*)
+     - |ms_sc_mp2rage| MS (MP2RAGE)
+     - |mice_sc| Mice
+     -
+
+
+Gray matter segmentation
+------------------------
+
+.. |mice_gm| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_mice_gm
+
+.. |seg_exvivo_gm_wm_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_exvivo_gm_wm_t2
+
+.. |seg_mouse_gm_wm_t1w| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_mouse_gm_wm_t1w
+
+.. list-table::
+   :align: center
+   :widths: 25 25 25 25
+
+   * - |seg_exvivo_gm_wm_t2| Ex-vivo GM/WM (T2)
+     - |mice_gm| Mice GM
+     - |seg_mouse_gm_wm_t1w| Mice GM/WM
+     -
+
+
+Tumors/lesions
+--------------
+
+.. |tumor_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_tumor_t2
+
+.. |seg_tumor_edema_cavity_t1_t2| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_tumor_edema_cavity_t1_t2
+
+.. |seg_ms_lesion_mp2rage| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_ms_lesion_mp2rage
+
+.. |seg_sc_ms_lesion_stir_psir| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_sc_ms_lesion_stir_psir
+
+.. list-table::
+   :align: center
+   :widths: 25 25 25 25
+
+   * - |seg_ms_lesion_mp2rage| MS lesions (MP2RAGE)
+     - |seg_sc_ms_lesion_stir_psir| MS lesions (STIR/PSIR)
+     - |seg_tumor_edema_cavity_t1_t2| Tumor/edema/cavity
+     - |tumor_t2| Tumor (T2)
+
+Vertebrae
+---------
+
+.. |seg_spinal_rootlets_t2w| image:: https://media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fsc.2011.107/MediaObjects/41393_2012_Article_BFsc2011107_Fig10_HTML.jpg
+   :target: deepseg/seg_spinal_rootlets_t2w
+
+.. list-table::
+   :align: center
+   :widths: 25 25 25 25
+
+   * - |seg_spinal_rootlets_t2w| Rootlets (T2)
+     -
+     -
+     -
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   deepseg/seg_exvivo_gm_wm_t2
+   deepseg/seg_gm_sc_7t_t2star
+   deepseg/seg_lumbar_sc_t2w
+   deepseg/seg_mice_gm
+   deepseg/seg_mice_sc
+   deepseg/seg_mouse_gm_wm_t1w
+   deepseg/seg_ms_lesion_mp2rage
+   deepseg/seg_ms_sc_mp2rage
+   deepseg/seg_sc_contrast_agnostic
+   deepseg/seg_sc_epi
+   deepseg/seg_sc_lesion_t2w_sci
+   deepseg/seg_sc_ms_lesion_stir_psir
+   deepseg/seg_spinal_rootlets_t2w
+   deepseg/seg_tumor_edema_cavity_t1_t2
+   deepseg/seg_tumor_t2

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -27,11 +27,11 @@ Spinal cord segmentation
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_sc_contrast_agnostic| Contrast agnostic
-     - |seg_lumbar_sc_t2w| Lumbar (T2)
-     - |seg_sc_epi| EPI
-     - |ms_sc_mp2rage| MS (MP2RAGE)
-   * - |mice_sc| Mice
+   * - |seg_sc_contrast_agnostic| ``seg_sc_contrast_agnostic``
+     - |seg_lumbar_sc_t2w| ``seg_lumbar_sc_t2w``
+     - |seg_sc_epi| ``seg_sc_epi``
+     - |ms_sc_mp2rage| ``ms_sc_mp2rage``
+   * - |mice_sc| ``mice_sc``
      -
      -
      -
@@ -56,10 +56,10 @@ Gray matter segmentation
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_gm_sc_7t_t2star| 7T GM (T2*)
-     - |seg_exvivo_gm_wm_t2| Ex-vivo GM/WM (T2)
-     - |seg_mouse_gm_wm_t1w| Mice GM/WM
-     - |mice_gm| Mice GM
+   * - |seg_gm_sc_7t_t2star| ``seg_gm_sc_7t_t2star``
+     - |seg_exvivo_gm_wm_t2| ``seg_exvivo_gm_wm_t2``
+     - |seg_mouse_gm_wm_t1w| ``seg_mouse_gm_wm_t1w``
+     - |mice_gm| ``mice_gm``
 
 
 Tumors/lesions
@@ -84,11 +84,11 @@ Tumors/lesions
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_sc_lesion_t2w_sci| SCI lesions (T2)
-     - |seg_sc_ms_lesion_stir_psir| MS lesions (STIR/PSIR)
-     - |seg_ms_lesion_mp2rage| MS lesions (MP2RAGE)
-     - |seg_tumor_edema_cavity_t1_t2| Tumor/edema/cavity
-   * - |tumor_t2| Tumor (T2)
+   * - |seg_sc_lesion_t2w_sci| ``seg_sc_lesion_t2w_sci``
+     - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
+     - |seg_ms_lesion_mp2rage| ``seg_ms_lesion_mp2rage``
+     - |seg_tumor_edema_cavity_t1_t2| ``seg_tumor_edema_cavity_t1_t2``
+   * - |tumor_t2| ``tumor_t2``
      -
      -
      -
@@ -104,7 +104,7 @@ Vertebrae
    :align: center
    :widths: 25 25 25 25
 
-   * - |seg_spinal_rootlets_t2w| Rootlets (T2)
+   * - |seg_spinal_rootlets_t2w| ``seg_spinal_rootlets_t2w``
      -
      -
      -


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR is roughly equivalent to half of PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4630. It is meant to grant us the benefits of the `sct_deepseg` model gallery right away (for v6.5), while also allowing us to update the gallery when we adopt `sct_deepseg` subparsers for v7.0.

This PR contains no functional changes; only documentation changes. Therefore, it should be safe to merge right away, especially with our recent change to only update the documentation for stable releases.

Note: One new change I added that differs from PR #4630 was switching from a 4-column table to a 3-column table to accommodate the longer task names:

![image](https://github.com/user-attachments/assets/d47f235a-1b83-47b1-98bc-741a652dfd9a)

Perhaps this is too large, though? Feedback is appreciated!

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3767.
