### PR TITLE
Preserve the `_seg` suffix for the contrast-agnostic model

### DIFF
--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -309,7 +309,7 @@ def segment_nnunet(path_img, tmpdir, predictor, device: torch.device):
     # for spinal cord segmentation models with only 1 output label, save the image directly with specific "_seg" suffix
     # this is added to preserve the typical expected output for SC models (`sct_propseg`, `sct_deepseg_sc`, etc.)
     # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4805
-    elif list(labels.keys()) == ['sc']:
+    elif sorted(labels.keys()) == ['sc']:
         targets = ["_seg"]
         outputs = [img_out]
     # for the other multiclass models (SCI lesion/SC, mouse GM/WM, etc.), save 1 image per label

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -306,6 +306,12 @@ def segment_nnunet(path_img, tmpdir, predictor, device: torch.device):
     if is_rootlet_model:
         targets = ["_rootlets"]
         outputs = [img_out]
+    # for spinal cord segmentation models with only 1 output label, save the image directly with specific "_seg" suffix
+    # this is added to preserve the typical expected output for SC models (`sct_propseg`, `sct_deepseg_sc`, etc.)
+    # see also: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4805
+    elif list(labels.keys()) == ['sc']:
+        targets = ["_seg"]
+        outputs = [img_out]
     # for the other multiclass models (SCI lesion/SC, mouse GM/WM, etc.), save 1 image per label
     else:
         targets, outputs = [], []


### PR DESCRIPTION
## Description

When the contrast-agnostic model was changed from MONAI to nnUNet, the method for determining the output suffix also changed, thus the output switched from `_seg.nii.gz` to `_sc_seg.nii.gz`. I think adding the "sc" part makes sense for multiclass models (SC/lesion, SC/GM, etc.). But, for our single-class SC tools (`sct_deepseg_sc`, `sct_propseg`, etc.) we typically just output `_seg.nii.gz`. 

So, this PR adds a special case to check for single-output SC models, then choose the "basic" suffix accordingly.

This PR is being tested in https://github.com/spinalcordtoolbox/sct_tutorial_data/pull/27/files#r1985521419, because that PR is getting blocked by this issue (SCT course was written for `_seg.nii.gz suffix`).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4805.
Needed for https://github.com/spinalcordtoolbox/sct_tutorial_data/pull/27, which is in turn needed for https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4804.
