### PR TITLE
Retire outdated DeepSeg models (`seg_sc_ms_lesion_stir_psir`, `ms_sc_mp2rage`)

### DIFF
--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -84,9 +84,6 @@ Pathologies
 .. |seg_sc_lesion_t2w_sci| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/sci_lesion_sc_t2.png
    :target: deepseg/seg_sc_lesion_t2w_sci.html
 
-.. |seg_sc_ms_lesion_stir_psir| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_sc_stir_psir.png
-   :target: deepseg/seg_sc_ms_lesion_stir_psir.html
-
 .. |seg_ms_lesion_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_mp2rage.png
    :target: deepseg/seg_ms_lesion_mp2rage.html
 
@@ -115,10 +112,9 @@ You can replace "``seg_sc_lesion_t2w_sci``" with any of the task names in the ta
    * - |seg_sc_lesion_t2w_sci| ``seg_sc_lesion_t2w_sci``
      - |seg_ms_lesion| ``seg_ms_lesion``
      - |seg_ms_lesion_mp2rage| ``seg_ms_lesion_mp2rage``
-   * - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
-     - |seg_tumor_edema_cavity_t1_t2| ``seg_tumor_edema_cavity_t1_t2``
+   * - |seg_tumor_edema_cavity_t1_t2| ``seg_tumor_edema_cavity_t1_t2``
      - |tumor_t2| ``tumor_t2``
-
+     -
 
 Other structures
 ----------------
@@ -178,6 +174,10 @@ If you absolutely require these models, you can downgrade to version of SCT list
      - Removed in
      - Last available
      - Superseded by
+   * - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
+     - SCT Version ``6.5``
+     - SCT Version ``6.4``
+     - ``seg_ms_lesion`` (contrast-agnostic MS lesion segmentation)
 
 .. toctree::
    :hidden:

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -167,18 +167,15 @@ If you absolutely require these models, you can downgrade to version of SCT list
 
 .. list-table::
    :align: center
-   :widths: 33 22 22 22
+   :widths: 33 33 33
 
    * - Model
-     - Removed in
      - Last available
      - Superseded by
    * - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
-     - SCT Version ``6.5``
      - SCT Version ``6.4``
      - ``seg_ms_lesion`` (contrast-agnostic MS lesion segmentation)
    * - |ms_sc_mp2rage| ``ms_sc_mp2rage``
-     - SCT Version ``6.5``
      - SCT Version ``6.4``
      - ``seg_sc_contrast_agnostic`` (contrast-agnostic SC segmentation)
 

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -17,9 +17,6 @@ Spinal cord
 .. |seg_sc_epi| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/epi_bold.png
    :target: deepseg/seg_sc_epi.html
 
-.. |ms_sc_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_sc_mp2rage.png
-   :target: deepseg/seg_ms_sc_mp2rage.html
-
 .. |mice_sc| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/mouse_t1.png
    :target: deepseg/mice_sc.html
 
@@ -38,10 +35,9 @@ You can replace "``seg_sc_contrast_agnostic``" with any of the task names in the
    * - |seg_sc_contrast_agnostic| ``seg_sc_contrast_agnostic``
      - |seg_lumbar_sc_t2w| ``seg_lumbar_sc_t2w``
      - |seg_sc_epi| ``seg_sc_epi``
-   * - |ms_sc_mp2rage| ``ms_sc_mp2rage``
-     - |mice_sc| ``mice_sc``
+   * - |mice_sc| ``mice_sc``
      -
-
+     -
 
 Gray matter
 -----------
@@ -162,6 +158,9 @@ Retired models
 .. |seg_sc_ms_lesion_stir_psir| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_sc_stir_psir.png
    :target: deepseg/seg_sc_ms_lesion_stir_psir.html
 
+.. |ms_sc_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_sc_mp2rage.png
+   :target: deepseg/seg_ms_sc_mp2rage.html
+
 These models have been replaced by newer, more advanced models. We recommend switching to the model listed in the table below.
 
 If you absolutely require these models, you can downgrade to version of SCT listed in the table below. If you do this, please let us know on the SCT Forum so we can better understand your use-case, and potentially reinstate the model if necessary.
