### PR TITLE
Fix orientation labels by properly swapping x/y radii rather than x/y coords

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -795,7 +795,7 @@ def add_orientation_labels(ax: mpl_axes.Axes, radius: tuple[int, int] = (15, 15)
     #    A                    [12,  6]
     # L     R   -->  [0, 17]            [24, 17]
     #    P                    [12, 28]
-    for letter, y, x, in [
+    for letter, x, y, in [
         (letters[0], radius[0] - 3,   6),
         (letters[1], radius[0] - 3,   radius[1]*2 - 2),
         (letters[2], 0,               radius[1] + 2),

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -796,10 +796,10 @@ def add_orientation_labels(ax: mpl_axes.Axes, radius: tuple[int, int] = (15, 15)
     # L     R   -->  [0, 17]            [24, 17]
     #    P                    [12, 28]
     for letter, x, y, in [
-        (letters[0], radius[0] - 3,   6),
-        (letters[1], radius[0] - 3,   radius[1]*2 - 2),
-        (letters[2], 0,               radius[1] + 2),
-        (letters[3], radius[0]*2 - 6, radius[1] + 2)
+        (letters[0], radius[1] - 3,   6),
+        (letters[1], radius[1] - 3,   radius[0]*2 - 2),
+        (letters[2], 0,               radius[0] + 2),
+        (letters[3], radius[1]*2 - 6, radius[0] + 2)
     ]:
         ax.text(x, y, letter, color='yellow', size=4).set_path_effects([
             mpl_patheffects.Stroke(linewidth=1, foreground='black'),


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4722, I fixed some issues that affected anisotropic QC reports that we had been blind to for isotropic images (i.e. the case where `radius[0] == radius[1]`). 

One of those changes swapped the x/y coordinates for orientation labels, because numpy arrays use "zyx" axis ordering, thus radius[0] corresponds to y and radius[1] corresponds to x.

However, in doing so, I not only swapped radius[0]/radius[1], but I also swapped the _axis-specific offsets_, causing the orientation labels to be misplaced. To fix this, I need to just swap radii.

Before (isotropic):

![image](https://github.com/user-attachments/assets/67743181-5a55-4ed8-8592-af70667d572c)

After (isotropic):

![image](https://github.com/user-attachments/assets/f7d927e6-2675-44a6-a563-955dbfc92e1d)

After (anisotropic):

![image](https://github.com/user-attachments/assets/5d4370b3-d6d2-4d18-ae75-3d548e29e1bf)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4734.
