### PR TITLE
Update `sct_course_data` URL to point to `SCT-Course-20241209`

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -50,7 +50,7 @@ DATASET_DICT = {
     },
     "sct_course_data": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20231020.zip",
+            "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20241209.zip",
         ],
         "default_location": os.path.join(__sct_dir__, "data", "sct_course_data"),
         "download_type": "SCT Course Files",


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is mostly just a placeholder URL. While a dataset using this name will exist (https://github.com/spinalcordtoolbox/sct_tutorial_data/actions/runs/11958727027), I suspect that we will end up updating the `sct_tutorial_data` repo as we modify the course slides in the coming weeks.

Thankfully, as long as we update the tag `SCT-Course-20241209`, the command `sct_download_data -d sct_course_data` will always stay up to date, and thus we can safely use this command in the SCT Course slides.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4703.