@@ -178,6 +177,10 @@ If you absolutely require these models, you can downgrade to version of SCT list
      - SCT Version ``6.5``
      - SCT Version ``6.4``
      - ``seg_ms_lesion`` (contrast-agnostic MS lesion segmentation)
+   * - |ms_sc_mp2rage| ``ms_sc_mp2rage``
+     - SCT Version ``6.5``
+     - SCT Version ``6.4``
+     - ``seg_sc_contrast_agnostic`` (contrast-agnostic SC segmentation)
 
 .. toctree::
    :hidden:

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -160,6 +160,25 @@ Spinal Canal segmentation can be performed by running the following sample comma
      -
 
 
+Retired models
+--------------
+
+.. |seg_sc_ms_lesion_stir_psir| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_lesion_sc_stir_psir.png
+   :target: deepseg/seg_sc_ms_lesion_stir_psir.html
+
+These models have been replaced by newer, more advanced models. We recommend switching to the model listed in the table below.
+
+If you absolutely require these models, you can downgrade to version of SCT listed in the table below. If you do this, please let us know on the SCT Forum so we can better understand your use-case, and potentially reinstate the model if necessary.
+
+.. list-table::
+   :align: center
+   :widths: 33 22 22 22
+
+   * - Model
+     - Removed in
+     - Last available
+     - Superseded by
+
 .. toctree::
    :hidden:
    :maxdepth: 2

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -156,15 +156,6 @@ MODELS = {
          "thr": None,  # Images are already binarized when splitting into gm-seg and wm-seg
          "default": False,
      },
