### PR TITLE
Set header datatype when applying dtype fix for NearestNeighbours interpolation to avoid warnings in log

### DIFF
--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -140,6 +140,7 @@ def isct_antsApplyTransforms(dimensionality,
     dtype_in = Image(fname_input).data.dtype
     if 'NearestNeighbor' in interpolation_args:
         im_out.data = im_out.data.astype(dtype_in)
+        im_out.hdr.set_data_dtype(dtype_in)
         im_out.save(verbose=0)
     # FIXME: Consider returning an `Image` type if the extra save/loads
     #        add significant overhead to `sct_apply_transfo`.


### PR DESCRIPTION
## Description

Since we're intentionally changing the datatype here, we can also safely change the header datatype (to avoid warnings about the header dtype not being int).

This makes `sct_warp_template` a lot less noisy, with almost all of the warnings coming from uint8 images in the template.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4738.