### PR TITLE
Port "past release" fixes to the tags themselves, and remove them from the GHA workflow

### DIFF
--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -6,10 +6,6 @@ on:
     # > Scheduled workflows run on the latest commit on the default or base branch
     # i.e. this can only run on master
     - cron:  '0 11 * * 0'
-  pull_request:
-    # JUST TEMPORARY UNTIL THIS PR IS MERGED
-    branches:
-      - '*'
 env:
     # Even when given -y, apt will still sometimes hang at a prompt if a package
     # has clarifications to ask; DEBIAN_FRONTEND=noninteractive prevents that,

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -29,21 +29,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sct_version: [ "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3.0", "5.2.0", "5.1.0" ]
+        sct_version: [ "6.5-bp", "6.4-bp", "6.3-bp", "6.2-bp", "6.1-bp", "6.0-bp", "5.8-bp", "5.7-bp", "5.6-bp", "5.5-bp", "5.4-bp", "5.3.0-bp", "5.2.0-bp", "5.1.0-bp" ]
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
         exclude:
           # Windows support was only properly introduced in 5.7
-          - sct_version: "5.6"
+          - sct_version: "5.6-bp"
             os: windows-2019
-          - sct_version: "5.5"
+          - sct_version: "5.5-bp"
             os: windows-2019
-          - sct_version: "5.4"
+          - sct_version: "5.4-bp"
             os: windows-2019
-          - sct_version: "5.3.0"
+          - sct_version: "5.3.0-bp"
             os: windows-2019
-          - sct_version: "5.2.0"
+          - sct_version: "5.2.0-bp"
             os: windows-2019
-          - sct_version: "5.1.0"
+          - sct_version: "5.1.0-bp"
             os: windows-2019
     runs-on: ${{ matrix.os }}
     defaults:
@@ -88,32 +88,32 @@ jobs:
           ./install_sct -y
 
       - name: Windows hotfix for >=5.9 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version != '5.7' && matrix.sct_version != '5.8'
+        if: runner.os == 'Windows' && matrix.sct_version != '5.7-bp' && matrix.sct_version != '5.8-bp'
         shell: bash
         # Versions >=5.9 use the new syntax ("-U pip!=21.2) and also need the '^`' escape for the '!' character.
         run: perl -i -pe 's/pip\^!=21.2.\*/pip^!=21.2.\*,<24.1" "setuptools[core]/g;' install_sct.bat
 
       - name: Windows hotfix for v5.8 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.8'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.8-bp'
         shell: bash
         # Version ==5.8 uses the old syntax ("--upgrade pip") and also needs the '^' escape for the '!' character.
         run: perl -i -pe 's/--upgrade pip /--upgrade "pip^!=21.2.\*,<24.1" "setuptools[core]"/g;' install_sct.bat
 
       - name: Windows hotfix for v5.7 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.7'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.7-bp'
         shell: bash
         # Version ==5.7 uses the old syntax ("--upgrade pip") but doesn't need the carat escape.
         run: perl -i -pe 's/--upgrade pip /--upgrade "pip!=21.2.\*,<24.1" "setuptools[core]"/g;' install_sct.bat
 
       - name: Force Python 3.7 (Windows, SCT v5.7)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.7'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.7-bp'
         # Version 5.7-5.8's Windows installer tapped into the system python, meaning we need to set it up ourselves here
         uses: actions/setup-python@v5
         with:
           python-version: '3.7'
 
       - name: Force Python 3.8 (Windows, SCT v5.8)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.8'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.8-bp'
         # Version 5.7-5.8's Windows installer tapped into the system python, meaning we need to set it up ourselves here
         uses: actions/setup-python@v5
         with:
@@ -130,7 +130,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             # SCT_DIR was different in the first iteration of Windows support
-            if [ "${{ matrix.sct_version }}" == "5.7" ] || [ "${{ matrix.sct_version }}" == "5.8" ]; then
+            if [ "${{ matrix.sct_version }}" == "5.7-bp" ] || [ "${{ matrix.sct_version }}" == "5.8-bp" ]; then
               export SCT_DIR="D:\a\spinalcordtoolbox\spinalcordtoolbox"
             else
               export SCT_DIR="$USERPROFILE\sct_${{ matrix.sct_version }}"
