### PR TITLE
Add new CLI script to predict compression probability

### DIFF
--- a/documentation/source/user_section/command-line.rst
+++ b/documentation/source/user_section/command-line.rst
@@ -26,6 +26,7 @@ Segmentation Analysis
 - :ref:`sct_analyze_lesion` - Compute statistics on segmented lesions.
 - :ref:`sct_compute_hausdorff_distance` - Compute the Hausdorff's distance between two binary images.
 - :ref:`sct_compute_compression` - Compute spinal cord compression morphometrics.
+- :ref:`sct_detect_compression` - Predict compression probability using spinal cord morphometrics.
 - :ref:`sct_dice_coefficient` - Compute the Dice Coefficient to estimate overlap between two binary images.
 - :ref:`sct_process_segmentation` - Perform various types of processing from the spinal cord segmentation.
 

--- a/documentation/source/user_section/command-line/all_tools.rst
+++ b/documentation/source/user_section/command-line/all_tools.rst
@@ -107,6 +107,12 @@ sct_denoising_onlm
 .. program-output:: sct_denoising_onlm -h
 
 
+sct_detect_compression
+==================
+
+.. program-output:: sct_detect_compression -h
+
+
 sct_detect_pmj
 ==============
 

--- a/documentation/source/user_section/command-line/all_tools.rst
+++ b/documentation/source/user_section/command-line/all_tools.rst
@@ -108,7 +108,7 @@ sct_denoising_onlm
 
 
 sct_detect_compression
-==================
+======================
 
 .. program-output:: sct_detect_compression -h
 

--- a/documentation/source/user_section/command-line/index/segmentation-analysis.rst
+++ b/documentation/source/user_section/command-line/index/segmentation-analysis.rst
@@ -8,5 +8,6 @@ Segmentation analysis
    ../sct_analyze_lesion
    ../sct_compute_hausdorff_distance
    ../sct_compute_compression
+   ../sct_detect_compression
    ../sct_dice_coefficient
    ../sct_process_segmentation

--- a/documentation/source/user_section/command-line/sct_detect_compression.rst
+++ b/documentation/source/user_section/command-line/sct_detect_compression.rst
@@ -1,0 +1,9 @@
+.. _sct_detect_compression:
+
+_sct_detect_compression
+=======================
+
+.. argparse::
+   :ref: spinalcordtoolbox.scripts.sct_detect_compression.get_parser
+   :prog: sct_detect_compression
+   :markdownhelp:

--- a/documentation/source/user_section/command-line/sct_detect_compression.rst
+++ b/documentation/source/user_section/command-line/sct_detect_compression.rst
@@ -1,6 +1,6 @@
 .. _sct_detect_compression:
 
-_sct_detect_compression
+sct_detect_compression
 =======================
 
 .. argparse::

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
                 'sct_deepseg_lesion',
                 'sct_deepseg_sc',
                 'sct_denoising_onlm',
+                'sct_detect_compression',
                 'sct_detect_pmj',
                 'sct_dice_coefficient',
                 'sct_dmri_compute_bvalue',

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -115,7 +115,7 @@ def predict_compression_probability(cr, csa, solidity, torsion, disc):
         + coefficients["cr"] * cr
         + coefficients["csa"] * csa
         + coefficients["solidity"] * solidity
-        + coefficients["torsion"] * torsion
+        + (coefficients["torsion"] * torsion if torsion is not None else 0)     # edge-case when torsion is None
         + (coefficients["level_c6c7"] if disc == 7 else 0)
     )
     return math.exp(model) / (1 + math.exp(model))

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -56,7 +56,7 @@ def get_parser():
             (the sum of sensitivity and specificity). More info in the reference below.
 
             Reference:
-            
+
                 - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
                   https://doi.org/10.21037/qims-21-782
         """),  # noqa: E501 (line too long)

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -232,23 +232,23 @@ def process_compression(metrics_agg_merged, disc_slices):
     """
     compression_df = pd.DataFrame()
     # Loop across discs
-    for disc, slices in disc_slices.items():
+    for disc, disc_slice in disc_slices.items():
         # Add one slice above and below to process multiple slices around the disc to compensate for potential
         # disc label shift in the superior-inferior (S-I) axis
-        slices = [slices + 1, slices, slices - 1]
-        for slice in slices:
+        slices = [disc_slice + 1, disc_slice, disc_slice - 1]
+        for slc in slices:
             if disc in SUPPORTED_DISCS.keys():
                 # Note: [slice,] is used to convert int to tuple
