### PR TITLE
Update `courses.rst` with SCT Course 2024 links

### DIFF
--- a/documentation/source/user_section/courses.rst
+++ b/documentation/source/user_section/courses.rst
@@ -7,6 +7,7 @@ We organize a **free** in-person SCT course each year after the ISMRM conference
 
 The past courses handouts are listed below:
 
+-  `SCT course (v6.5), Online, 2024-12-09`_ \| `Video recording <https://youtu.be/CDj8PYW1WaA>`__
 -  `SCT course (v6.1), Online, 2023-11-20`_ \| `Video recording <https://youtu.be/hTbJo8GO5IU>`__
 -  `SCT course (v5.4.0), Boston, 2021-11-16`_ \| `Video recording <https://www.youtube.com/watch?v=Pcg2ngc9hj8&list=PLJ5-Fnq9XpaXmDmtwDPycLyZoitv8PsTi&index=2>`__
 -  `SCT course (v4.2.1), London, 2020-01-21`_ \| `Video recording <https://www.youtube.com/watch?v=whbtjYNtHko>`__
@@ -19,6 +20,7 @@ The past courses handouts are listed below:
 -  `SCT course (v3.0_beta1), Montreal, 2016-04-19`_
 -  `SCT Hands-on Workshop (v2.0.4), Toronto, 2015-06-15`_
 
+.. _SCT course (v6.5), Online, 2024-12-09: https://docs.google.com/presentation/d/1uUOpgshwnyC2p8r2GalXlUczQLpX6PfJbtzNELxbqdI/edit?usp=sharing
 .. _SCT course (v6.1), Online, 2023-11-20: https://docs.google.com/presentation/d/1t40Fd0fS0SwWR5FU_GWKEvHkB9d96LVddLQW6L3QAx0/edit?usp=sharing
 .. _SCT course (v5.4.0), Boston, 2021-11-16: https://drive.google.com/file/d/1Oe9XHepUbd-nMNZvlNojh4YttEPep01P/view?usp=sharing
 .. _SCT course (v4.2.1), London, 2020-01-21: https://drive.google.com/file/d/1TZireJ6yhV8q7PbKKXyXg7Heov9-YJMu/view?usp=sharing


### PR DESCRIPTION
## Description

This PR updates the documentation with the newest links to the material and YouTube video (needed to send out final SCT Course email).

## Backporting to 6.5

Now that our documentation links to the latest "stable" release, this change won't go live immediately. Meaning, we will need to backport this for it to go live.

We could update the 6.5 tag, but this would require remaking the release and etc. But because `stable` triggers for the most recent tag, it's possible to create a secondary tag just for backported documentation changes. Something as simple as `6.5.docs` would cause `stable` to update while leaving `6.5` itself unchanged.

## Linked issues

Partially addresses <!--don't close-->#4749.