### PR TITLE
Pin SetupTools to Prevent Crashing at Documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,22 @@ build:
   tools:
       # This python version needs to be compatible with SCT, see setup.py
       python: "3.9"
+  jobs:
+    # NOTES:
+    # - Add fix for mismatch between `batchgenerators` and `setuptools==78.0`
+    # - We choose 75.8.2 to match the version installed in the conda 3.9 venv_sct
+    # - This step *should* run after the environment is created, but before
+    #   SCT+dependencies are installed (i.e. the `python: install:` config below)
+    # - The reason we can't just pin this in `requirements.txt` is because
+    #   RTD automatically upgrades `setuptools` beforehand. So we need to
+    #   downgrade it after the environment is created + upgraded, but *before*
+    #   installing everything in `requirements.txt`.
+    #
+    # FURTHER READING:
+    #  - https://docs.readthedocs.com/platform/stable/builds.html#understanding-the-build-process
+    #  - https://docs.readthedocs.com/platform/stable/build-customization.html#extend-or-override-the-build-process
+    post_create_environment:
+      - python -m pip install setuptools==75.8.2
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ build:
     # FURTHER READING:
     #  - https://docs.readthedocs.com/platform/stable/builds.html#understanding-the-build-process
     #  - https://docs.readthedocs.com/platform/stable/build-customization.html#extend-or-override-the-build-process
-    pre_install:
+    install:
       - python -m pip install setuptools==75.8.2
 
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,18 +14,19 @@ build:
     # NOTES:
     # - Add fix for mismatch between `batchgenerators` and `setuptools==78.0`
     # - We choose 75.8.2 to match the version installed in the conda 3.9 venv_sct
-    # - This step *should* run after the environment is created, but before
-    #   SCT+dependencies are installed (i.e. the `python: install:` config below)
-    # - The reason we can't just pin this in `requirements.txt` is because
-    #   RTD automatically upgrades `setuptools` beforehand. So we need to
-    #   downgrade it after the environment is created + upgraded, but *before*
-    #   installing everything in `requirements.txt`.
+    # - This replaces the existing `install` step, which upgrades `setuptools`
+    #   *without* a hard limit. All we're doing here is freezing setuptools.
     #
     # FURTHER READING:
     #  - https://docs.readthedocs.com/platform/stable/builds.html#understanding-the-build-process
     #  - https://docs.readthedocs.com/platform/stable/build-customization.html#extend-or-override-the-build-process
     install:
-      - python -m pip install setuptools==75.8.2
+      - python -m pip install --upgrade --no-cache-dir pip setuptools==75.8.2
+      - python -m pip install --upgrade --no-cache-dir sphinx
+      # - These two lines replicate the parts of the `install` step defined in
+      #   the `python: install:` section below, too.
+      - python -m pip install --exists-action=w --no-cache-dir -r requirements.txt
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir .[docs]
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ build:
     # FURTHER READING:
     #  - https://docs.readthedocs.com/platform/stable/builds.html#understanding-the-build-process
     #  - https://docs.readthedocs.com/platform/stable/build-customization.html#extend-or-override-the-build-process
-    post_create_environment:
+    pre_install:
       - python -m pip install setuptools==75.8.2
 
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,5 @@ wquantiles
 # XlxsWriter is needed to write `.xlsx` files, since pandas removed support for the `xlwt` engine
 # Source: https://github.com/pandas-dev/pandas/pull/49296
 xlsxwriter
+# Temporary; pins SetupTools to <78
+setuptools<78.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,5 +83,3 @@ wquantiles
 # XlxsWriter is needed to write `.xlsx` files, since pandas removed support for the `xlwt` engine
 # Source: https://github.com/pandas-dev/pandas/pull/49296
 xlsxwriter
-# Temporary; pins SetupTools to <78
-setuptools<78.0


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
See issue #4822; this PR aims to try and fix it (by pinning SetupTools to a version where the issue does not occur)

## Linked issues
Resolves #4822