@@ -161,8 +161,8 @@ jobs:
       # But, in SCT v5.5, the `sct_testing` name was re-used as an alias for pytest.
       # This means that, for only v5.4, we need to run the tests differently by calling pytest directly.
       - name: Run tests (v5.4)
-        if: matrix.sct_version == '5.4'
+        if: matrix.sct_version == '5.4-bp'
         run: ./python/envs/venv_sct/bin/pytest ./testing
       - name: Run tests (non-v5.4)
-        if: matrix.sct_version != '5.4'
+        if: matrix.sct_version != '5.4-bp'
         run: sct_testing

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -6,6 +6,10 @@ on:
     # > Scheduled workflows run on the latest commit on the default or base branch
     # i.e. this can only run on master
     - cron:  '0 11 * * 0'
+  pull_request:
+    # JUST TEMPORARY UNTIL THIS PR IS MERGED
+    branches:
+      - '*'
 env:
     # Even when given -y, apt will still sometimes hang at a prompt if a package
     # has clarifications to ask; DEBIAN_FRONTEND=noninteractive prevents that,

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -81,11 +81,12 @@ jobs:
       - name: Update environment variables
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
+            export VERSION_TXT=$(< spinalcordtoolbox/version.txt)
             # SCT_DIR was different in the first iteration of Windows support
-            if [ "${{ matrix.sct_version }}" == "5.7-bp" ] || [ "${{ matrix.sct_version }}" == "5.8-bp" ]; then
+            if [ "${VERSION_TXT}" == "5.7" ] || [ ${VERSION_TXT} == "5.8" ]; then
               export SCT_DIR="D:\a\spinalcordtoolbox\spinalcordtoolbox"
             else
-              export SCT_DIR="$USERPROFILE\sct_${{ matrix.sct_version }}"
+              export SCT_DIR="$USERPROFILE\sct_${VERSION_TXT}"
             fi
 
             # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash to set the environment variables.

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -55,55 +55,9 @@ jobs:
         with:
           ref: ${{ matrix.sct_version }}
 
-      - name: Un-freeze `setuptools` and `packaging`
-        # A user on the forum encountered the following error when installing SCT:
-        #
-        #           TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
-        #
-        # This occurs because the `packaging` library changed its API out of lockstep with `setuptools`, causing
-        # `setuptools` to sometimes incorrectly call the `packaging` function depending on the versions of each
-        # library. If we upgrade one but not the other, the two libraries can get out of sync.
-        #
-        # The issue is complicated further by the fact that `setuptools` currently gets installed *as a conda package*,
-        # while `packaging` gets installed *as a pip package* (i.e. packaging gets frozen in requirements-freeze.txt).
-        # This means that the conda `setuptools` + pip `packaging` might work fine when the release is drafted, but
-        # since setuptools wasn't frozen, its version advances while packaging's doesn't.
-        #
-        # Ideally, we would go back in time and freeze setuptools alongside packaging. But, since we can't do that,
-        # the easiest way to fix the issue in the short-term is:
-        #
-        #   1) Unfreeze `packaging` and any `setuptools-related` packages (such as `setuptools-types` that got frozen)
-        #   2) Install `setuptools[core]`, which will install both `setuptools` and `packaging` as compatible conda packages.
-        #
-        # Once we confirm that everything works, we can then freeze the new versions of `setuptools` and `packaging`.
-        run: |
-          cat requirements-freeze.txt | grep -v "setuptools" > requirements-freeze-2.txt
-          cat requirements-freeze-2.txt | grep -v "packaging" > requirements-freeze.txt
-
       - name: Install SCT (Unix)
         if: runner.os != 'Windows'
