### PR TITLE
Make sure subtractions are signed and divisions are floating point

### DIFF
--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -459,16 +459,18 @@ def main(argv: Sequence[str]):
                         list_data = get_data_arrays(data.shape, arg_value)
                     except ValueError as e:
                         printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                    # the addition can't use += because the dtypes could be different
-                    data = data + np.sum(list_data, axis=0)
+                    # for addition, this dtype is usually ok
+                    safe_dtype = np.result_type(data, *list_data)
+                    data = np.add(data, np.sum(list_data, axis=0, dtype=safe_dtype), dtype=safe_dtype)
 
             elif arg_name == "sub":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                # the subtraction can't use -= because the dtypes could be different
-                data = data - np.sum(list_data, axis=0)
+                # for subtraction, make sure the dtype is at least signed by including int8
+                safe_dtype = np.result_type(data, *list_data, np.int8)
+                data = np.subtract(data, np.sum(list_data, axis=0, dtype=safe_dtype), dtype=safe_dtype)
 
             elif arg_name == "mul":
                 if data.ndim == 4 and not arg_value:
@@ -479,16 +481,18 @@ def main(argv: Sequence[str]):
                         list_data = get_data_arrays(data.shape, arg_value)
                     except ValueError as e:
                         printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                    # the multiplication can't use *= because the dtypes could be different
-                    data = data * np.prod(list_data, axis=0)
+                    # for multiplication, this dtype is usually ok
+                    safe_dtype = np.result_type(data, *list_data)
+                    data = np.multiply(data, np.prod(list_data, axis=0, dtype=safe_dtype), dtype=safe_dtype)
 
             elif arg_name == "div":
                 try:
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                # the division can't use /= because the dtypes could be different
-                data = data / np.prod(list_data, axis=0)
+                # for division, make sure the dtype is at least floating point by including float16
+                safe_dtype = np.result_type(data, *list_data, np.float16)
+                data = np.divide(data, np.prod(list_data, axis=0, dtype=safe_dtype), dtype=safe_dtype)
 
             elif arg_name == "mean":
                 axis = ('x', 'y', 'z', 't').index(arg_value)

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -490,8 +490,8 @@ def main(argv: Sequence[str]):
                     list_data = get_data_arrays(data.shape, arg_value)
                 except ValueError as e:
                     printv(f"ERROR: -{arg_name}: {e}", 1, 'error')
-                # for division, make sure the dtype is at least floating point by including float16
-                safe_dtype = np.result_type(data, *list_data, np.float16)
+                # for division, make sure the dtype is at least floating point by including float32
+                safe_dtype = np.result_type(data, *list_data, np.float32)
                 data = np.divide(data, np.prod(list_data, axis=0, dtype=safe_dtype), dtype=safe_dtype)
 
             elif arg_name == "mean":

--- a/testing/cli/test_cli_sct_maths.py
+++ b/testing/cli/test_cli_sct_maths.py
@@ -136,13 +136,13 @@ def test_sub_between_uints(tmp_path):
 
 def test_div_between_uints(tmp_path):
     """Make sure dividing uints results in a float, rather than a truncated uint."""
-    # make two dummy unsigned integer images, one zeros and one ones
+    # make two dummy unsigned integer images, one ones and one twos
     path_im_uint_twos = str(tmp_path / "im_uint_zeros.nii.gz")
     Image(np.ones((2, 3, 4), dtype=np.uint8) * 2).save(path_im_uint_twos)
     path_im_uint_ones = str(tmp_path / "im_uint_ones.nii.gz")
     Image(np.ones((2, 3, 4), dtype=np.uint8)).save(path_im_uint_ones)
 
-    # test subtraction
+    # test division
     path_im_out = str(tmp_path / "im_out.nii.gz")
     sct_maths.main([
         "-i", path_im_uint_ones,


### PR DESCRIPTION
Numpy arithmetic can be tricky, because subtractions using unsigned integers can result in wraparound to huge positive values. Also, divisions of integer arrays default to `float64`, which may be unnecessarily big.

Rather than relying on these defaults, we should be careful about the expected dtype of arithmetic operations in `sct_maths`. (For uniformity, I also updated the code for addition and multiplication, so that all arithmetic uses the same pattern.)

Fixes #4725.

(I can add a test case on Monday if @joshuacwnewton doesn't beat me to it :wink: but I wanted to get this PR open asap.)