### PR TITLE
Update `sct_deepseg` documentation and arg help

### DIFF
--- a/documentation/source/user_section/command-line.rst
+++ b/documentation/source/user_section/command-line.rst
@@ -13,7 +13,7 @@ Segmentation
 ============
 
 - :ref:`sct_create_mask` - Create mask along z direction.
-- :ref:`sct_deepseg` - Segment an anatomical structure or pathologies according using a deep learning model created with `ivadomed <https://ivadomed.org/>`_.
+- :ref:`sct_deepseg` - Segment anatomical structures or pathologies using deep learning models created with different frameworks (`ivadomed <https://ivadomed.org/>`_,  `nnUNet  <https://github.com/MIC-DKFZ/nnUNet>`_, `monai <https://monai.io>`_).
 - :ref:`sct_deepseg_gm` - Segment spinal cord gray matter using deep learning.
 - :ref:`sct_deepseg_lesion` - Segment multiple sclerosis lesions.
 - :ref:`sct_deepseg_sc` - Segment spinal cord using deep learning.

--- a/documentation/source/user_section/command-line.rst
+++ b/documentation/source/user_section/command-line.rst
@@ -13,7 +13,7 @@ Segmentation
 ============
 
 - :ref:`sct_create_mask` - Create mask along z direction.
-- :ref:`sct_deepseg` - Segment anatomical structures or pathologies using deep learning models created with different frameworks (`ivadomed <https://ivadomed.org/>`_,  `nnUNet  <https://github.com/MIC-DKFZ/nnUNet>`_, `monai <https://monai.io>`_).
+- :ref:`sct_deepseg` - Segment anatomical structures or pathologies using deep learning models created with different frameworks (`ivadomed <https://ivadomed.org>`__,  `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, `monai <https://monai.io>`__).
 - :ref:`sct_deepseg_gm` - Segment spinal cord gray matter using deep learning.
 - :ref:`sct_deepseg_lesion` - Segment multiple sclerosis lesions.
 - :ref:`sct_deepseg_sc` - Segment spinal cord using deep learning.

--- a/documentation/source/user_section/tutorials/segmentation/sct_deepseg.rst
+++ b/documentation/source/user_section/tutorials/segmentation/sct_deepseg.rst
@@ -1,7 +1,7 @@
 Specialized segmentation models: ``sct_deepseg``
 ################################################
 
-The :ref:`sct_deepseg` script is separate from :ref:`sct_deepseg_sc`, and provides access to specialized models created by the ivadomed project (https://ivadomed.org). These specialized models focus on tasks outside of basic spinal cord segmentation. In recent versions, new models for the segmentation of spinal tumors, human multi-class SC & GM at 7T, MS lesion segmentation on MP2RAGE, mouse SC, etc. have been added.
+The :ref:`sct_deepseg` script is separate from :ref:`sct_deepseg_sc`, and provides access to specialized models created by created with different frameworks (`ivadomed`: https://ivadomed.org/, `nnUNet`: https://github.com/MIC-DKFZ/nnUNet, `monai`: https://monai.io>). These specialized models focus on tasks outside of basic spinal cord segmentation. In recent versions, new models for the segmentation of spinal tumors, human multi-class SC & GM at 7T, MS lesion segmentation on MP2RAGE, mouse SC, etc. have been added.
 
 You can list the available tasks by running :ref:`sct_deepseg` ``-h``, or you view detailed descriptions of each task by running :ref:`sct_deepseg` ``-list-tasks``.
 

--- a/documentation/source/user_section/tutorials/segmentation/sct_deepseg.rst
+++ b/documentation/source/user_section/tutorials/segmentation/sct_deepseg.rst
@@ -1,7 +1,7 @@
 Specialized segmentation models: ``sct_deepseg``
 ################################################
 
-The :ref:`sct_deepseg` script is separate from :ref:`sct_deepseg_sc`, and provides access to specialized models created by created with different frameworks (`ivadomed`: https://ivadomed.org/, `nnUNet`: https://github.com/MIC-DKFZ/nnUNet, `monai`: https://monai.io>). These specialized models focus on tasks outside of basic spinal cord segmentation. In recent versions, new models for the segmentation of spinal tumors, human multi-class SC & GM at 7T, MS lesion segmentation on MP2RAGE, mouse SC, etc. have been added.
+The :ref:`sct_deepseg` script is separate from :ref:`sct_deepseg_sc`, and provides access to specialized models created by created with different frameworks (`ivadomed <https://ivadomed.org/>`__, `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, and `monai <https://monai.io>`__). These specialized models focus on tasks outside of basic spinal cord segmentation. In recent versions, new models for the segmentation of spinal tumors, human multi-class SC & GM at 7T, MS lesion segmentation on MP2RAGE, mouse SC, etc. have been added.
 
 You can list the available tasks by running :ref:`sct_deepseg` ``-h``, or you view detailed descriptions of each task by running :ref:`sct_deepseg` ``-list-tasks``.
 

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -71,8 +71,8 @@ def get_parser():
         nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: `sct_deepseg -list-tasks`. To use a custom task, indicate the path to the "
-             " packaged model. Models created with different frameworks (`ivadomed`: https://ivadomed.org/,  "
-             "`nnUNet`: https://github.com/MIC-DKFZ/nnUNet, `monai`: https://monai.io>) are supported."
+             " packaged model. Models created with different frameworks ([ivadomed](https://ivadomed.org/), "
+             "[nnUNet](https://github.com/MIC-DKFZ/nnUNet), and [monai](https://monai.io)) are supported."
              " More than one path can be indicated (separated with space) for cascaded application of the models.",
         metavar=Metavar.str)
     seg.add_argument(

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -71,7 +71,8 @@ def get_parser():
         nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: `sct_deepseg -list-tasks`. To use a custom task, indicate the path to the "
-             " ivadomed packaged model (see https://ivadomed.org/en/latest/pretrained_models.html#packaged-model-format for more details). "
+             " packaged model. Models created with different frameworks (`ivadomed`: https://ivadomed.org/,  "
+             "`nnUNet`: https://github.com/MIC-DKFZ/nnUNet, `monai`: https://monai.io>) are supported."
              " More than one path can be indicated (separated with space) for cascaded application of the models.",
         metavar=Metavar.str)
     seg.add_argument(


### PR DESCRIPTION
## Description

This minor PR updates `sct_deepseg` documentation and arg help to make clear that it also supports other than ivadomed models.

## Linked issues

Resolves: #4762 