-        run: |
-          # Add fix for clash between pip 24.1 and dipy 1.5.0
-          perl -i -pe 's/pip!=21.2.\*/pip!=21.2.\*,<24.1" "setuptools[core]/g;' install_sct
-          ./install_sct -y
-
-      - name: Windows hotfix for >=5.9 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version != '5.7-bp' && matrix.sct_version != '5.8-bp'
-        shell: bash
-        # Versions >=5.9 use the new syntax ("-U pip!=21.2) and also need the '^`' escape for the '!' character.
-        run: perl -i -pe 's/pip\^!=21.2.\*/pip^!=21.2.\*,<24.1" "setuptools[core]/g;' install_sct.bat
-
-      - name: Windows hotfix for v5.8 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.8-bp'
-        shell: bash
-        # Version ==5.8 uses the old syntax ("--upgrade pip") and also needs the '^' escape for the '!' character.
-        run: perl -i -pe 's/--upgrade pip /--upgrade "pip^!=21.2.\*,<24.1" "setuptools[core]"/g;' install_sct.bat
-
-      - name: Windows hotfix for v5.7 (separate bc bash)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.7-bp'
-        shell: bash
-        # Version ==5.7 uses the old syntax ("--upgrade pip") but doesn't need the carat escape.
-        run: perl -i -pe 's/--upgrade pip /--upgrade "pip!=21.2.\*,<24.1" "setuptools[core]"/g;' install_sct.bat
+        run: ./install_sct -y
 
       - name: Force Python 3.7 (Windows, SCT v5.7)
         if: runner.os == 'Windows' && matrix.sct_version == '5.7-bp'
@@ -122,9 +76,7 @@ jobs:
       - name: Install SCT (Windows)
         if: runner.os == 'Windows'
         shell: cmd
-        run: | 
-          # Add fix for clash between pip 24.1 and dipy 1.5.0
-          install_sct.bat
+        run: install_sct.bat
 
       - name: Update environment variables
         run: |

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -29,21 +29,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sct_version: [ "6.5-bp", "6.4-bp", "6.3-bp", "6.2-bp", "6.1-bp", "6.0-bp", "5.8-bp", "5.7-bp", "5.6-bp", "5.5-bp", "5.4-bp", "5.3.0-bp", "5.2.0-bp", "5.1.0-bp" ]
+        sct_version: [ "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3.0", "5.2.0", "5.1.0" ]
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
         exclude:
           # Windows support was only properly introduced in 5.7
-          - sct_version: "5.6-bp"
+          - sct_version: "5.6"
             os: windows-2019
-          - sct_version: "5.5-bp"
+          - sct_version: "5.5"
             os: windows-2019
-          - sct_version: "5.4-bp"
+          - sct_version: "5.4"
             os: windows-2019
-          - sct_version: "5.3.0-bp"
+          - sct_version: "5.3.0"
             os: windows-2019
-          - sct_version: "5.2.0-bp"
+          - sct_version: "5.2.0"
             os: windows-2019
-          - sct_version: "5.1.0-bp"
+          - sct_version: "5.1.0"
             os: windows-2019
     runs-on: ${{ matrix.os }}
     defaults:
@@ -60,14 +60,14 @@ jobs:
         run: ./install_sct -y
 
       - name: Force Python 3.7 (Windows, SCT v5.7)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.7-bp'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.7'
         # Version 5.7-5.8's Windows installer tapped into the system python, meaning we need to set it up ourselves here
         uses: actions/setup-python@v5
         with:
           python-version: '3.7'
 
       - name: Force Python 3.8 (Windows, SCT v5.8)
-        if: runner.os == 'Windows' && matrix.sct_version == '5.8-bp'
+        if: runner.os == 'Windows' && matrix.sct_version == '5.8'
         # Version 5.7-5.8's Windows installer tapped into the system python, meaning we need to set it up ourselves here
         uses: actions/setup-python@v5
         with:
@@ -114,8 +114,8 @@ jobs:
       # But, in SCT v5.5, the `sct_testing` name was re-used as an alias for pytest.
       # This means that, for only v5.4, we need to run the tests differently by calling pytest directly.
       - name: Run tests (v5.4)
-        if: matrix.sct_version == '5.4-bp'
+        if: matrix.sct_version == '5.4'
         run: ./python/envs/venv_sct/bin/pytest ./testing
       - name: Run tests (non-v5.4)
-        if: matrix.sct_version != '5.4-bp'
+        if: matrix.sct_version != '5.4'
         run: sct_testing


### PR DESCRIPTION
## Description

This PR is part of the plan to backport fixes to the 5.x and 6.x series of SCT releases. We've already tested the fixes as part of the workflow using the `perl` find and replace fix. But, now we're going to actually put those changes into the branches themselves.

I've created some temporary "-bp" ("backport") branches based off of their corresponding tag,  that will contain the fixes and allow us to briefly test them before making any modifications to the tags themselves. Once we confirm that the fixes work in this new context, we can update the tags (and the releases), and revert this PR back to testing the tags.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4777. 
Fixes #4696. (When tags are updated.)
Fixes #4670. (When tags are updated.)