### PR TITLE
Replace monai-based contrast agnostic model to nnunet-based r20250204 release

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -116,11 +116,11 @@ MODELS = {
     #       - Binarization is applied within SCT code
     "model_seg_sc_contrast_agnostic_softseg_monai": {
         "url": [
-            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.5/model_contrast-agnostic_20240930-1002.zip"
+            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v3.1/model_contrast_agnostic_20250123.zip"
         ],
-        "description": "Spinal cord segmentation agnostic to MRI contrasts using MONAI-based nnUNet model",
+        "description": "Spinal cord segmentation agnostic to MRI contrasts",
         "contrasts": ["any"],
-        "thr": 0.5,  # Softseg model -> threshold at 0.5
+        "thr": None,  # not using Softseg model anymore since switching to the more robust nnunet model
         "default": False,
     },
     "model_seg_sci_multiclass_sc_lesion_nnunet": {

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -306,11 +306,12 @@ TASKS = {
          'models': ['model_seg_epfl_t2w_lumbar_sc']},
     'seg_sc_contrast_agnostic':
         {'description': 'Spinal cord segmentation agnostic to MRI contrasts',
-         'long_description': 'This model for contrast agnostic spinal cord segmentation uses an nnUNet '
-                             'architecture, and was created with the MONAI package. Training data consists of healthy '
-                             'controls from the open-source Spine Generic Multi Subject database and pathologies from '
-                             'private datasets including DCM and MS patients. Segmentation has been tested with the '
-                             'following contrasts: [T1w, T2w, T2star, MTon_MTS, GRE_T1w, DWI, mp2rage_UNIT1], but '
+         'long_description': 'The contrast agnostic spinal cord segmentation uses a 3D CNN model based on the nnUNet '
+                             'framework. Training data consists of healthy controls from the open-source Spine Generic '
+                             'Multi Subject database and pathologies from private datasets including DCM, MS, '
+                             'SCI (Acute, Intermediate and Chronic; Pre/Post-operative) patients. Segmentations have been '
+                             'tested with the following contrasts: '
+                             '[T1w, T2w, T2star, MTon_MTS, GRE_T1w, DWI, mp2rage_UNIT1, PSIR, STIR, EPI], but '
                              'other contrasts that are close visual matches may also work well with this model.',
          'url': 'https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/',
          'models': ['model_seg_sc_contrast_agnostic_softseg_monai']},

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -296,11 +296,14 @@ def main(argv: Sequence[str]):
         else:
             thr = (arguments.binarize_prediction if arguments.binarize_prediction is not None
                    else models.MODELS[name_model]['thr'])  # Default `thr` value stored in model dict
-            im_lst, target_lst = inference.segment_non_ivadomed(path_model, model_type, input_filenames, thr,
-                                                                keep_largest=arguments.keep_largest,
-                                                                fill_holes_in_pred=arguments.fill_holes,
-                                                                remove_small=arguments.remove_small,
-                                                                use_gpu=use_gpu, remove_temp_files=arguments.r)
+            im_lst, target_lst = inference.segment_non_ivadomed(
+                path_model, model_type, input_filenames, thr, 
+                # NOTE: contrast-agnostic nnunet model sometimes predicts pixels outside the cord, we want to 
+                # set keep_largest object as the default behaviour when using this model
+                keep_largest=1 if arguments.task[0] == 'seg_sc_contrast_agnostic' else arguments.keep_largest, 
+                fill_holes_in_pred=arguments.fill_holes, 
+                remove_small=arguments.remove_small,
+                use_gpu=use_gpu, remove_temp_files=arguments.r)
 
         # Delete intermediate outputs
         if fname_prior and os.path.isfile(fname_prior) and arguments.r:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -297,11 +297,11 @@ def main(argv: Sequence[str]):
             thr = (arguments.binarize_prediction if arguments.binarize_prediction is not None
                    else models.MODELS[name_model]['thr'])  # Default `thr` value stored in model dict
             im_lst, target_lst = inference.segment_non_ivadomed(
-                path_model, model_type, input_filenames, thr, 
-                # NOTE: contrast-agnostic nnunet model sometimes predicts pixels outside the cord, we want to 
+                path_model, model_type, input_filenames, thr,
+                # NOTE: contrast-agnostic nnunet model sometimes predicts pixels outside the cord, we want to
                 # set keep_largest object as the default behaviour when using this model
-                keep_largest=1 if arguments.task[0] == 'seg_sc_contrast_agnostic' else arguments.keep_largest, 
-                fill_holes_in_pred=arguments.fill_holes, 
+                keep_largest=1 if arguments.task[0] == 'seg_sc_contrast_agnostic' else arguments.keep_largest,
+                fill_holes_in_pred=arguments.fill_holes,
                 remove_small=arguments.remove_small,
                 use_gpu=use_gpu, remove_temp_files=arguments.r)
 

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -101,19 +101,6 @@ def test_segment_nifti_binary_seg(fname_image, fname_seg_manual, fname_out, task
                 assert label in detected_labels
 
 
-def test_segment_nifti_softseg_error_with_fill_holes(tmp_path):
-    """
-    Test soft output (produced using `-thr 0`) throws error when used with `-fill-holes 1'
-    """
-    # Ignore warnings from ivadomed model source code changing
-    warnings.filterwarnings("ignore", category=SourceChangeWarning)
-    fname_out = str(tmp_path/'t2_seg_deepseg.nii.gz')  # tmp_path for automatic cleanup
-    with pytest.raises(AssertionError):
-        sct_deepseg.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-task', 'seg_sc_contrast_agnostic',
-                               '-o', fname_out, '-qc', str(tmp_path/'qc'),
-                               '-thr', '0', '-fill-holes', '1'])
-
-
 def t2_ax():
     """Generate an approximation of an axially-acquired T2w anat image using resampling."""
     fname_out = os.path.abspath('t2_ax.nii.gz')

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -8,7 +8,6 @@ from torch.serialization import SourceChangeWarning
 
 import spinalcordtoolbox as sct
 from spinalcordtoolbox.image import Image, compute_dice, add_suffix, check_image_kind
-from spinalcordtoolbox.math import binarize
 from spinalcordtoolbox.utils.sys import sct_test_path
 import spinalcordtoolbox.deepseg.models
 
@@ -100,38 +99,6 @@ def test_segment_nifti_binary_seg(fname_image, fname_seg_manual, fname_out, task
             detected_labels = {coord.value for coord in im_seg.getCoordinatesAveragedByValue()}
             for label in expected_labels:
                 assert label in detected_labels
-
-
-# NOTE: This test used to be for contrast-agnostic monai-based softseg model which also predicted
-# soft masks. Commenting it out since the switch to an nnunet-based model (which is trained with the
-# softseg approach and does not output soft masks)
-# @pytest.mark.parametrize('fname_image, fname_seg_manual, fname_out, task, thr', [
-#     (sct_test_path('t2', 't2.nii.gz'),
-#      sct_test_path('t2', 't2_seg-manual.nii.gz'),
-#      't2_seg_deepseg.nii.gz',
-#      'seg_sc_contrast_agnostic',
-#      0),
-# ])
-# def test_segment_nifti_softseg(fname_image, fname_seg_manual, fname_out, task, thr, tmp_path):
-#     """
-#     Test soft output (produced using `-thr 0`) with sct_deepseg postprocessing CLI arguments.
-#     """
-#     # Ignore warnings from ivadomed model source code changing
-#     warnings.filterwarnings("ignore", category=SourceChangeWarning)
-#     fname_out = str(tmp_path/fname_out)  # tmp_path for automatic cleanup
-#     sct_deepseg.main(argv=['-i', fname_image, '-task', task, '-o', fname_out, '-qc', str(tmp_path/'qc'),
-#                            '-thr', str(thr), '-largest', '1', '-remove-small', '5mm3'])
-#     # Make sure output file exists
-#     assert os.path.isfile(fname_out)
-#     # Compare with ground-truth segmentation if provided
-#     if fname_seg_manual:
-#         im_seg = Image(fname_out)
-#         im_seg_manual = Image(fname_seg_manual)
-#         output_type = check_image_kind(im_seg)
-#         assert output_type == 'softseg'
-#         im_seg.data = binarize(im_seg.data, bin_thr=0.5)
-#         dice_segmentation = compute_dice(im_seg, im_seg_manual, mode='3d', zboundaries=False)
-#         assert dice_segmentation > 0.95
 
 
 def test_segment_nifti_softseg_error_with_fill_holes(tmp_path):

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -102,33 +102,36 @@ def test_segment_nifti_binary_seg(fname_image, fname_seg_manual, fname_out, task
                 assert label in detected_labels
 
 
-@pytest.mark.parametrize('fname_image, fname_seg_manual, fname_out, task, thr', [
-    (sct_test_path('t2', 't2.nii.gz'),
-     sct_test_path('t2', 't2_seg-manual.nii.gz'),
-     't2_seg_deepseg.nii.gz',
-     'seg_sc_contrast_agnostic',
-     0),
-])
-def test_segment_nifti_softseg(fname_image, fname_seg_manual, fname_out, task, thr, tmp_path):
-    """
-    Test soft output (produced using `-thr 0`) with sct_deepseg postprocessing CLI arguments.
-    """
-    # Ignore warnings from ivadomed model source code changing
-    warnings.filterwarnings("ignore", category=SourceChangeWarning)
-    fname_out = str(tmp_path/fname_out)  # tmp_path for automatic cleanup
-    sct_deepseg.main(argv=['-i', fname_image, '-task', task, '-o', fname_out, '-qc', str(tmp_path/'qc'),
-                           '-thr', str(thr), '-largest', '1', '-remove-small', '5mm3'])
-    # Make sure output file exists
-    assert os.path.isfile(fname_out)
-    # Compare with ground-truth segmentation if provided
-    if fname_seg_manual:
-        im_seg = Image(fname_out)
-        im_seg_manual = Image(fname_seg_manual)
-        output_type = check_image_kind(im_seg)
-        assert output_type == 'softseg'
-        im_seg.data = binarize(im_seg.data, bin_thr=0.5)
-        dice_segmentation = compute_dice(im_seg, im_seg_manual, mode='3d', zboundaries=False)
-        assert dice_segmentation > 0.95
+# NOTE: This test used to be for contrast-agnostic monai-based softseg model which also predicted
+# soft masks. Commenting it out since the switch to an nnunet-based model (which is trained with the
+# softseg approach and does not output soft masks)
+# @pytest.mark.parametrize('fname_image, fname_seg_manual, fname_out, task, thr', [
+#     (sct_test_path('t2', 't2.nii.gz'),
+#      sct_test_path('t2', 't2_seg-manual.nii.gz'),
+#      't2_seg_deepseg.nii.gz',
+#      'seg_sc_contrast_agnostic',
+#      0),
+# ])
+# def test_segment_nifti_softseg(fname_image, fname_seg_manual, fname_out, task, thr, tmp_path):
+#     """
+#     Test soft output (produced using `-thr 0`) with sct_deepseg postprocessing CLI arguments.
+#     """
+#     # Ignore warnings from ivadomed model source code changing
+#     warnings.filterwarnings("ignore", category=SourceChangeWarning)
+#     fname_out = str(tmp_path/fname_out)  # tmp_path for automatic cleanup
+#     sct_deepseg.main(argv=['-i', fname_image, '-task', task, '-o', fname_out, '-qc', str(tmp_path/'qc'),
+#                            '-thr', str(thr), '-largest', '1', '-remove-small', '5mm3'])
+#     # Make sure output file exists
+#     assert os.path.isfile(fname_out)
+#     # Compare with ground-truth segmentation if provided
+#     if fname_seg_manual:
+#         im_seg = Image(fname_out)
+#         im_seg_manual = Image(fname_seg_manual)
+#         output_type = check_image_kind(im_seg)
+#         assert output_type == 'softseg'
+#         im_seg.data = binarize(im_seg.data, bin_thr=0.5)
+#         dice_segmentation = compute_dice(im_seg, im_seg_manual, mode='3d', zboundaries=False)
+#         assert dice_segmentation > 0.95
 
 
 def test_segment_nifti_softseg_error_with_fill_holes(tmp_path):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR aims to update the `contrast-agnostic` model to the nnunet based one (which was monai-based until now). Experiments showed that the nnunet model was more robust across difficult subjects than the current monai-based model. It also fixed issues we were having with shifted predictions on a few test cases, and works _much more_ better on compressed cord and whole-spine images.  

Notable change is that I set the `keep_largest` argument as the default for this model as we have seen some cases where the model was predicting a few pixels outside the cord (quite rarely though). 

## Testing the PR

1. Check out to the branch `nk/update-contrast-agnostic-to-v3.1`
2. Run `sct_deepseg -install-task seg_sc_contrast_agnostic`
3. Run `sct_deepseg -task seg_sc_contrast_agnostic -i <path-to-the-image>.nii.gz` on your test image. 

@valosekj or @sandrinebedard could you please checkout to this branch and try the latest model? Thank you! 