### PR TITLE
Add missing binarization+thresholding step for segmentations in `sct_deepseg` QC

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -326,11 +326,14 @@ def sct_deepseg_axial(
         image_dest=img_input,
         interpolation='linear',
     )
+    img_seg_sc.data = (img_seg_sc.data > 0.5) * 1
     img_seg_lesion = resample_nib(
         image=img_seg_lesion,
         image_dest=img_input,
         interpolation='linear',
     ) if fname_seg_lesion else None
+    if fname_seg_lesion:
+        img_seg_lesion.data = (img_seg_lesion.data > 0.5) * 1
 
     # Each slice is centered on the segmentation
     logger.info('Find the center of each slice')
@@ -527,11 +530,14 @@ def sct_deepseg_sagittal(
         image_dest=img_input,
         interpolation='linear',
     )
+    img_seg_sc.data = (img_seg_sc.data > 0.5) * 1
     img_seg_lesion = resample_nib(
         image=img_seg_lesion,
         image_dest=img_input,
         interpolation='linear',
     ) if fname_seg_lesion else None
+    if fname_seg_lesion:
+        img_seg_lesion.data = (img_seg_lesion.data > 0.5) * 1
 
     # The radius is set to display the entire slice
     radius = (img_input.dim[1]//2, img_input.dim[2]//2)


### PR DESCRIPTION
## Description

Thresholding is done by default (**AFTER** resampling w/linear interpolation) for all segmentations in the old `qc.py` QC:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/4868a2cdd79a7109bce1de8747f52cbed9d18b0f/spinalcordtoolbox/reports/slice.py#L174-L183

We remembered to add a simplified version of this thresholding step (that always performs binarization) when we converted the `sct_register_multimodal` QC from `qc.py` to `qc2.py`:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/f72607f22cdf1debc4e8da148f3827cbfd941667/spinalcordtoolbox/reports/qc2.py#L199-L205

However, we forgot to add this same step in the `sct_deepseg` QC reports. So, I've added it to both the axial and sagittal mosaic QCs:

Before:

![image](https://github.com/user-attachments/assets/c6b12b5c-9863-46b9-96b0-468a2be62b59)

After:

![image](https://github.com/user-attachments/assets/3121ef5f-d479-4595-bfcb-e288388d96a4)

Note that this isn't relevant for rootlets/totalspineseg QCs because we don't resample for those.

## Linked issues

Fixes #4741.
