### PR TITLE
Remove hardcoded `num_workers=8` and replace with `cpu_count()`-based value

### DIFF
--- a/spinalcordtoolbox/deepseg/monai.py
+++ b/spinalcordtoolbox/deepseg/monai.py
@@ -1,5 +1,7 @@
 import os
 import glob
+import math
+import multiprocessing as mp
 
 import torch
 import torch.nn.functional as F
@@ -164,7 +166,7 @@ def prepare_data(path_image, crop_size=(64, 160, 320), padding='edge'):
         ThresholdIntensityd(keys=["pred"], threshold=1.0, above=False, cval=1.0)
     ])
     test_ds = Dataset(data=[{"image": path_image}], transform=transforms_test)
-    test_loader = DataLoader(test_ds, batch_size=1, shuffle=False, num_workers=8, pin_memory=True)
+    test_loader = DataLoader(test_ds, batch_size=1, shuffle=False, num_workers=math.ceil(mp.cpu_count() / 2), pin_memory=True)
 
     return test_loader, test_post_pred
 


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This is a quick temporary fix (to be backported to v6.5) to address the issue of `num_workers` being greater than the `cpu_count()`.

A more complex fix would be to add a flag to control this value, to be discussed for v7.0.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4750.
