### PR TITLE
Temporarily set `torch<2.6` due to upstream `weights_only=True` change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,11 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze
+# In January 2025, PyTorch changed the default of `torch.load()` to `weights_only=True`, breaking the loading of some of our models.
+# We can set `weights_only=False` to retain the old behavior, however there are additional calls to `torch.load()` within our 
+# dependencies as well, meaning that we need to wait until they update themselves (or become compatible with `weights_only=True`).
+# Until then, we can pin torch to a version prior to this breaking change.
+torch<2.6
 ivadomed
 matplotlib
 # `matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive.


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

PyTorch 2.6 changed the default of `torch.load()` to `weights_only=True`, breaking the loading of some of our models. We can set `weights_only=False` to retain the old behavior, however there are additional calls to `torch.load()` within our dependencies as well, meaning that we need to wait until they update themselves (or become compatible with `weights_only=True`).

Until then, we can pin torch to a version prior to this breaking change.

There is a bigger conversation to be had about the attack vector of someone taking over one of the URLs to one of our models, causing users to download malicious model weights. But, I'm not sure what we would need to do to make our models become compatible with this `weights=True` option. We should watch how the upstream `nnunetv2` package handles it, since I imagine they will probably get some good discussion from downstream users.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4775.
