### PR TITLE
Fix rootlets QC for anisotropic images

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -774,7 +774,7 @@ def mosaic(img: Image, centers: np.ndarray, radius: tuple[int, int] = (15, 15), 
     for center, slice in zip(centers.astype(int), img.data):
         # Add a margin before cropping, in case the center is too close to the edge
         # Also, use Kronecker product to scale each block in multiples
-        cropped.append(np.kron(np.pad(slice, ((radius[0], radius[0]), (radius[1], radius[1])))[
+        cropped.append(np.kron(np.pad(slice, [[r] for r in radius])[
             center[0]:center[0] + 2*radius[0],
             center[1]:center[1] + 2*radius[1],
         ], np.ones((scale, scale))))

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -416,12 +416,12 @@ def sct_deepseg_spinal_rootlets_t2w(
     # - However, we cannot apply resampling here because rootlets labels are often small (~1vox wide), and so resampling might
     #   corrupt the labels and cause them to be displayed unfaithfully.
     # - So, instead of resampling the image to fit the default crop radius, we scale the crop radius to suit the original resolution.
-    p_original = img_seg_sc.dim[5]  # dim[0:3] => shape, dim[4:7] => pixdim, so dim[5] == pixdim[1]
-    p_ratio = p_resample / p_original
-    radius = tuple(int(v * p_ratio) for v in radius)
+    p_original = (img_seg_sc.dim[5], img_seg_sc.dim[6])  # Image may be anisotropic, so use both resolutions (H,W)
+    p_ratio = tuple(p_resample / p for p in p_original)
+    radius = tuple(int(r * p) for r, p in zip(radius, p_ratio))
     # - One problem with this, however, is that if the crop radius ends up being smaller than the default, the QC will in turn be smaller as well.
     #   So, to ensure that the QC is still readable, we scale up by an integer factor whenever the p_ratio is < 1
-    scale = int(math.ceil(1 / p_ratio))  # e.g. 0.8mm human => p_ratio == 0.6/0.8 == 0.75; scale == 1/p_ratio == 1/0.75 == 1.33 => 2x scale
+    scale = int(math.ceil(1 / max(p_ratio)))  # e.g. 0.8mm human => p_ratio == 0.6/0.8 == 0.75; scale == 1/p_ratio == 1/0.75 == 1.33 => 2x scale
 
     # Each slice is centered on the segmentation
     logger.info('Find the center of each slice')

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -795,7 +795,7 @@ def add_orientation_labels(ax: mpl_axes.Axes, radius: tuple[int, int] = (15, 15)
     #    A                    [12,  6]
     # L     R   -->  [0, 17]            [24, 17]
     #    P                    [12, 28]
-    for letter, x, y, in [
+    for letter, y, x, in [
         (letters[0], radius[0] - 3,   6),
         (letters[1], radius[0] - 3,   radius[1]*2 - 2),
         (letters[2], 0,               radius[1] + 2),

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -774,7 +774,7 @@ def mosaic(img: Image, centers: np.ndarray, radius: tuple[int, int] = (15, 15), 
     for center, slice in zip(centers.astype(int), img.data):
         # Add a margin before cropping, in case the center is too close to the edge
         # Also, use Kronecker product to scale each block in multiples
-        cropped.append(np.kron(np.pad(slice, radius)[
+        cropped.append(np.kron(np.pad(slice, ((radius[0], radius[0]), (radius[1], radius[1])))[
             center[0]:center[0] + 2*radius[0],
             center[1]:center[1] + 2*radius[1],
         ], np.ones((scale, scale))))


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Typically, for our QC functions, anisotropic images (i.e. images with resolutions that are not equal for all three x/y/z axes) don't really cause any issues when plotting axial mosaics. This is because typically we will [resample the images to an isotropic resolution](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/89b1ffcbc649cb0f90573cb37aa378f1a3cd3b08/spinalcordtoolbox/reports/qc2.py#L316-L323), which allows us to proceed under the assumption that the slicewise X/Y resolutions are equal.

However, for the rootlets QC, we skip this resampling step and instead modify the crop radius to fit the native resolution of the data. This helps to preserve the thin, often 1-voxel wide rootlets labels when displaying them in the QC report. (See 4c0c1f4180883d800036a11054f237609095d12b for more context.)

But because we skip the resampling, the assumption I described earlier (that the slicewise X/Y resolutions are equal) is no longer valid. Yet, I mistakenly developed the rootlets QC by only testing isotropic images. So, there are a number of steps that use faulty logic, causing anisotropic images to produce a poor QC report.

This PR adds a number of fixes that cause anisotropic images to display correctly:

- d7ca325e1848ff089b8941f15637d2f554a09d95: Choose a crop radius that respects both X and Y resolutions.
- 3bf1eaba7839f1f89040537c7e67a8229779504f: Apply `aspect` to scale the figure so that the voxel size matches the respective X/Y resolutions.
- Fix 2 other bugs that were invisible when tested using only isotropic images:
    - 13006f441ea0600309834750e4d5812272b2de49: Fix bug with how we specific the `pad_width` argument to `np.pad` in the `mosaic` function.
    - 36cd25a2160122397a9bffdcf980d40ce6e746dc: Fix bug with how we specify the x/y coords when writing text.

Before:

![image](https://github.com/user-attachments/assets/274af7cb-0cf8-40d1-b7e4-d7254bec40e7)

After:

![image](https://github.com/user-attachments/assets/aee71041-de4e-4d9b-9177-647050f2a3a9)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4716.