### PR TITLE
Allow ANTs binaries to access `msvc-runtime` DLLs to avoid DLL not found errors

### DIFF
--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -316,7 +316,7 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         # also, for windows, add the bin directory to the path (to allow ANTs to access 'msvc-runtime' DLLs)
         # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4655#issuecomment-2430178901
         if sys.platform.startswith("win32"):
-            env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
+            env['PATH'] = __bin_dir__ + os.pathsep + env['PATH']
 
     if isinstance(cmd, str):
         cmdline = cmd

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -316,7 +316,9 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         # also, for windows, add the bin directory to the path (to allow ANTs to access 'msvc-runtime' DLLs)
         # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4655#issuecomment-2430178901
         if sys.platform.startswith("win32"):
-            env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
+            # sanity check to make sure this is really the issue
+            pass
+            # env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
 
     if isinstance(cmd, str):
         cmdline = cmd

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -301,7 +301,7 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         cwd = os.getcwd()
 
     if env is None:
-        env = os.environ
+        env = os.environ.copy()
 
     if is_sct_binary:
         # create an absolute path to the binary inside of SCT's bin directory

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -316,9 +316,7 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         # also, for windows, add the bin directory to the path (to allow ANTs to access 'msvc-runtime' DLLs)
         # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4655#issuecomment-2430178901
         if sys.platform.startswith("win32"):
-            # sanity check to make sure this is really the issue
-            pass
-            # env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
+            env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
 
     if isinstance(cmd, str):
         cmdline = cmd

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -304,14 +304,19 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         env = os.environ
 
     if is_sct_binary:
+        # create an absolute path to the binary inside of SCT's bin directory
         name = cmd[0] if isinstance(cmd, list) else cmd.split(" ", 1)[0]
         path = os.path.join(__bin_dir__, name)
-
         if isinstance(cmd, list):
             cmd[0] = path
         elif isinstance(cmd, str):
             rem = cmd.split(" ", 1)[1:]
             cmd = path if len(rem) == 0 else "{} {}".format(path, rem[0])
+
+        # also, for windows, add the bin directory to the path (to allow ANTs to access 'msvc-runtime' DLLs)
+        # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4655#issuecomment-2430178901
+        if sys.platform.startswith("win32"):
+            env['PATH'] = env['PATH'] + os.pathsep + __bin_dir__
 
     if isinstance(cmd, str):
         cmdline = cmd


### PR DESCRIPTION
## Description

As discussed in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4655#issuecomment-2430178901, we install `msvc-runtime` on Windows to avoid missing DLL errors. However, we completely missed that subprocesses can't see these DLLs, meaning ANTs binaries will fail if these DLLs aren't present via other means.

We've subtly disguised this missing DLL error by asking users to [install the necessary dependency themselves](https://spinalcordtoolbox.com/stable/user_section/installation/windows.html#visual-c-2019-runtime). However, for workstations with limited installation privileges, this may not be possible. And, this second dependency installation is largely redundant with our own installation of `msvc-runtime`, anyway. 

Since we already have the necessary DLLs in the Scripts folder, why not (temporarily) add Scripts to the PATH when specifically running "SCT binaries" (i.e. the `isct_XXX` binaries)?

## Further discussion

It's possible that we may want to remove the requirement of Visual Studio Runtime from our installation docs. But, it also doesn't seem like it's necessarily harmful, either, as it's the sort of thing that users will probably want to install at some point. And, I wouldn't want to cause errors just in case there is another part of SCT that isn't covered by this path fix.

## Linked issues

Fixes #4655.
