### PR TITLE
Ensure that `torch<2.6` requirement gets copied over to `requirements-freeze.txt`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,6 +11,12 @@ on:
     # > Scheduled workflows run on the latest commit on the default or base branch
     # i.e. this can only run on master
     - cron: '0 11 * * *'
+  pull_request:
+    # temporarily enable for testing, note that this refers to the base branch (i.e. master)
+    # so specifying 'jn/4775-ensure-torch-gets-frozen' wouldn't work here.
+    # See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+    branches:
+      - '*'
 
 env:
   MAIN_BRANCH: "master"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,6 @@ jobs:
         pip freeze | grep -v "-e git+" | grep -v "torch" | grep -v "certifi @ file" > requirements-freeze.txt
         conda deactivate
         grep "# append_to_freeze" requirements.txt >> requirements-freeze.txt
-        grep "torch" requirements.txt >> requirements-freeze.txt
 
     - name: Upload requirements-freeze.txt
       uses: actions/upload-artifact@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,12 +11,6 @@ on:
     # > Scheduled workflows run on the latest commit on the default or base branch
     # i.e. this can only run on master
     - cron: '0 11 * * *'
-  pull_request:
-    # temporarily enable for testing, note that this refers to the base branch (i.e. master)
-    # so specifying 'jn/4775-ensure-torch-gets-frozen' wouldn't work here.
-    # See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
-    branches:
-      - '*'
 
 env:
   MAIN_BRANCH: "master"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         source python/etc/profile.d/conda.sh
         conda activate venv_sct
-        pip freeze | grep -v "-e git+" | grep -v "torch" | grep -v "certifi @ file" > requirements-freeze.txt
+        pip freeze | grep -v "-e git+" | grep -v "certifi @ file" > requirements-freeze.txt
         conda deactivate
         grep "# append_to_freeze" requirements.txt >> requirements-freeze.txt
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,9 +45,10 @@ jobs:
       run: |
         source python/etc/profile.d/conda.sh
         conda activate venv_sct
-        pip freeze | grep -v "-e git+" | grep -v "certifi @ file" > requirements-freeze.txt
+        pip freeze | grep -v "-e git+" | grep -v "torch" | grep -v "certifi @ file" > requirements-freeze.txt
         conda deactivate
         grep "# append_to_freeze" requirements.txt >> requirements-freeze.txt
+        grep "torch" requirements.txt >> requirements-freeze.txt
 
     - name: Upload requirements-freeze.txt
       uses: actions/upload-artifact@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ dipy!=1.6.*,!=1.7.*,<1.9.0
 # We can set `weights_only=False` to retain the old behavior, however there are additional calls to `torch.load()` within our 
 # dependencies as well, meaning that we need to wait until they update themselves (or become compatible with `weights_only=True`).
 # Until then, we can pin torch to a version prior to this breaking change.
-torch<2.6
+torch<2.6 # append_to_freeze
 ivadomed
 matplotlib
 # `matplotlib-inline` is an optional package that comes with `jupyter` for use with the '%matplotlib inline' directive.


### PR DESCRIPTION
## Description

This commit is a follow-up to the previous fix of pinning `torch<2.6` (#4776).

The `grep -v torch` line is preventing the `torch<2.6` fix from being propagated to the `requirements-freeze.txt` file, causing the Create Release nightly workflow to fail (https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/13050987631).

The `grep -v torch` line was originally added nearly 4 years ago in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3383. At that time, the state of the repository included several platform-specific frozen requirements that we wanted to explicitly copy over, so that we would override the actually-installed version of torch:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/634670e4e0e282d27abaf457def5feb49da9a1f6/requirements.txt#L33-L36

However, we now have a better way of copying over specific lines in `requirements-freeze.txt` (namely, the string `# append_to_freeze`)

## Linked issues

Fixes #4775.
