### PR TITLE
Improve clarity of `ZeroDivisionError` message when resampling

### DIFF
--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -105,10 +105,12 @@ def resample_nib(image, new_size=None, new_size_type=None, image_dest=None, inte
         for i in range(3):
             try:
                 R[i, i] = img.shape[i] / float(shape_r[i])
-            except ZeroDivisionError:
-                raise ZeroDivisionError("Destination size is zero for dimension {}. You are trying to resample to an "
-                                        "unrealistic dimension. Check your NIFTI pixdim values to make sure they are "
-                                        "not corrupted.".format(i))
+            except ZeroDivisionError as e:
+                raise ValueError(
+                    f"Requested resampling (`-{new_size_type} {'x'.join(new_size)}`) would resample the input image from {shape} to {shape_r}. "
+                    f"Please double-check the requested resampling parameters. (Note that for the 'factor' and 'mm' resampling types, "
+                    f"voxels will be rounded to the nearest whole number, which may result in a shape of [0].)"
+                ) from e
 
         affine_r = np.dot(affine, R)
         reference = (shape_r, affine_r)


### PR DESCRIPTION
## Description

In #4773, we encountered a confusing error when trying to resample an image with a small amount of slices to begin with. Luckily, we're already catching the error and adding our own message -- we just need to tweak the wording a bit.

Before:

```python
Traceback (most recent call last):
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 107, in resample_nib
    R[i, i] = img.shape[i] / float(shape_r[i])
ZeroDivisionError: float division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/scripts/sct_resample.py", line 162, in <module>
    main(sys.argv[1:])
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/scripts/sct_resample.py", line 156, in main
    spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 182, in resample_file
    img_r = resample_nib(img, new_size.split('x'), new_size_type, image_dest=img_ref, interpolation=interpolation)
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 109, in resample_nib
    raise ZeroDivisionError("Destination size is zero for dimension {}. You are trying to resample to an "
"""
ZeroDivisionError: Destination size is zero for dimension 0. You are trying to resample to an unrealistic 
dimension. Check your NIFTI pixdim values to make sure they are not corrupted.
"""
```

After:

```python
Traceback (most recent call last):
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 107, in resample_nib
    R[i, i] = img.shape[i] / float(shape_r[i])
ZeroDivisionError: float division by zero

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/scripts/sct_resample.py", line 162, in <module>
    main(sys.argv[1:])
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/scripts/sct_resample.py", line 156, in main
    spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 184, in resample_file
    img_r = resample_nib(img, new_size.split('x'), new_size_type, image_dest=img_ref, interpolation=interpolation)
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/resampling.py", line 109, in resample_nib
    raise ValueError(
"""
ValueError: Requested resampling (`-mm 100000x100000x100000`) would resample the input image from 
(60, 55, 52) to (0, 0, 0). Please double-check the requested resampling parameters. (Note that for 
the 'factor' and 'mm' resampling types, voxels will be rounded to the nearest whole number, which 
may result in a shape of [0].)
"""
```


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Fixes #4773.