### PR TITLE
Allow `nnunetv2>=2.5.1` due to bugfix for previous issue with `2.4.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,12 @@ monai[nibabel]
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
-# Only allow nnunetv2==2.3.1 or 2.5.1 and above (NB: there is no 2.5.0)
-# 2.4.2 causes empty predictions (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4556)
-# 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
+# Only allow nnunetv2==2.3.1 or 2.5.1 (NB: there is no 2.5.0)
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
-nnunetv2>2.3.0,!=2.4.*
+# 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
+# 2.4.2 causes empty predictions (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4556)
+# 2.5.2 and above will be tested manually when they are released.
+nnunetv2>2.3.0,!=2.4.*,<=2.5.1
 # SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later. See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
 numpy<2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,10 +27,11 @@ monai[nibabel]
 msvc-runtime==14.29.30133; sys.platform == 'win32' # append_to_freeze
 nibabel
 nilearn
+# Only allow nnunetv2==2.3.1 or 2.5.1 and above (NB: there is no 2.5.0)
 # 2.4.2 causes empty predictions (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4556)
 # 2.4.0/2.4.1 fail during inference due to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4444
 # 2.3.0 and below are incompatible due to breaking API change (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4380)
-nnunetv2==2.3.1
+nnunetv2>2.3.0,!=2.4.*
 # SCT is compatible, however the upgrade to numpy==2.0.0 broke *many* upstream packages. Let's try again later. See https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4535
 numpy<2
 # 1.7.0>onnxruntime>=1.5.1 required `brew install libomp` on macOS.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Previously, we encountered a bug with `nnunetv2==2.4.2` where an empty segmentation would be produced by our SCI model. We temporarily limited `nnunetv2==2.3.1`, since that was seemingly the only version that worked for us. See:

- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4564

However, there is a newer version of `nnunetv2` (`2.5.1`) that seems to fix the "empty segmentation" problem. 

Note that TotalSpineSeg is incompatible with 2.5.1, so we're probably going to revert back to 2.3.1 immediately. But, this PR will prepare for an eventual 2.5.2 release that will finally work for both SCT and TotalSpineSeg.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4556.
