### PR TITLE
Update warnings filter to properly filter `Private repos` warning from `requirements.parse`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -159,7 +159,7 @@ def get_dependencies(requirements_txt=None):
     requirements_txt = open(requirements_txt, "r", encoding="utf-8")
 
     # workaround for https://github.com/davidfischer/requirements-parser/issues/39
-    warnings.filterwarnings(action='ignore', module='requirements')
+    warnings.filterwarnings(message='Private repos not supported', action='ignore', category=UserWarning)
 
     for req in requirements.parse(requirements_txt):
         if ';' in req.line:  # handle environment markers; TODO: move this upstream into requirements-parser


### PR DESCRIPTION
## Description

We can no longer rely on `module` to filter this warning due to an upstream addition of `stacklevel=2`. So, we must instead filter based on message, rather than module.

Before:

![image](https://github.com/user-attachments/assets/a14a8d23-6b53-4334-a5f3-6242c76aa623)

After:

![image](https://github.com/user-attachments/assets/7d8d63a5-f413-4d2a-9321-5c530ef9be16)

## Linked issues

Fixes #4712.