-    "model_seg_sc_lesion_canproco_nnunet": {
-         "url": [
-             "https://github.com/ivadomed/canproco/releases/download/r20240125/model_ms_seg_sc-lesion_regionBased_2d.zip"
-         ],
-         "description": "MS lesion/SC seg for STIR/PSIR contrasts",
-         "contrasts": ["stir", "psir"],
-         "thr": None,  # Images are already binarized when splitting into spinal cord and lesion
-         "default": False,
-    },
     "model_seg_sc_epi_nnunet": {
          "url": [
              "https://github.com/sct-pipeline/fmri-segmentation/releases/download/v0.2/model-fmri-segmentation-v0.2_nnUNetTrainer.zip"
@@ -347,16 +338,6 @@ TASKS = {
                              'the University of Zurich.',
          'url': 'https://github.com/ivadomed/model_seg_mouse-sc_wm-gm_t1',
          'models': ['model_seg_gm_wm_mouse_nnunet']},
-    'seg_sc_ms_lesion_stir_psir':
-        {'description': 'Segmentation of spinal cord and MS lesions for STIR and PSIR contrasts',
-         'long_description': 'This segmentation model for MS lesion segmentation uses a 2D U-Net architecture, and was '
-                             'trained with the nnUNetV2 framework. It is a region-based model, outputting a single '
-                             'segmentation image containing 2 classes representing the spinal cord and MS lesions. '
-                             'Training data consisted of sagittal PSIR 0.7×0.7×3 mm3 (4 sites, 333 participants) multiplied '
-                             'by -1 and sagittal STIR 0.7×0.7×3 mm3 (1 site, 92 participants) images of the cervical SC from '
-                             'the Canadian Prospective Cohort Study (CanProCo).',
-         'url': 'https://github.com/ivadomed/canproco',
-         'models': ['model_seg_sc_lesion_canproco_nnunet']},
     'seg_sc_epi':
         {'description': 'Spinal cord segmentation for EPI-BOLD fMRI data',
          'long_description': 'This segmentation model for spinal cord on EPI data (single 3D volume) uses a 3D UNet model built from '

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -87,14 +87,6 @@ MODELS = {
         "contrasts": ["t2"],
         "default": False,
     },
-    "model_seg_ms_sc_mp2rage": {
-        "url": [
-            "https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20211223/model_seg_ms_sc_mp2rage.zip"
-        ],
-        "description": "Segmentation of spinal cord on MP2RAGE data from MS participants.",
-        "contrasts": ["mp2rage"],
-        "default": False,
-    },
     "model_7t_multiclass_gm_sc_unet2d": {
         "url": [
             "https://github.com/ivadomed/model_seg_gm-wm_t2star_7t_unet3d-multiclass/archive/refs/tags/r20211012.zip"
@@ -246,14 +238,6 @@ TASKS = {
                              '(https://github.com/ivadomed/findcord_tumor).',
          'url': 'https://github.com/sct-pipeline/tumor-segmentation',
          'models': ['findcord_tumor', 't2_tumor']},
-    'seg_ms_sc_mp2rage':
-        {'description': 'Cord segmentation on MP2RAGE in MS patients',
-         'long_description': 'This segmentation model for MP2RAGE spinal cord segmentation uses a Modified3DUNet '
-                             'architecture, and was created with the `ivadomed` package. Training data consisted of '
-                             'scans from 30 multiple sclerosis (MS) patients, and the dataset included manual '
-                             'segmentations of MS lesions. This dataset was provided by the University of Basel.',
-         'url': 'https://github.com/ivadomed/model_seg_ms_mp2rage',
-         'models': ['model_seg_ms_sc_mp2rage']},
     'seg_tumor-edema-cavity_t1-t2':
         {'description': 'Multiclass cord tumor/edema/cavity segmentation',
          'long_description': 'This segmentation model for T1w and T2w spinal tumor, edema, and cavity segmentation '

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -23,7 +23,6 @@ from spinalcordtoolbox.reports import qc2
 from spinalcordtoolbox.image import splitext, Image, check_image_kind
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, __version__, _git_info
-from spinalcordtoolbox.utils.fs import tmp_create
 from spinalcordtoolbox.utils.sys import LazyLoader
 
 cuda = LazyLoader("cuda", globals(), 'torch.cuda')
@@ -55,11 +54,10 @@ def get_parser():
             Contrast of the input. The `-c` option is only relevant for the following tasks:
 
               - `seg_tumor-edema-cavity_t1-t2`: Specifies the contrast order of input images (e.g. `-c t1 t2`)
-              - `seg_sc_ms_lesion_stir_psir`: Specifies whether input should be inverted based on contrast (`-c stir`: no inversion, `-c psir`: inverted)
 
             Because all other models have only a single input contrast, the `-c` option is ignored for them.
         """),
-        choices=('t1', 't2', 't2star', 'stir', 'psir'),
+        choices=('t1', 't2', 't2star'),
         metavar=Metavar.str)
     input_output.add_argument(
         "-o",
@@ -262,26 +260,6 @@ def main(argv: Sequence[str]):
                         input_filenames.append(input_filename)
         else:
             input_filenames = arguments.i.copy()
-
-        # Inversion workaround for regular PSIR input to canproco STIR/PSIR model
-        if 'seg_sc_ms_lesion_stir_psir' in arguments.task[0]:
-            contrast = arguments.c[0] if arguments.c else None  # default is empty list
-            if not contrast:
-                parser.error(
-                    "Task 'seg_sc_ms_lesion_stir_psir' requires the flag `-c` to identify whether the input is "
-                    "STIR or PSIR. If `-c psir` is passed, the input will be inverted.")
-            elif contrast == "psir":
-                logger.warning("Inverting input PSIR image (multiplying data array by -1)...")
-                tmpdir = tmp_create("sct_deepseg-inverted-psir")
-                for i, fname_in in enumerate(input_filenames.copy()):
-                    im_in = Image(fname_in)
-                    im_in.data *= -1
-                    path_img_tmp = os.path.join(tmpdir, os.path.basename(fname_in))
-                    im_in.save(path_img_tmp)
-                    input_filenames[i] = path_img_tmp
-            else:
-                if contrast != "stir":
-                    parser.error("Task 'seg_sc_ms_lesion_stir_psir' requires the flag `-c` to be either psir or stir.")
 
         if 'seg_sc_epi' in arguments.task[0]:
             for image in arguments.i:


### PR DESCRIPTION
## Description

This PR adds a new section to the Model Gallery for "Retired models", moves 2 models into this section, and deletes them from the `sct_deepseg` and `models.py` scripts.

![Screenshot from 2024-11-21 13-07-23](https://github.com/user-attachments/assets/932ff39f-e17a-4e59-a6b6-0ba796a35978)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4700.