### PR TITLE
Added automated testing for new profiling utilities

### DIFF
--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -21,7 +21,7 @@ class Timer:
 
     def stop(self):
         time_delta = time.time() - self._t0
-        logging.warning(f"PROFILER: Elapsed time: {time_delta:.3f} seconds.")
+        logging.warning(f"PROFILER: Elapsed time; {time_delta:.3f} seconds.")
 
 
 # ArgParse Action class which starts a timer when requested

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -29,7 +29,7 @@ def false_atexit(monkeypatch):
 
     # Return a method which will run each function in the teardown_fn list, simulating the program closing
     def _return_fn():
-        for i, fn in enumerate(teardown_fns):
+        for fn in teardown_fns:
             fn()
 
     return _return_fn

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -37,7 +37,7 @@ def false_atexit(monkeypatch):
 
 def test_timeit_by_cli(false_atexit, caplog):
     """Confirm our profiling flags enable profiling correctly"""
-    # Capture all log input explicitly, so that we can test that the total runtime was run correctrly
+    # Capture all log input explicitly, so that we can test that the total runtime was run correctly
     caplog.set_level(logging.INFO)
 
     # Initiate a dummy argument parser

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -1,0 +1,58 @@
+# pytest unit tests for spinalcordtoolbox.utils.profiling
+
+import atexit
+import logging
+import time
+
+import pytest
+
+from spinalcordtoolbox.utils import profiling, shell
+
+
+@pytest.fixture()
+def false_atexit(monkeypatch):
+    """
+    Proxy's a program "ending" in the eyes of atexit, allowing the user to "end" the program at will
+    """
+    # Define a proxy functions for atexit's registration management, allowing them to be explicitly called
+    teardown_fns = []
+    register_proxy = lambda fn: teardown_fns.append(fn)
+    unregister_proxy = lambda fn: teardown_fns.remove(fn)
+
+    # Monkeypatch it in
+    monkeypatch.setattr(atexit, "register", register_proxy)
+    monkeypatch.setattr(atexit, "unregister", unregister_proxy)
+
+    # Return a method which will run each function in the teardown_fn list, simulating the program closing
+    def _return_fn():
+        for i, fn in enumerate(teardown_fns):
+            fn()
+
+    return _return_fn
+
+
+def test_timeit_by_cli(false_atexit, caplog):
+    """Confirm our profiling flags enable profiling correctly"""
+    # Capture all log input explicitly, so that we can test that the total runtime was run correctrly
+    caplog.set_level(logging.INFO)
+
+    # Initiate a dummy argument parser
+    parser = shell.SCTArgumentParser(description="Time-based profiling test parser.")
+
+    # Add our common argument
+    parser.add_common_args()
+
+    # Run an "analysis" with full-program time profiling
+    parser.parse_args(['-timeit'])
+
+    # Confirm the timer initialized correctly
+    assert profiling.PROFILING_TIMER is not None
+
+    # Wait 1 second to give us some "time" to actually measure
+    time.sleep(1)
+
+    false_atexit()
+
+    # At this time, the last log should be the reported time; confirm this is correct
+    most_recent_log = caplog.records[-1]
+    assert "PROFILER:" in most_recent_log.message

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -49,10 +49,15 @@ def test_timeit_by_cli(false_atexit, caplog):
     assert profiling.PROFILING_TIMER is not None
 
     # Wait 1 second to give us some "time" to actually measure
-    time.sleep(1)
+    sleep_time = 1
+    time.sleep(sleep_time)
 
     false_atexit()
 
     # At this time, the last log should be the reported time; confirm this is correct
     most_recent_log = caplog.records[-1]
     assert "PROFILER:" in most_recent_log.message
+
+    # Confirm the reported runtime is ~1 second
+    prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])
+    assert prog_runtime == pytest.approx(sleep_time, 0.05)

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -16,12 +16,16 @@ def false_atexit(monkeypatch):
     """
     # Define a proxy functions for atexit's registration management, allowing them to be explicitly called
     teardown_fns = []
-    register_proxy = lambda fn: teardown_fns.append(fn)
-    unregister_proxy = lambda fn: teardown_fns.remove(fn)
+
+    def _register_proxy(fn):
+        teardown_fns.append(fn)
+
+    def _unregister_proxy(fn):
+        teardown_fns.remove(fn)
 
     # Monkeypatch it in
-    monkeypatch.setattr(atexit, "register", register_proxy)
-    monkeypatch.setattr(atexit, "unregister", unregister_proxy)
+    monkeypatch.setattr(atexit, "register", _register_proxy)
+    monkeypatch.setattr(atexit, "unregister", _unregister_proxy)
 
     # Return a method which will run each function in the teardown_fn list, simulating the program closing
     def _return_fn():


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] ~~I've linked relevant issues in the PR body~~ Not relevant to this PR
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [x] ~~I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages~~ Not relevant, as this is just adding tests for previously documented additions.,

## Description

This adds automated testing to the time-based profiling utilities added in #4825. Now we'll know if something broke before it errors out during a live run!

**NOTE:** The reason this is a separate PR from the "main" addition is due to way the profiling works (running a command when the program terminates) requiring additional investigation into how to work with PyTest (which, obviously, could not test anything after it was terminated)

## Linked issues
N/A