-                cr = metrics_agg_merged[slice,]['MEAN(compression_ratio)'] * 100    # to convert to %
-                csa = metrics_agg_merged[slice,]['MEAN(area)']
-                solidity = metrics_agg_merged[slice,]['MEAN(solidity)'] * 100     # to convert to %
-                torsion = metrics_agg_merged[slice,]['Torsion']
+                cr = metrics_agg_merged[slc,]['MEAN(compression_ratio)'] * 100    # to convert to %
+                csa = metrics_agg_merged[slc,]['MEAN(area)']
+                solidity = metrics_agg_merged[slc,]['MEAN(solidity)'] * 100     # to convert to %
+                torsion = metrics_agg_merged[slc,]['Torsion']
                 # Compute compression probability
                 probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
                 compression_category = 'yes' if probability > CUT_OFF_HIGH else \
                     'possible' if probability > CUT_OFF_MODERATE else 'no'
                 compression_df = pd.concat([compression_df,
-                                            pd.DataFrame([{'Disc': SUPPORTED_DISCS[disc], 'Axial slice #': slice,
+                                            pd.DataFrame([{'Disc': SUPPORTED_DISCS[disc], 'Axial slice #': slc,
                                                            'Compression probability': probability,
                                                            'Compression probability category': compression_category,
                                                            'Compression ratio (%)': cr, 'CSA (mm2)': csa,

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -100,10 +100,8 @@ def get_parser():
         choices=[0, 1],
         default=1,
         help=textwrap.dedent("""
-            Angle correction for computing morphometric measures. When angle correction is used, the cord within the
-            slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline
-            and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set  -angle-corr to 0.
-        """)
+            Angle correction for computing morphometric measures. When angle correction is used, the cord within the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set  -angle-corr to 0.
+        """)  # noqa: E501 (line too long)
     )
     optional.add_argument(
         '-o',

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -315,9 +315,11 @@ def main(argv: Sequence[str]):
     for disc in compression_df['Disc'].unique():
         # If any axial slice around the disc is compressed, the disc is considered compressed
         if 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {disc}: compressed", verbose)
+            printv(f"Disc {disc}, compression probability: yes", verbose)
         elif 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {disc}: possibly compressed", verbose)
+            printv(f"Disc {disc}, compression probability: possible", verbose)
+        elif 'no' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
+            printv(f"Disc {disc}, compression probability: no", verbose)
 
     if verbose == 2:
         for index, row in compression_df.iterrows():

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -65,9 +65,9 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help=textwrap.dedent("""
-            File with disc labels, which will be used to identify the axial slices for processing.
+            File with disc labels. Each label must be a single voxel. Only label values 4, 5, 6, and 7 (C3/C4 to C6/C7) are supported for now; all other labels will be ignored.
             Labels can be located either at the posterior edge of the intervertebral discs, or at the orthogonal projection of each disc onto the spinal cord.
-            Such label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
+            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
             obtained automatically using the sct_label_vertebrae function (the file with the \'labeled_discs.nii.gz\' suffix).
             Example: t2s_discs.nii.gz.
         """),  # noqa: E501 (line too long)

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+#
+# Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
+# IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/7
+# (value: 7). In other words, the script does *not* process all axial slices of the spinal cord segmentation.
+#
+# The script requires spinal cord segmentation (used to compute the shape metrics) and disc labels.
+#
+# More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
+#
+# Copyright (c) 2024 Polytechnique Montreal <www.neuro.polymtl.ca>
+# License: see the file LICENSE
+
+import sys
+import math
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from spinalcordtoolbox.process_seg import compute_shape
+from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, func_wa, func_std, merge_dict
+from spinalcordtoolbox.centerline.core import ParamCenterline
+from spinalcordtoolbox.template import get_slices_from_vertebral_levels
+from spinalcordtoolbox.image import Image, add_suffix, splitext
+from spinalcordtoolbox.utils.fs import get_absolute_path
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
+from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
+
+
+# Currently, the model works only for discs C3/C4 (4) to C6/7 (7)
+SUPPORTED_DISCS = [4, 5, 6, 7]
+# Cut-off to determine the presence of the compression
+CUT_OFF = 0.451
+
+def get_parser():
+    parser = SCTArgumentParser(
+        description=("""\
+Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
+IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/7 (value: 7).
+More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
+        """)
+    )
+
+    mandatoryArguments = parser.add_argument_group("MANDATORY ARGUMENTS")
+    mandatoryArguments.add_argument(
+        '-s',
+        metavar=Metavar.file,
+        required=True,
+        help="Segmentation of the spinal cord. Example: t2s_seg.nii.gz"
+    )
+    mandatoryArguments.add_argument(
+        '-discfile',
+        metavar=Metavar.file,
+        required=True,
+        help="File with disc labels. Example: t2s_discs.nii.gz "
+             "The convention for disc labels is the following: value=3 -> disc C2/C3, value=4 -> disc C3/C4, etc."
+             "Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 "
+             "or obtained automatically using the sct_label_vertebrae function "
+             "(the file with the \'labeled_discs.nii.gz\' suffix)."
+    )
+
+    optional = parser.add_argument_group('OPTIONAL ARGUMENTS')
+    optional.add_argument(
+        '-angle-corr',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
+        help="Angle correction for computing morphometric measures used within "
+             "\'spinalcordtoolbox.process_seg.compute_shape\'. When angle correction is used, the cord within "
+             "the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the "
+             "centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set "
+             "-angle-corr to 0."
+    )
+    optional.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        help="Show this help message and exit")
+    optional.add_argument(
+        '-v',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
+
+    return parser
+
+
+def predict_compression_probability(cr, csa, solidity, torsion, disc):
+    """
+    Predict compression probability using the spinal cord shape metrics for currently processed axial slice.
+    See Equation 4 and Table 3 for details: https://pubmed.ncbi.nlm.nih.gov/35371944/
+    :param cr: compression ratio (CR) in %
+    :param csa: cross-sectional area (CSA) in mm2
+    :param solidity: solidity in %
+    :param torsion: torsion in degrees
+    :param disc: intervertebral disc level (e.g., value=4 -> disc C3/C4)
+    :return: probability
+    """
+    coefficients = {
+        "constant": 57.501,
+        "cr": -0.273,
+        "csa": -0.102,
+        "solidity": -0.408,
+        "torsion": 2.168,
+        "level_c6c7": -2.729,
+    }
+    model = (
+        coefficients["constant"]
+        + coefficients["cr"] * cr
+        + coefficients["csa"] * csa
+        + coefficients["solidity"] * solidity
+        + coefficients["torsion"] * torsion
+        + (coefficients["level_c6c7"] if disc == 7 else 0)
+    )
+    return math.exp(model) / (1 + math.exp(model))
+
+def compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose):
+    """
+    Compute shape metrics per slice.
+    Then, compute compression ratio and torsion.
+    :param fname_seg: file with spinal cord segmentation
+    :param fname_disc: file with disc labels
+    :param angle_correction: bool: angle correction for computing morphometric measures
+    :param verbose: verbosity
+    :return: dictionary with aggregated metrics
+    """
+    metrics, fit_results = compute_shape(fname_seg,
+                                         angle_correction=angle_correction,
+                                         param_centerline=ParamCenterline(),
+                                         verbose=verbose)
+
+    # Compute the average and standard deviation across axial slices
+    group_funcs = (('MEAN', func_wa), ('STD', func_std))
+    metrics_agg = {}
+    for key in ['area', 'diameter_AP', 'diameter_RL', 'solidity', 'orientation']:
+        # Note: we do not need to calculate all the metrics, we need just:
+        #   - area (will be CSA)
+        #   - diameter_AP and diameter_RL (used to calculate compression ratio)
+        #   - solidity
+        #   - orientation (used to calculate torsion)
+        # Note: we have to calculate metrics across all slices (perslice) to be able to compute orientation
+        metrics_agg[key] = aggregate_per_slice_or_level(metrics[key],
+                                                        perslice=True,
+                                                        perlevel=False, fname_vert_level=fname_disc,
+                                                        group_funcs=group_funcs
+                                                        )
+    metrics_agg_merged = merge_dict(metrics_agg)
+    # Compute compression ratio
+    metrics_agg_merged = compute_compression_ratio(metrics_agg_merged)
+    # Compute torsion
+    metrics_agg_merged = compute_torsion(metrics_agg_merged, verbose)
+
+    return metrics_agg_merged
+
+def compute_compression_ratio(metrics_agg_merged):
+    """
+    Compute compression ratio (CR) as 'diameter_AP' / 'diameter_RL'
+    :param metrics_agg_merged: dictionary with aggregated metrics
+    :return: dictionary with compression ratio added
+    """
+    for metrics in metrics_agg_merged.values():  # Loop across slices
+        ap = metrics['MEAN(diameter_AP)']
+        rl = metrics['MEAN(diameter_RL)']
+        metrics['MEAN(compression_ratio)'] = None if ap is None or rl is None else ap / rl
+
+    return metrics_agg_merged
+
+def compute_torsion(metrics_agg_merged, verbose):
+    """
+    Compute torsion as the average of absolute differences in orientation between the given slice and 3 slices
+    above and below. For details see Equation 3 and Supplementary Material in https://pubmed.ncbi.nlm.nih.gov/35371944/.
+    NOTE: As the torsion is computed from 3 slices above and below, it cannot be computed for the 3 first and last
+    3 slices --> `torsion = None` is used for the 3 first and 3 last slices.
+    :param metrics_agg_merged: dictionary with aggregated metrics
+    :param verbose: verbosity
+    :return: dictionary with torsion added
+    """
+    slices = list(metrics_agg_merged.keys())[3:-3]
+
+    for key in metrics_agg_merged.keys():  # Loop across slices
+        if key in slices:
+            try:
+                # Note: the key is a tuple (e.g. `1,`), not an int (e.g., 1), thus key[0] is used to convert tuple to int
+                # and `,` is used to convert int back to tuple
+                metrics_agg_merged[key]['Torsion'] = 1/6 * (abs(metrics_agg_merged[key]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] - 1,]['MEAN(orientation)']) +
+                                                            abs(metrics_agg_merged[key]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] + 1,]['MEAN(orientation)']) +
+                                                            abs(metrics_agg_merged[key[0] - 1,]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] - 2,]['MEAN(orientation)']) +
+                                                            abs(metrics_agg_merged[key[0] + 1,]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] + 2,]['MEAN(orientation)']) +
+                                                            abs(metrics_agg_merged[key[0] - 2,]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] - 3,]['MEAN(orientation)']) +
+                                                            abs(metrics_agg_merged[key[0] + 2,]['MEAN(orientation)'] -
+                                                                metrics_agg_merged[key[0] + 3,]['MEAN(orientation)']))
+            except Exception as e:
+                # TODO: the warning below is raise mainly in cases of no SC segmentation, for example above the C1 level
+                #  --> consider processing only slices with SC segmentation
+                printv(f"WARNING: Failed to compute torsion for slice {key[0]}. Use `-v 2` flag to see details",
+                       verbose, type='warning')
+                if verbose == 2:
+                    printv(f"\t{e}", verbose)
+                metrics_agg_merged[key]['Torsion'] = None
+        else:
+            metrics_agg_merged[key]['Torsion'] = None
+
+    return metrics_agg_merged
+
+def process_compression(metrics_agg_merged, disc_slices):
+    """
+    Process shape metrics for axial slices at the level of each disc to predict the compression probability.
+    :param metrics_agg_merged: dictionary with aggregated metrics
+    :param disc_slices: dictionary with disc labels as keys and corresponding axial slice numbers as values
+    :return: dataframe with compression probability
+    """
+    compression_df = pd.DataFrame()
+    # Loop across discs
+    for disc, slice in disc_slices.items():
+    # for disc, slices in disc_slices.items():
+    #     # Add one slice above and below to process multiple slices around the disc to compensate for potential
+    #     # disc label shift in the superior-inferior direction
+    #     slices = [slices - 1, slices, slices + 1]
+    #     for slice in slices:
+        if disc in SUPPORTED_DISCS:
+            # Note: [slice,] is used to convert int to tuple
+            cr = metrics_agg_merged[slice,]['MEAN(compression_ratio)'] * 100    # to convert to %
+            csa = metrics_agg_merged[slice,]['MEAN(area)']
+            solidity = metrics_agg_merged[slice,]['MEAN(solidity)'] * 100     # to convert to %
+            torsion = metrics_agg_merged[slice,]['Torsion']
+            # Compute compression probability
+            probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
+            compression_df = pd.concat([compression_df,
+                                        pd.DataFrame([{'Disc': disc, 'Axial slice #': slice,
+                                                       'Compression probability': probability,
+                                                       'Compression ratio (%)': cr, 'CSA (mm2)': csa,
+                                                       'Solidity (%)': solidity, 'Torsion (degrees)': torsion}])],
+                                       ignore_index=True)
+
+    return compression_df
+
+def get_disc_slices(fname_disc):
+    """
+    Get axial slice numbers corresponding to the intervertebral discs.
+    :param fname_disc: file with disc labels
+    :return: dictionary with disc labels as keys and corresponding axial slice numbers as values
+    """
+    im_disc = Image(fname_disc).change_orientation('RPI')
+    discs = [int(disc) for disc in np.trim_zeros(np.unique(im_disc.data))]  # get unique disc labels (e.g., 3, 4, 5 etc)
+    # Find axial slices corresponding to the discs
+    # Note: [0] is used because get_slices_from_vertebral_levels returns list
+    disc_slices = {disc: get_slices_from_vertebral_levels(im_disc, disc)[0] for disc in discs}
+
+    return disc_slices
+
+
+def main(argv: Sequence[str]):
+    parser = get_parser()
+    arguments = parser.parse_args(argv)
+    verbose = arguments.v
+    set_loglevel(verbose=verbose, caller_module_name=__name__)
+
+    # Parse arguments
+    fname_seg = get_absolute_path(arguments.s)
+    fname_disc = get_absolute_path(arguments.discfile)
+    angle_correction = bool(arguments.angle_corr)
+
+    # Compute shape metrics per slice
+    metrics_agg_merged = compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose)
+
+    # Get discs corresponding to the compression
+    disc_slices = get_disc_slices(fname_disc)
+
+    # Process axial slices for each disc to compute compression probability
+    compression_df = process_compression(metrics_agg_merged, disc_slices)
+
+    # Save the results to a CSV file
+    fname_out = splitext(add_suffix(fname_seg, '_compression_results'))[0] + '.csv'
+    compression_df.to_csv(fname_out, index=False)
+    printv(f"Results saved to: {fname_out}", verbose)
+
+    # Loop across compressions and print the results if the probability is above the cut-off
+    for index, row in compression_df.iterrows():
+        if row['Compression probability'] > CUT_OFF:
+            printv(f"Disc {int(row['Disc'])} at axial slice {int(row['Axial slice #'])} has a high probability "
+                   f"of compression: {row['Compression probability'] * 100:.2f}%. ", verbose)
+
+
+if __name__ == "__main__":
+    init_sct()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -30,10 +30,10 @@ from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
 
 # Currently, the model works only for discs C3/C4 (4) to C6/C7 (7)
 SUPPORTED_DISCS = [4, 5, 6, 7]
-# Compression cut-offs
-#   >0.451 high probability of compression
-#   0.345-0.451 moderate probability of compression
-#   <0.345 low probability of compression
+# Compression cut-offs --> compression probability
+#   >0.451 high probability of compression --> yes
+#   0.345-0.451 moderate probability of compression --> possible
+#   <0.345 low probability of compression --> no
 CUT_OFF_HIGH = 0.451
 CUT_OFF_MODERATE = 0.345
 
@@ -297,10 +297,12 @@ def main(argv: Sequence[str]):
     printv(f"Results saved to: {fname_out}", verbose)
 
     # Loop across discs and print results to terminal
-    for index, row in compression_df.iterrows():
-        printv(f"Disc {int(row['Disc'])} at axial slice {int(row['Axial slice #'])} has a "
-               f"{row['Compression probability category']} probability of compression: "
-               f"{row['Compression probability'] * 100:.2f}%. ", verbose)
+    for disc in compression_df['Disc'].unique():
+        # If any axial slice around the disc is compressed, the disc is considered compressed
+        if 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
+            printv(f"Disc {int(disc)} is possibly compressed.", verbose)
+        elif 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
+            printv(f"Disc {int(disc)} is compressed.", verbose)
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -62,7 +62,7 @@ def get_parser():
         help=textwrap.dedent("""
             File with disc labels. Example: t2s_discs.nii.gz.
             The convention for disc labels is the following: value=3 -> disc C2/C3, value=4 -> disc C3/C4, etc.
-            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or 
+            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
             obtained automatically using the sct_label_vertebrae function (the file with the \'labeled_discs.nii.gz\' suffix).
         """),  # noqa: E501 (line too long)
     )
@@ -75,8 +75,8 @@ def get_parser():
         choices=[0, 1],
         default=1,
         help=textwrap.dedent("""
-            Angle correction for computing morphometric measures. When angle correction is used, the cord within the 
-            slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline 
+            Angle correction for computing morphometric measures. When angle correction is used, the cord within the
+            slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline
             and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set  -angle-corr to 0.
         """)
     )

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -160,6 +160,9 @@ def compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose):
     :param verbose: verbosity
     :return: dictionary with aggregated metrics
     """
+    if not np.any(Image(fname_seg).data):
+        raise ValueError("Spinal cord segmentation file is empty.")
+
     metrics, fit_results = compute_shape(fname_seg,
                                          angle_correction=angle_correction,
                                          param_centerline=ParamCenterline(),

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -316,21 +316,10 @@ def main(argv: Sequence[str]):
     compression_df.to_csv(fname_out, index=False)
     printv(f"Results saved to: {fname_out}", verbose)
 
-    # Loop across discs and print results to terminal
-    for disc in compression_df['Disc'].unique():
-        # If any axial slice around the disc is compressed, the disc is considered compressed
-        if 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {disc}, compression probability: yes", verbose)
-        elif 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {disc}, compression probability: possible", verbose)
-        elif 'no' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {disc}, compression probability: no", verbose)
-
-    if verbose == 2:
-        for index, row in compression_df.iterrows():
-            printv(f"Disc {(row['Disc'])}, axial slice {int(row['Axial slice #'])}: "
-                   f"probability of compression: {row['Compression probability'] * 100:.2f}% "
-                   f"(compression probability category: {row['Compression probability category']})", verbose)
+    for index, row in compression_df.iterrows():
+        printv(f"Disc {(row['Disc'])}, axial slice {int(row['Axial slice #'])} --> "
+               f"compression probability: {row['Compression probability category']} "
+               f"({row['Compression probability'] * 100:.2f}%)")
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -44,7 +44,10 @@ def get_parser():
         description=textwrap.dedent("""
             Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
             IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
-            More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
+            
+            Reference:
+                - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279. 
+                  https://doi.org/10.21037/qims-21-782
         """),  # noqa: E501 (line too long)
     )
 

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -33,6 +33,7 @@ SUPPORTED_DISCS = [4, 5, 6, 7]
 # Cut-off to determine the presence of the compression
 CUT_OFF = 0.451
 
+
 def get_parser():
     parser = SCTArgumentParser(
         description=("""\
@@ -119,6 +120,7 @@ def predict_compression_probability(cr, csa, solidity, torsion, disc):
     )
     return math.exp(model) / (1 + math.exp(model))
 
+
 def compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose):
     """
     Compute shape metrics per slice.
@@ -157,6 +159,7 @@ def compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose):
 
     return metrics_agg_merged
 
+
 def compute_compression_ratio(metrics_agg_merged):
     """
     Compute compression ratio (CR) as 'diameter_AP' / 'diameter_RL'
@@ -169,6 +172,7 @@ def compute_compression_ratio(metrics_agg_merged):
         metrics['MEAN(compression_ratio)'] = None if ap is None or rl is None else ap / rl
 
     return metrics_agg_merged
+
 
 def compute_torsion(metrics_agg_merged, verbose):
     """
@@ -212,6 +216,7 @@ def compute_torsion(metrics_agg_merged, verbose):
 
     return metrics_agg_merged
 
+
 def process_compression(metrics_agg_merged, disc_slices):
     """
     Process shape metrics for axial slices at the level of each disc to predict the compression probability.
@@ -243,6 +248,7 @@ def process_compression(metrics_agg_merged, disc_slices):
                                        ignore_index=True)
 
     return compression_df
+
 
 def get_disc_slices(fname_disc):
     """

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -35,7 +35,7 @@ SUPPORTED_DISCS = [4, 5, 6, 7]
 #   0.345-0.451 moderate probability of compression
 #   <0.345 low probability of compression
 CUT_OFF_HIGH = 0.451
-CUT_OFF_MILD = 0.345
+CUT_OFF_MODERATE = 0.345
 
 
 def get_parser():
@@ -245,7 +245,7 @@ def process_compression(metrics_agg_merged, disc_slices):
             # Compute compression probability
             probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
             compression_category = 'high' if probability > CUT_OFF_HIGH else \
-                'moderate' if probability > CUT_OFF_MILD else 'low'
+                'moderate' if probability > CUT_OFF_MODERATE else 'low'
             compression_df = pd.concat([compression_df,
                                         pd.DataFrame([{'Disc': disc, 'Axial slice #': slice,
                                                        'Compression probability': probability,

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -48,16 +48,16 @@ def get_parser():
 
             Compression categories are determined based on the following cut-offs:
 
-                - 'yes'     : p > {CUT_OFF_HIGH}
-                - 'possible': {CUT_OFF_MODERATE} <= p <= {CUT_OFF_HIGH}
-                - 'no'      : p < {CUT_OFF_MODERATE}
+              - 'yes'     : p > {CUT_OFF_HIGH}
+              - 'possible': {CUT_OFF_MODERATE} <= p <= {CUT_OFF_HIGH}
+              - 'no'      : p < {CUT_OFF_MODERATE}
 
             These cut-off values and compression categories were determined by ROC analysis and the Youden’s index
             (the sum of sensitivity and specificity). More info in the reference below.
 
             Reference:
 
-                - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
+              - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
                   https://doi.org/10.21037/qims-21-782
         """),  # noqa: E501 (line too long)
     )

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -258,9 +258,7 @@ def process_compression(metrics_agg_merged, disc_slices, num_of_slices):
     for disc, disc_slice in disc_slices.items():
         # Add one slice above and below to process multiple slices around the disc to compensate for potential
         # disc label shift in the superior-inferior (S-I) axis
-        slices = [disc_slice] if num_of_slices == 0 \
-            else range(disc_slice - num_of_slices, disc_slice + num_of_slices + 1)
-        for slc in slices:
+        for slc in range(disc_slice - num_of_slices, disc_slice + num_of_slices + 1):
             if disc in SUPPORTED_DISCS.keys():
                 # Note: [slice,] is used to convert int to tuple
                 cr = metrics_agg_merged[slc,]['MEAN(compression_ratio)'] * 100    # to convert to %

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -29,7 +29,7 @@ from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
 
 
 # Currently, the model works only for discs C3/C4 (4) to C6/C7 (7)
-SUPPORTED_DISCS = [4, 5, 6, 7]
+SUPPORTED_DISCS = {4: 'C3/C4', 5: 'C4/C5', 6: 'C5/C6', 7: 'C6/C7'}
 # Compression cut-offs --> compression probability
 #   >0.451 high probability of compression --> yes
 #   0.345-0.451 moderate probability of compression --> possible
@@ -235,7 +235,7 @@ def process_compression(metrics_agg_merged, disc_slices):
         # disc label shift in the superior-inferior (S-I) axis
         slices = [slices + 1, slices, slices - 1]
         for slice in slices:
-            if disc in SUPPORTED_DISCS:
+            if disc in SUPPORTED_DISCS.keys():
                 # Note: [slice,] is used to convert int to tuple
                 cr = metrics_agg_merged[slice,]['MEAN(compression_ratio)'] * 100    # to convert to %
                 csa = metrics_agg_merged[slice,]['MEAN(area)']
@@ -246,7 +246,7 @@ def process_compression(metrics_agg_merged, disc_slices):
                 compression_category = 'yes' if probability > CUT_OFF_HIGH else \
                     'possible' if probability > CUT_OFF_MODERATE else 'no'
                 compression_df = pd.concat([compression_df,
-                                            pd.DataFrame([{'Disc': disc, 'Axial slice #': slice,
+                                            pd.DataFrame([{'Disc': SUPPORTED_DISCS[disc], 'Axial slice #': slice,
                                                            'Compression probability': probability,
                                                            'Compression probability category': compression_category,
                                                            'Compression ratio (%)': cr, 'CSA (mm2)': csa,
@@ -300,13 +300,13 @@ def main(argv: Sequence[str]):
     for disc in compression_df['Disc'].unique():
         # If any axial slice around the disc is compressed, the disc is considered compressed
         if 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {int(disc)} is compressed.", verbose)
+            printv(f"Disc {disc}: compressed", verbose)
         elif 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {int(disc)} is possibly compressed.", verbose)
+            printv(f"Disc {disc}: possibly compressed", verbose)
 
     if verbose == 2:
         for index, row in compression_df.iterrows():
-            printv(f"Disc {int(row['Disc'])} at axial slice {int(row['Axial slice #'])}: "
+            printv(f"Disc {(row['Disc'])}, axial slice {int(row['Axial slice #'])}: "
                    f"probability of compression: {row['Compression probability'] * 100:.2f}% "
                    f"(compression probability category: {row['Compression probability category']})", verbose)
 

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
-# IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/7
+# IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7
 # (value: 7). In other words, the script does *not* process all axial slices of the spinal cord segmentation.
 #
 # The script requires spinal cord segmentation (used to compute the shape metrics) and disc labels.
@@ -28,7 +28,7 @@ from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, set_loglevel, printv
 
 
-# Currently, the model works only for discs C3/C4 (4) to C6/7 (7)
+# Currently, the model works only for discs C3/C4 (4) to C6/C7 (7)
 SUPPORTED_DISCS = [4, 5, 6, 7]
 # Compression cut-offs
 #   >0.451 high probability of compression
@@ -42,7 +42,7 @@ def get_parser():
     parser = SCTArgumentParser(
         description=("""\
 Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
-IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/7 (value: 7).
+IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
 More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
         """)
     )

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -304,6 +304,12 @@ def main(argv: Sequence[str]):
         elif 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
             printv(f"Disc {int(disc)} is compressed.", verbose)
 
+    if verbose == 2:
+        for index, row in compression_df.iterrows():
+            printv(f"Disc {int(row['Disc'])} at axial slice {int(row['Axial slice #'])}: "
+                   f"probability of compression: {row['Compression probability'] * 100:.2f}% "
+                   f"(compression probability category: {row['Compression probability category']})", verbose)
+
 
 if __name__ == "__main__":
     init_sct()

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -80,9 +80,8 @@ def get_parser():
         type=int,
         default=0,
         help=textwrap.dedent("""
-            Number of slices above and below the intervertebral disc to process.
-            If 0 is provided, only the axial slice corresponding to the disc is processed.
-            If 1 is provided, the axial slice corresponding to the disc and one slice above and below are processed (i.e., 3 slices in total).
+            Number of additional axial slices above and below the intervertebral disc to process.
+            Specifying `-num-of-slices 1` will process 3 slices total per disc (+/- 1), `2` will process 5 slices total (+/- 2), and so on.
         """),  # noqa: E501 (line too long)
     )
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -44,9 +44,9 @@ def get_parser():
         description=textwrap.dedent("""
             Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
             The script process axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
-            
+
             Reference:
-                - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279. 
+                - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
                   https://doi.org/10.21037/qims-21-782
         """),  # noqa: E501 (line too long)
     )

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -6,7 +6,7 @@
 #
 # The script requires spinal cord segmentation (used to compute the shape metrics) and disc labels.
 #
-# More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
+# More details in: https://doi.org/10.21037/qims-21-782
 #
 # Copyright (c) 2024 Polytechnique Montreal <www.neuro.polymtl.ca>
 # License: see the file LICENSE
@@ -122,7 +122,7 @@ def get_parser():
 def predict_compression_probability(cr, csa, solidity, torsion, disc):
     """
     Predict compression probability using the spinal cord shape metrics for currently processed axial slice.
-    See Equation 4 and Table 3 for details: https://pubmed.ncbi.nlm.nih.gov/35371944/
+    See Equation 4 and Table 3 for details: https://doi.org/10.21037/qims-21-782
     :param cr: compression ratio (CR) in %
     :param csa: cross-sectional area (CSA) in mm2
     :param solidity: solidity in %
@@ -208,7 +208,7 @@ def compute_compression_ratio(metrics_agg_merged):
 def compute_torsion(metrics_agg_merged, verbose):
     """
     Compute torsion as the average of absolute differences in orientation between the given slice and 3 slices
-    above and below. For details see Equation 3 and Supplementary Material in https://pubmed.ncbi.nlm.nih.gov/35371944/.
+    above and below. For details see Equation 3 and Supplementary Material in https://doi.org/10.21037/qims-21-782.
     NOTE: As the torsion is computed from 3 slices above and below, it cannot be computed for the 3 first and last
     3 slices --> `torsion = None` is used for the 3 first and 3 last slices.
     :param metrics_agg_merged: dictionary with aggregated metrics

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -262,8 +262,8 @@ def process_compression(metrics_agg_merged, disc_slices, num_of_slices):
     for disc, disc_slice in disc_slices.items():
         # Add one slice above and below to process multiple slices around the disc to compensate for potential
         # disc label shift in the superior-inferior (S-I) axis
-        slices = [disc_slice] if num_of_slices == 0 else \
-            [disc_slice + num_of_slices, disc_slice, disc_slice - num_of_slices]
+        slices = [disc_slice] if num_of_slices == 0 \
+            else range(disc_slice - num_of_slices, disc_slice + num_of_slices + 1)
         for slc in slices:
             if disc in SUPPORTED_DISCS.keys():
                 # Note: [slice,] is used to convert int to tuple

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -233,7 +233,7 @@ def process_compression(metrics_agg_merged, disc_slices):
     for disc, slices in disc_slices.items():
         # Add one slice above and below to process multiple slices around the disc to compensate for potential
         # disc label shift in the superior-inferior (S-I) axis
-        slices = [slices - 1, slices, slices + 1]
+        slices = [slices + 1, slices, slices - 1]
         for slice in slices:
             if disc in SUPPORTED_DISCS:
                 # Note: [slice,] is used to convert int to tuple

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 #
 # Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
-# IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7
-# (value: 7). In other words, the script does *not* process all axial slices of the spinal cord segmentation.
+# The script process axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
+# In other words, the script does *not* process all axial slices of the spinal cord segmentation.
 #
 # The script requires spinal cord segmentation (used to compute the shape metrics) and disc labels.
 #
@@ -43,7 +43,7 @@ def get_parser():
     parser = SCTArgumentParser(
         description=textwrap.dedent("""
             Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
-            IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
+            The script process axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
             
             Reference:
                 - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279. 
@@ -56,17 +56,19 @@ def get_parser():
         '-s',
         metavar=Metavar.file,
         required=True,
-        help="Segmentation of the spinal cord. Example: t2s_seg.nii.gz."
+        help="Segmentation of the spinal cord, which will be used to compute the shape metrics. "
+             "Example: t2s_seg.nii.gz."
     )
     mandatoryArguments.add_argument(
         '-discfile',
         metavar=Metavar.file,
         required=True,
         help=textwrap.dedent("""
-            File with disc labels. Example: t2s_discs.nii.gz.
-            The convention for disc labels is the following: value=3 -> disc C2/C3, value=4 -> disc C3/C4, etc.
-            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
+            File with disc labels, which will be used to identify the axial slices for processing.
+            Labels can be located either at the posterior edge of the intervertebral discs, or at the orthogonal projection of each disc onto the spinal cord.
+            Such label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
             obtained automatically using the sct_label_vertebrae function (the file with the \'labeled_discs.nii.gz\' suffix).
+            Example: t2s_discs.nii.gz.
         """),  # noqa: E501 (line too long)
     )
 

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -56,6 +56,7 @@ def get_parser():
             (the sum of sensitivity and specificity). More info in the reference below.
 
             Reference:
+            
                 - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
                   https://doi.org/10.21037/qims-21-782
         """),  # noqa: E501 (line too long)

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -319,11 +319,11 @@ def main(argv: Sequence[str]):
     fname_disc = get_absolute_path(arguments.discfile)
     angle_correction = bool(arguments.angle_corr)
 
-    # Compute shape metrics per slice
-    metrics_agg_merged = compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose)
-
     # Get discs corresponding to the compression
     disc_slices = get_disc_slices(fname_disc)
+
+    # Compute shape metrics per slice
+    metrics_agg_merged = compute_shape_metrics(fname_seg, fname_disc, angle_correction, verbose)
 
     # Process axial slices for each disc to compute compression probability
     compression_df = process_compression(metrics_agg_merged, disc_slices, arguments.num_of_slices)

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -42,9 +42,18 @@ CUT_OFF_MODERATE = 0.345
 
 def get_parser():
     parser = SCTArgumentParser(
-        description=textwrap.dedent("""
+        description=textwrap.dedent(f"""
             Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
             The script process axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
+
+            Compression categories are determined based on the following cut-offs:
+
+                - 'yes'     : p > {CUT_OFF_HIGH}
+                - 'possible': {CUT_OFF_MODERATE} <= p <= {CUT_OFF_HIGH}
+                - 'no'      : p < {CUT_OFF_MODERATE}
+
+            These cut-off values and compression categories were determined by ROC analysis and the Youden’s index
+            (the sum of sensitivity and specificity). More info in the reference below.
 
             Reference:
                 - Horáková M, Horák T, Valošek J, Rohan T, Koriťáková E, Dostál M, Kočica J, Skutil T, Keřkovský M, Kadaňka Z Jr, Bednařík P, Svátková A, Hluštík P, Bednařík J. Semi-automated detection of cervical spinal cord compression with the Spinal Cord Toolbox. Quant Imaging Med Surg 2022; 12:2261–2279.
@@ -263,7 +272,7 @@ def process_compression(metrics_agg_merged, disc_slices, num_of_slices):
                 # Compute compression probability
                 probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
                 compression_category = 'yes' if probability > CUT_OFF_HIGH else \
-                    'possible' if probability > CUT_OFF_MODERATE else 'no'
+                    'possible' if probability >= CUT_OFF_MODERATE else 'no'
                 compression_df = pd.concat([compression_df,
                                             pd.DataFrame([{'Disc': SUPPORTED_DISCS[disc], 'Axial slice #': slc,
                                                            'Compression probability': probability,

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -299,10 +299,10 @@ def main(argv: Sequence[str]):
     # Loop across discs and print results to terminal
     for disc in compression_df['Disc'].unique():
         # If any axial slice around the disc is compressed, the disc is considered compressed
-        if 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
-            printv(f"Disc {int(disc)} is possibly compressed.", verbose)
-        elif 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
+        if 'yes' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
             printv(f"Disc {int(disc)} is compressed.", verbose)
+        elif 'possible' in compression_df.loc[compression_df['Disc'] == disc, 'Compression probability category'].values:
+            printv(f"Disc {int(disc)} is possibly compressed.", verbose)
 
     if verbose == 2:
         for index, row in compression_df.iterrows():

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -294,6 +294,13 @@ def get_disc_slices(fname_disc):
     """
     im_disc = Image(fname_disc).change_orientation('RPI')
     discs = [int(disc) for disc in np.trim_zeros(np.unique(im_disc.data))]  # get unique disc labels (e.g., 3, 4, 5 etc)
+
+    if not discs:
+        raise ValueError("Disc file is empty.")
+    # Check if discs contains any supported discs, if not, raise an error
+    if not any(disc in SUPPORTED_DISCS.keys() for disc in discs):
+        raise ValueError(f"No supported disc labels found in the disc file. Supported discs: {SUPPORTED_DISCS.keys()}")
+
     # Find axial slices corresponding to the discs
     # Note: [0] is used because get_slices_from_vertebral_levels returns list
     disc_slices = {disc: get_slices_from_vertebral_levels(im_disc, disc)[0] for disc in discs}

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -68,7 +68,7 @@ def get_parser():
         metavar=Metavar.file,
         required=True,
         help="Segmentation of the spinal cord, which will be used to compute the shape metrics. "
-             "Example: t2s_seg.nii.gz."
+             "Example: `t2s_seg.nii.gz`."
     )
     mandatoryArguments.add_argument(
         '-discfile',
@@ -77,9 +77,9 @@ def get_parser():
         help=textwrap.dedent("""
             File with disc labels. Each label must be a single voxel. Only label values 4, 5, 6, and 7 (C3/C4 to C6/C7) are supported for now; all other labels will be ignored.
             Labels can be located either at the posterior edge of the intervertebral discs, or at the orthogonal projection of each disc onto the spinal cord.
-            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or
-            obtained automatically using the sct_label_vertebrae function (the file with the \'labeled_discs.nii.gz\' suffix).
-            Example: t2s_discs.nii.gz.
+            Such a label file can be manually created using: `sct_label_utils -i IMAGE_REF -create-viewer 4:7` or
+            obtained automatically using the `sct_label_vertebrae` function (the file with the `labeled_discs.nii.gz` suffix).
+            Example: `t2s_discs.nii.gz`.
         """),  # noqa: E501 (line too long)
     )
 
@@ -101,7 +101,7 @@ def get_parser():
         choices=[0, 1],
         default=1,
         help=textwrap.dedent("""
-            Angle correction for computing morphometric measures. When angle correction is used, the cord within the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set  -angle-corr to 0.
+            Angle correction for computing morphometric measures. When angle correction is used, the cord within the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set `-angle-corr` to 0.
         """)  # noqa: E501 (line too long)
     )
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -215,8 +215,9 @@ def compute_compression_ratio(metrics_agg_merged):
 
 def compute_torsion(metrics_agg_merged, verbose):
     """
-    Compute torsion as the average of absolute differences in orientation between the given slice and 3 slices
-    above and below. For details see Equation 3 and Supplementary Material in https://doi.org/10.21037/qims-21-782.
+    Compute torsion as the average of absolute differences in orientation taking into account 3 slices above and
+    3 slices below. For details, see Equation 3 in https://doi.org/10.21037/qims-21-782.
+    For a comparison between torsion computed using 1, 2, and 3 slices, see https://cdn.amegroups.cn/static/public/QIMS-21-782-supplementary.pdf
     NOTE: As the torsion is computed from 3 slices above and below, it cannot be computed for the 3 first and last
     3 slices --> `torsion = None` is used for the 3 first and 3 last slices.
     :param metrics_agg_merged: dictionary with aggregated metrics

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -14,6 +14,7 @@
 import sys
 import math
 from typing import Sequence
+import textwrap
 
 import numpy as np
 import pandas as pd
@@ -40,11 +41,11 @@ CUT_OFF_MODERATE = 0.345
 
 def get_parser():
     parser = SCTArgumentParser(
-        description=("""\
-Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
-IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
-More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
-        """)
+        description=textwrap.dedent("""
+            Predict compression probability in a spinal cord MRI image using spinal cord shape metrics.
+            IMPORTANT NOTE: The script process *only* axial slices at the level of intervertebral discs C3/C4 (value: 4) to C6/C7 (value: 7).
+            More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
+        """),  # noqa: E501 (line too long)
     )
 
     mandatoryArguments = parser.add_argument_group("MANDATORY ARGUMENTS")
@@ -52,17 +53,18 @@ More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
         '-s',
         metavar=Metavar.file,
         required=True,
-        help="Segmentation of the spinal cord. Example: t2s_seg.nii.gz"
+        help="Segmentation of the spinal cord. Example: t2s_seg.nii.gz."
     )
     mandatoryArguments.add_argument(
         '-discfile',
         metavar=Metavar.file,
         required=True,
-        help="File with disc labels. Example: t2s_discs.nii.gz "
-             "The convention for disc labels is the following: value=3 -> disc C2/C3, value=4 -> disc C3/C4, etc."
-             "Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 "
-             "or obtained automatically using the sct_label_vertebrae function "
-             "(the file with the \'labeled_discs.nii.gz\' suffix)."
+        help=textwrap.dedent("""
+            File with disc labels. Example: t2s_discs.nii.gz.
+            The convention for disc labels is the following: value=3 -> disc C2/C3, value=4 -> disc C3/C4, etc.
+            Such a label file can be manually created using: sct_label_utils -i IMAGE_REF -create-viewer 4:7 or 
+            obtained automatically using the sct_label_vertebrae function (the file with the \'labeled_discs.nii.gz\' suffix).
+        """),  # noqa: E501 (line too long)
     )
 
     optional = parser.add_argument_group('OPTIONAL ARGUMENTS')
@@ -72,11 +74,11 @@ More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/
         type=int,
         choices=[0, 1],
         default=1,
-        help="Angle correction for computing morphometric measures used within "
-             "\'spinalcordtoolbox.process_seg.compute_shape\'. When angle correction is used, the cord within "
-             "the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the "
-             "centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set "
-             "-angle-corr to 0."
+        help=textwrap.dedent("""
+            Angle correction for computing morphometric measures. When angle correction is used, the cord within the 
+            slice is stretched/expanded by a factor corresponding to the cosine of the angle between the centerline 
+            and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set  -angle-corr to 0.
+        """)
     )
     optional.add_argument(
         "-h",

--- a/spinalcordtoolbox/scripts/sct_detect_compression.py
+++ b/spinalcordtoolbox/scripts/sct_detect_compression.py
@@ -230,29 +230,28 @@ def process_compression(metrics_agg_merged, disc_slices):
     """
     compression_df = pd.DataFrame()
     # Loop across discs
-    for disc, slice in disc_slices.items():
-    # for disc, slices in disc_slices.items():
-    #     # Add one slice above and below to process multiple slices around the disc to compensate for potential
-    #     # disc label shift in the superior-inferior direction
-    #     slices = [slices - 1, slices, slices + 1]
-    #     for slice in slices:
-        if disc in SUPPORTED_DISCS:
-            # Note: [slice,] is used to convert int to tuple
-            cr = metrics_agg_merged[slice,]['MEAN(compression_ratio)'] * 100    # to convert to %
-            csa = metrics_agg_merged[slice,]['MEAN(area)']
-            solidity = metrics_agg_merged[slice,]['MEAN(solidity)'] * 100     # to convert to %
-            torsion = metrics_agg_merged[slice,]['Torsion']
-            # Compute compression probability
-            probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
-            compression_category = 'high' if probability > CUT_OFF_HIGH else \
-                'moderate' if probability > CUT_OFF_MODERATE else 'low'
-            compression_df = pd.concat([compression_df,
-                                        pd.DataFrame([{'Disc': disc, 'Axial slice #': slice,
-                                                       'Compression probability': probability,
-                                                       'Compression probability category': compression_category,
-                                                       'Compression ratio (%)': cr, 'CSA (mm2)': csa,
-                                                       'Solidity (%)': solidity, 'Torsion (degrees)': torsion}])],
-                                       ignore_index=True)
+    for disc, slices in disc_slices.items():
+        # Add one slice above and below to process multiple slices around the disc to compensate for potential
+        # disc label shift in the superior-inferior (S-I) axis
+        slices = [slices - 1, slices, slices + 1]
+        for slice in slices:
+            if disc in SUPPORTED_DISCS:
+                # Note: [slice,] is used to convert int to tuple
+                cr = metrics_agg_merged[slice,]['MEAN(compression_ratio)'] * 100    # to convert to %
+                csa = metrics_agg_merged[slice,]['MEAN(area)']
+                solidity = metrics_agg_merged[slice,]['MEAN(solidity)'] * 100     # to convert to %
+                torsion = metrics_agg_merged[slice,]['Torsion']
+                # Compute compression probability
+                probability = predict_compression_probability(cr, csa, solidity, torsion, disc)
+                compression_category = 'yes' if probability > CUT_OFF_HIGH else \
+                    'possible' if probability > CUT_OFF_MODERATE else 'no'
+                compression_df = pd.concat([compression_df,
+                                            pd.DataFrame([{'Disc': disc, 'Axial slice #': slice,
+                                                           'Compression probability': probability,
+                                                           'Compression probability category': compression_category,
+                                                           'Compression ratio (%)': cr, 'CSA (mm2)': csa,
+                                                           'Solidity (%)': solidity, 'Torsion (degrees)': torsion}])],
+                                           ignore_index=True)
 
     return compression_df
 

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -18,12 +18,14 @@ def test_sct_detect_compression_check_missing_input_segmentation(tmp_path):
         sct_detect_compression.main(argv=['-discfile', path_labels])
         assert e.value.code == 2
 
+
 def test_sct_detect_compression_check_missing_input_discfile(tmp_path):
     """ Run sct_detect_compression when missing -discfile"""
     path_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
     with pytest.raises(SystemExit) as e:
         sct_detect_compression.main(argv=['-s', path_seg])
         assert e.value.code == 2
+
 
 def test_sct_detect_compression_check_empty_input_segmentation(tmp_path):
     """ Run sct_detect_compression when -s is empty"""
@@ -37,6 +39,7 @@ def test_sct_detect_compression_check_empty_input_segmentation(tmp_path):
                                           '-discfile', path_labels])
         assert e.value == "Spinal cord segmentation file is empty."
 
+
 def test_sct_detect_compression_check_empty_input_discfile(tmp_path):
     """ Run sct_detect_compression when -discfile is empty"""
     nii = nibabel.nifti1.Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
@@ -48,6 +51,7 @@ def test_sct_detect_compression_check_empty_input_discfile(tmp_path):
         sct_detect_compression.main(argv=['-s', path_seg,
                                           '-discfile', path_labels])
         assert e.value == "Disc file is empty."
+
 
 def test_sct_detect_compression(tmp_path):
     """ Run sct_detect_compression and check output CSV file"""

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -1,11 +1,11 @@
 # pytest unit tests for sct_detect_compression
 
 import os
-import csv
 import pytest
 import tempfile
 import nibabel
 import numpy as np
+import pandas as pd
 
 from spinalcordtoolbox.utils.sys import sct_test_path
 from spinalcordtoolbox.scripts import sct_detect_compression
@@ -66,13 +66,13 @@ def test_sct_detect_compression(tmp_path):
     # Test presence of output CSV file
     assert os.path.isfile(filename)
 
-    with open(filename, "r") as csvfile:
-        reader = csv.DictReader(csvfile, delimiter=',')
-        row = next(reader)
-        assert float(row['Axial slice #']) == 9
-        assert float(row['Compression probability']) == pytest.approx(0.009026609893705780)
-        assert row['Compression probability category'] == 'no'
-        assert float(row['Compression ratio (%)']) == pytest.approx(63.00680776424760)
-        assert float(row['CSA (mm2)']) == pytest.approx(78.5321685211387)
-        assert float(row['Solidity (%)']) == pytest.approx(96.82139253279520)
-        assert float(row['Torsion (degrees)']) == pytest.approx(1.1599432885836200)
+    df = pd.read_csv(filename)
+    assert len(df) == 1  # '-num-of-slices 0' (default) --> 1 slice in total --> 1 row in the CSV file
+    row = df.iloc[0]
+    assert float(row['Slice (I->S)']) == 9
+    assert float(row['Compression probability']) == pytest.approx(0.009026609893705780)
+    assert row['Compression probability category'] == 'no'
+    assert float(row['Compression ratio (%)']) == pytest.approx(63.00680776424760)
+    assert float(row['CSA (mm2)']) == pytest.approx(78.5321685211387)
+    assert float(row['Solidity (%)']) == pytest.approx(96.82139253279520)
+    assert float(row['Torsion (degrees)']) == pytest.approx(1.1599432885836200)

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -97,3 +97,20 @@ def test_sct_detect_compression_num_of_slices(tmp_path):
     assert float(df[df['Axial slice #'] == 8]['Compression probability'].values) == pytest.approx(0.011063310989869700)
     assert float(df[df['Axial slice #'] == 9]['Compression probability'].values) == pytest.approx(0.009026609893705780)
     assert float(df[df['Axial slice #'] == 10]['Compression probability'].values) == pytest.approx(0.00944641208649796)
+
+    sct_detect_compression.main(argv=['-s', path_seg,
+                                      '-discfile', path_labels,
+                                      '-num-of-slices', '2',  # 2 slices above and below the disc --> 5 slices in total
+                                      '-o', filename])
+
+    # Test presence of output CSV file
+    assert os.path.isfile(filename)
+
+    df = pd.read_csv(filename)
+    assert len(df) == 5     # '-num-of-slices 2' --> 5 slices in total --> 5 rows in the CSV file
+    assert float(df[df['Axial slice #'] == 7]['Compression probability'].values) == pytest.approx(0.04174064023173820)
+    assert float(df[df['Axial slice #'] == 8]['Compression probability'].values) == pytest.approx(0.011063310989869700)
+    assert float(df[df['Axial slice #'] == 9]['Compression probability'].values) == pytest.approx(0.009026609893705780)
+    assert float(df[df['Axial slice #'] == 10]['Compression probability'].values) == pytest.approx(0.00944641208649796)
+    assert float(df[df['Axial slice #'] == 11]['Compression probability'].values) == pytest.approx(0.03042584296488690)
+

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -69,7 +69,7 @@ def test_sct_detect_compression(tmp_path):
     df = pd.read_csv(filename)
     assert len(df) == 1  # '-num-of-slices 0' (default) --> 1 slice in total --> 1 row in the CSV file
     row = df.iloc[0]
-    assert float(row['Slice (I->S)']) == 9
+    assert float(row['Axial slice #']) == 9
     assert float(row['Compression probability']) == pytest.approx(0.009026609893705780)
     assert row['Compression probability category'] == 'no'
     assert float(row['Compression ratio (%)']) == pytest.approx(63.00680776424760)
@@ -94,6 +94,6 @@ def test_sct_detect_compression_num_of_slices(tmp_path):
 
     df = pd.read_csv(filename)
     assert len(df) == 3     # '-num-of-slices 1' --> 3 slices in total --> 3 rows in the CSV file
-    assert float(df[df['Slice (I->S)'] == 8]['Compression probability'].values) == pytest.approx(0.011063310989869700)
-    assert float(df[df['Slice (I->S)'] == 9]['Compression probability'].values) == pytest.approx(0.009026609893705780)
-    assert float(df[df['Slice (I->S)'] == 10]['Compression probability'].values) == pytest.approx(0.00944641208649796)
+    assert float(df[df['Axial slice #'] == 8]['Compression probability'].values) == pytest.approx(0.011063310989869700)
+    assert float(df[df['Axial slice #'] == 9]['Compression probability'].values) == pytest.approx(0.009026609893705780)
+    assert float(df[df['Axial slice #'] == 10]['Compression probability'].values) == pytest.approx(0.00944641208649796)

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -113,4 +113,3 @@ def test_sct_detect_compression_num_of_slices(tmp_path):
     assert float(df[df['Axial slice #'] == 9]['Compression probability'].values) == pytest.approx(0.009026609893705780)
     assert float(df[df['Axial slice #'] == 10]['Compression probability'].values) == pytest.approx(0.00944641208649796)
     assert float(df[df['Axial slice #'] == 11]['Compression probability'].values) == pytest.approx(0.03042584296488690)
-

--- a/testing/cli/test_cli_sct_detect_compression.py
+++ b/testing/cli/test_cli_sct_detect_compression.py
@@ -1,0 +1,74 @@
+# pytest unit tests for sct_detect_compression
+
+import os
+import csv
+import pytest
+import tempfile
+import nibabel
+import numpy as np
+
+from spinalcordtoolbox.utils.sys import sct_test_path
+from spinalcordtoolbox.scripts import sct_detect_compression
+
+
+def test_sct_detect_compression_check_missing_input_segmentation(tmp_path):
+    """ Run sct_detect_compression when missing -s"""
+    path_labels = sct_test_path('t2', 'labels.nii.gz')
+    with pytest.raises(SystemExit) as e:
+        sct_detect_compression.main(argv=['-discfile', path_labels])
+        assert e.value.code == 2
+
+def test_sct_detect_compression_check_missing_input_discfile(tmp_path):
+    """ Run sct_detect_compression when missing -discfile"""
+    path_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
+    with pytest.raises(SystemExit) as e:
+        sct_detect_compression.main(argv=['-s', path_seg])
+        assert e.value.code == 2
+
+def test_sct_detect_compression_check_empty_input_segmentation(tmp_path):
+    """ Run sct_detect_compression when -s is empty"""
+    nii = nibabel.nifti1.Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+    path_seg = tempfile.NamedTemporaryFile(prefix='seg_empty', suffix='.nii.gz', delete=False).name
+    nibabel.save(nii, path_seg)
+
+    path_labels = sct_test_path('t2', 'labels.nii.gz')
+    with pytest.raises(ValueError) as e:
+        sct_detect_compression.main(argv=['-s', path_seg,
+                                          '-discfile', path_labels])
+        assert e.value == "Spinal cord segmentation file is empty."
+
+def test_sct_detect_compression_check_empty_input_discfile(tmp_path):
+    """ Run sct_detect_compression when -discfile is empty"""
+    nii = nibabel.nifti1.Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+    path_labels = tempfile.NamedTemporaryFile(prefix='seg_empty', suffix='.nii.gz', delete=False).name
+    nibabel.save(nii, path_labels)
+
+    path_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
+    with pytest.raises(ValueError) as e:
+        sct_detect_compression.main(argv=['-s', path_seg,
+                                          '-discfile', path_labels])
+        assert e.value == "Disc file is empty."
+
+def test_sct_detect_compression(tmp_path):
+    """ Run sct_detect_compression and check output CSV file"""
+    path_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
+    path_labels = sct_test_path('t2', 'labels.nii.gz')  # contains only labels 3 and 5 --> okay for testing
+
+    filename = str(tmp_path / 'compression_results.csv')
+    sct_detect_compression.main(argv=['-s', path_seg,
+                                      '-discfile', path_labels,
+                                      '-o', filename])
+
+    # Test presence of output CSV file
+    assert os.path.isfile(filename)
+
+    with open(filename, "r") as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=',')
+        row = next(reader)
+        assert float(row['Axial slice #']) == 9
+        assert float(row['Compression probability']) == pytest.approx(0.009026609893705780)
+        assert row['Compression probability category'] == 'no'
+        assert float(row['Compression ratio (%)']) == pytest.approx(63.00680776424760)
+        assert float(row['CSA (mm2)']) == pytest.approx(78.5321685211387)
+        assert float(row['Solidity (%)']) == pytest.approx(96.82139253279520)
+        assert float(row['Torsion (degrees)']) == pytest.approx(1.1599432885836200)


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR adds a script to predict compression probability in a spinal cord MRI image using spinal cord shape metrics. The script requires spinal cord segmentation (used to compute the shape metrics) and disc labels.

Briefly, the script computes shape metrics for 3 axial slices at intervertebral disc levels C3/C4 to C6/7 (3 slices are used to compensate for potential disc label shift in the superior-inferior (S-I) axis; details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4760#discussion_r1903118334 and https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4760/commits/90cbfa6654154987b0f542a6b544505fcaf8f076). Then, it predicts compression probability for each of these axial slices using a logistic regression model. The compression probability is printed to CLI and saved to a CSV file; see the next section for examples. More details in: https://pubmed.ncbi.nlm.nih.gov/35371944/. Particularly, equation 4.

## How to test this PR

```bash
# Download the script
cd $SCT_DIR
git fetch
git checkout jv/add_sct_detect_compression

# Activate SCT python
cd $SCT_DIR
source ./python/etc/profile.d/conda.sh
conda activate venv_sct

# Run the script
python $SCT_DIR/spinalcordtoolbox/scripts/sct_detect_compression.py -s T2w_seg.nii.gz -discfile T2w_discs.nii.gz
```

## Testing on a few spine-generic subjects with mild compression

<details><summary>sub-tokyoIngenia02</summary>

<img width="700" alt="image" src="https://github.com/user-attachments/assets/b0574f30-2e91-4aa1-a23e-fc1e0e81b973" />

```bash
cd ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-tokyoIngenia02/anat
python $SCT_DIR/spinalcordtoolbox/scripts/sct_detect_compression.py -s sub-tokyoIngenia02_space-other_T2w_label-SC_seg.nii.gz -discfile sub-tokyoIngenia02_T2w_label-discs_dlabel.nii.gz
...
Results saved to: ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-tokyoIngenia02/anat/sub-tokyoIngenia02_space-other_T2w_label-SC_seg_compression_results.csv
Disc C3/C4, compression probability: no
Disc C4/C5, compression probability: yes
Disc C5/C6, compression probability: yes
Disc C6/C7, compression probability: yes
```

Output CSV:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/8b650cd4-99d5-4838-aaa5-d59389f74419" />

</details>

<details><summary>sub-ucl05</summary>

<img width="700" alt="image" src="https://github.com/user-attachments/assets/2590e471-e6af-449e-9f86-60fef8e3e766" />

```bash
cd ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-ucl05/anat
python $SCT_DIR/spinalcordtoolbox/scripts/sct_detect_compression.py -s sub-ucl05_space-other_T2w_label-SC_seg.nii.gz -discfile sub-ucl05_T2w_label-discs_dlabel.nii.gz
...
Results saved to: ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-ucl05/anat/sub-ucl05_space-other_T2w_label-SC_seg_compression_results.csv
Disc C3/C4, compression probability: no
Disc C4/C5, compression probability: no
Disc C5/C6, compression probability: yes
Disc C6/C7, compression probability: possible
```

Output CSV:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/80de1aac-1248-43b3-8633-8b3e3d69531e" />


</details>

<details><summary>sub-vuiisAchieva01</summary>

<img width="700" alt="image" src="https://github.com/user-attachments/assets/0e19b7f8-a958-4f4f-a7f3-e6ebef4b062d" />

```bash
cd  ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-vuiisAchieva01/anat
python $SCT_DIR/spinalcordtoolbox/scripts/sct_detect_compression.py -s sub-vuiisAchieva01_space-other_T2w_label-SC_seg.nii.gz -discfile sub-vuiisAchieva01_T2w_label-discs_dlabel.nii.gz
...
Results saved to: ~/data/data.neuro.polymtl.ca/data-multi-subject/derivatives/labels/sub-vuiisAchieva01/anat/sub-vuiisAchieva01_space-other_T2w_label-SC_seg_compression_results.csv
Disc C3/C4, compression probability: yes
Disc C4/C5, compression probability: no
Disc C5/C6, compression probability: no
Disc C6/C7, compression probability: no
```

Output CSV:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f8f02e12-edf8-4a11-9dfd-f1e5fe4abd62" />

</details>

> [!NOTE]  
> Note that the predictive model was trained using axial T2star images from a private dataset. The example spine-generic images shown above are T2w 0.8mm iso. I used these images because they are [open-access](https://github.com/spine-generic/data-multi-subject/tree/master) to verify that the script works properly.
(I did not choose spine-generic T2star images as they cover only C2-C5, while the model detects compression also at discs C5/6 and C6/7).

## Linked issues

Follow-up of: https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/32153ad9e8136141dcff22d1ddc25291fa065b9a