### PR TITLE
Fix bug due to discrepancy introduced by `set_qform` and `set_sform` methods

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1162,8 +1162,12 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
         im_src_data.shape)
     im_dst_aff = np.matmul(im_src_aff, aff)
 
+    # NB: When setting the xforms, the qform will be made orthogonal (to meet NIfTI1 requirements),
+    #     while the sform won't. Since im_dst_aff doesn't always equal orthogonal(im_dst_aff), this
+    #     could introduce a discrepancy. So, we first set the qform, then we set the sform to the
+    #     qform (i.e. orthogonal(im_dst_aff)), which ensures that the two matrices are identical.
     im_dst.header.set_qform(im_dst_aff)
-    im_dst.header.set_sform(im_dst_aff)
+    im_dst.header.set_sform(im_dst.header.get_qform())
     im_dst.header.set_data_shape(data.shape)
     im_dst.data = data
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR ensures that the qform will always match the sform when reorienting the image.

Note that with the old method:

- sform == im_dst_aff
- qform == [orthogonal(im_dst_aff)](https://github.com/nipy/nibabel/blob/d9c479a03df4119fcac0ffd3bd1b2b0fabf650e7/nibabel/nifti1.py#L1251-L1260)

And because orthogonal(im_dst_affine) may not always equal im_dst_aff, the two `set_xform` commands may result in different matrices.

Depending on how we utilize the `sform`, this change may result in numerical differences? So, I am opening this PR also as a way of quickly checking our test suite.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4689.
