### PR TITLE
Remove opt-in `-timeit` flag in favor of running a timer by default 

### DIFF
--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -1,8 +1,6 @@
 import atexit
 import logging
-import os
 import time
-from argparse import Action, SUPPRESS
 
 PROFILING_TIMER = None
 
@@ -21,23 +19,7 @@ class Timer:
 
     def stop(self):
         time_delta = time.time() - self._t0
-        logging.warning(f"PROFILER: Elapsed time; {time_delta:.3f} seconds.")
-
-
-# ArgParse Action class which starts a timer when requested
-class StartGlobalTimer(Action):
-    def __init__(self, option_strings, dest=SUPPRESS, default=SUPPRESS, help=None):
-        super(StartGlobalTimer, self).__init__(
-            option_strings=option_strings,
-            dest=dest,
-            default=default,
-            nargs=0,
-            help=help
-        )
-
-    """argparse Action, which will start a timing tracker for us"""
-    def __call__(self, *args, **kwargs):
-        begin_global_timer()
+        logging.info(f"Total runtime; {time_delta:.3f} seconds.")
 
 
 def begin_global_timer():
@@ -48,14 +30,7 @@ def begin_global_timer():
         PROFILING_TIMER = Timer()
     # Otherwise, skip and warn the user
     else:
-        # If this was because the OS-level environmental variable was set
-        if "SCT_TIMER" in os.environ.keys():
-            logging.warning(
-                "Both the '-timeit' flag and the 'SCT_TIMER' environmental variable were used, resulting in the timer "
-                "being started twice; you should only do one or the other!"
-            )
-        else:
-            logging.warning(
-                "Tried to start the global profiling timer twice; you should generally leave this initialization to the "
-                "CLI, rather than calling 'begin_global_timer yourself!"
-            )
+        logging.warning(
+            "Tried to start the global profiling timer twice; you should leave generally leave this initialization to "
+            "SCT itself, rather than calling 'begin_global_timer' explicitly!"
+        )

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -18,7 +18,6 @@ from functools import cached_property, partial
 
 from .sys import check_exe, printv, removesuffix, ANSIColors16
 from .fs import relpath_or_abspath
-from .profiling import StartGlobalTimer
 
 logger = logging.getLogger(__name__)
 
@@ -297,13 +296,6 @@ class SCTArgumentParser(argparse.ArgumentParser):
             default=1,
             # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
             help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode."
-        )
-
-        # Add profiling-related arguments
-        arg_group.add_argument(
-            "-timeit",
-            action=StartGlobalTimer,
-            help="If this flag is present, the program will report its total runtime once it has finished running."
         )
 
         # Return the arg_group to allow for chained operations

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -182,9 +182,8 @@ def init_sct():
     hdlr.setFormatter(fmt)
     logging.root.addHandler(hdlr)
 
-    # Enable timer, if requested
-    if os.environ.get("SCT_TIMER", None) is not None:
-        begin_global_timer()
+    # Enable timing
+    begin_global_timer()
 
     # Display SCT version
     logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -182,9 +182,6 @@ def init_sct():
     hdlr.setFormatter(fmt)
     logging.root.addHandler(hdlr)
 
-    # Enable timing
-    begin_global_timer()
-
     # Display SCT version
     logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
 
@@ -195,6 +192,9 @@ def init_sct():
         arguments = ' '.join(sys.argv[1:])
         logger.info(f"{script} {arguments}\n"
                     f"--\n")
+
+    # Enable timing
+    begin_global_timer()
 
 
 def send_email(addr_to, addr_from, subject, message='', passwd=None, filename=None, html=False, smtp_host=None, smtp_port=None, login=None):

--- a/testing/api/test_centerline.py
+++ b/testing/api/test_centerline.py
@@ -13,6 +13,10 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.sys import sct_test_path
 
 
+# Enforce that all tests in this suite use verbose logging
+pytestmark = pytest.mark.usefixtures("verbose_logging")
+
+
 # Separate setting for get_centerline. Set to 2 to save images ("DEBUG"), 0 otherwise ("INFO")
 VERBOSE = 0
 
@@ -145,78 +149,82 @@ param_optic = [
 ]
 
 
-@pytest.mark.usefixtures("verbose_logging")
-class TestCenterline:
-    @pytest.mark.parametrize('img_ctl,expected', im_ctl_find_and_sort_coord)
-    def test_find_and_sort_coord(self, img_ctl, expected):
-        img = img_ctl[0].copy()
-        centermass = find_and_sort_coord(img)
-        assert centermass.shape == (3, 9)
-        assert np.linalg.norm(centermass - img_ctl[2]) == 0
+@pytest.mark.parametrize('img_ctl,expected', im_ctl_find_and_sort_coord)
+def test_find_and_sort_coord(img_ctl, expected):
+    img = img_ctl[0].copy()
+    centermass = find_and_sort_coord(img)
+    assert centermass.shape == (3, 9)
+    assert np.linalg.norm(centermass - img_ctl[2]) == 0
 
-    @pytest.mark.parametrize('img_ctl,expected', im_ctl_zeroslice)
-    def test_get_centerline_polyfit_minmax(self, img_ctl, expected):
-        """Test centerline fitting with minmax=True"""
-        img_sub = img_ctl[1].copy()
-        img_out, arr_out, _, _ = get_centerline(
-            img_sub, ParamCenterline(algo_fitting='polyfit', degree=3, minmax=True), verbose=VERBOSE)
-        # Assess output size
-        assert arr_out.shape == expected
 
-    @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
-    def test_get_centerline_polyfit(self, img_ctl, expected, params):
-        """Test centerline fitting using polyfit"""
-        if 'exclude_polyfit':
-            return
-        img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
-        img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
-            img_sub, ParamCenterline(algo_fitting='polyfit', minmax=False), verbose=VERBOSE)
-        assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
-        assert np.max(np.absolute(np.diff(arr_deriv_out))) < expected['laplacian']
-        # check arr_out only if input orientation is RPI (because the output array is always in RPI)
-        if img.orientation == 'RPI':
-            assert np.linalg.norm(find_and_sort_coord(img) - arr_out) < expected['norm']
+@pytest.mark.parametrize('img_ctl,expected', im_ctl_zeroslice)
+def test_get_centerline_polyfit_minmax(img_ctl, expected):
+    """Test centerline fitting with minmax=True"""
+    img_sub = img_ctl[1].copy()
+    img_out, arr_out, _, _ = get_centerline(
+        img_sub, ParamCenterline(algo_fitting='polyfit', degree=3, minmax=True), verbose=VERBOSE)
+    # Assess output size
+    assert arr_out.shape == expected
 
-    @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
-    def test_get_centerline_bspline(self, img_ctl, expected, params):
-        """Test centerline fitting using bspline"""
-        img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
-        img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
-            img_sub, ParamCenterline(algo_fitting='bspline', minmax=False), verbose=VERBOSE)
-        assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
-        assert fit_results.rmse < expected['rmse']
-        assert fit_results.laplacian_max < expected['laplacian']
 
-    @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
-    def test_get_centerline_linear(self, img_ctl, expected, params):
-        """Test centerline fitting using linear interpolation"""
-        img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
-        img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
-            img_sub, ParamCenterline(algo_fitting='linear', minmax=False), verbose=VERBOSE)
-        assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
-        assert fit_results.laplacian_max < expected['laplacian']
+@pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
+def test_get_centerline_polyfit(img_ctl, expected, params):
+    """Test centerline fitting using polyfit"""
+    if 'exclude_polyfit':
+        return
+    img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
+    img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
+        img_sub, ParamCenterline(algo_fitting='polyfit', minmax=False), verbose=VERBOSE)
+    assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
+    assert np.max(np.absolute(np.diff(arr_deriv_out))) < expected['laplacian']
+    # check arr_out only if input orientation is RPI (because the output array is always in RPI)
+    if img.orientation == 'RPI':
+        assert np.linalg.norm(find_and_sort_coord(img) - arr_out) < expected['norm']
 
-    @pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
-    def test_get_centerline_nurbs(self, img_ctl, expected, params):
-        """Test centerline fitting using nurbs"""
-        if 'exclude_nurbs':
-            return
-        img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
-        img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
-            img_sub, ParamCenterline(algo_fitting='nurbs', minmax=False), verbose=VERBOSE)
-        assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
-        assert fit_results.laplacian_max < expected['laplacian']
 
-    @pytest.mark.parametrize('params', param_optic)
-    def test_get_centerline_optic(self, params):
-        """Test centerline extraction with optic"""
-        # TODO: add assert on the output .csv files for more precision
-        im = Image(params['fname_image'])
-        # Add non-numerical values at the top corner of the image for testing purpose
-        im.change_type('float32')
-        im.data[0, 0, 0] = np.nan
-        im.data[1, 0, 0] = np.inf
-        im_centerline, arr_out, _, _ = get_centerline(
-            im, ParamCenterline(algo_fitting='optic', contrast=params['contrast'], minmax=False), verbose=VERBOSE)
-        # Compare with ground truth centerline
-        assert np.all(im_centerline.data == Image(params['fname_centerline-optic']).data)
+@pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
+def test_get_centerline_bspline(img_ctl, expected, params):
+    """Test centerline fitting using bspline"""
+    img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
+    img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
+        img_sub, ParamCenterline(algo_fitting='bspline', minmax=False), verbose=VERBOSE)
+    assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
+    assert fit_results.rmse < expected['rmse']
+    assert fit_results.laplacian_max < expected['laplacian']
+
+
+@pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
+def test_get_centerline_linear(img_ctl, expected, params):
+    """Test centerline fitting using linear interpolation"""
+    img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
+    img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
+        img_sub, ParamCenterline(algo_fitting='linear', minmax=False), verbose=VERBOSE)
+    assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
+    assert fit_results.laplacian_max < expected['laplacian']
+
+
+@pytest.mark.parametrize('img_ctl,expected,params', im_centerlines)
+def test_get_centerline_nurbs(img_ctl, expected, params):
+    """Test centerline fitting using nurbs"""
+    if 'exclude_nurbs':
+        return
+    img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
+    img_out, arr_out, arr_deriv_out, fit_results = get_centerline(
+        img_sub, ParamCenterline(algo_fitting='nurbs', minmax=False), verbose=VERBOSE)
+    assert np.median(find_and_sort_coord(img) - find_and_sort_coord(img_out)) == expected['median']
+    assert fit_results.laplacian_max < expected['laplacian']
+
+
+@pytest.mark.parametrize('params', param_optic)
+def test_get_centerline_optic(params):
+    """Test centerline extraction with optic"""
+    # TODO: add assert on the output .csv files for more precision
+    im = Image(params['fname_image'])
+    # Add non-numerical values at the top corner of the image for testing purpose
+    im.change_type('float32')
+    im.data[0, 0, 0] = np.nan
+    im.data[1, 0, 0] = np.inf
+    im_centerline, arr_out, _, _ = get_centerline(
+        im, ParamCenterline(algo_fitting='optic', contrast=params['contrast'], minmax=False), verbose=VERBOSE)
+    # Compare with ground truth centerline
+    assert np.all(im_centerline.data == Image(params['fname_centerline-optic']).data)

--- a/testing/api/test_qmri.py
+++ b/testing/api/test_qmri.py
@@ -8,6 +8,10 @@ from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
 
 
+# Enforce that all tests in this suite use verbose logging
+pytestmark = pytest.mark.usefixtures("verbose_logging")
+
+
 def make_sct_image(data):
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -19,24 +23,23 @@ def make_sct_image(data):
     return img
 
 
-@pytest.mark.usefixtures("verbose_logging")
-class TestQMRI:
-    def test_compute_mtr(self):
-        img_mtr = mt.compute_mtr(nii_mt1=make_sct_image(10),
-                                 nii_mt0=make_sct_image(20)
-                                 )
-        assert img_mtr.data[0] == 0.5 * 100  # output is in percent
+def test_compute_mtr():
+    img_mtr = mt.compute_mtr(nii_mt1=make_sct_image(10),
+                             nii_mt0=make_sct_image(20)
+                             )
+    assert img_mtr.data[0] == 0.5 * 100  # output is in percent
 
-    def test_compute_mtsat(self):
-        img_mtsat, img_t1map = mt.compute_mtsat(nii_mt=make_sct_image(1500),
-                                                nii_pd=make_sct_image(2000),
-                                                nii_t1=make_sct_image(1500),
-                                                tr_mt=0.030,
-                                                tr_pd=0.030,
-                                                tr_t1=0.015,
-                                                fa_mt=9,
-                                                fa_pd=9,
-                                                fa_t1=15
-                                                )
-        assert img_mtsat.data[0] == pytest.approx(1.5327, 0.0001)
-        assert img_t1map.data[0] == pytest.approx(0.8916, 0.0001)
+
+def test_compute_mtsat():
+    img_mtsat, img_t1map = mt.compute_mtsat(nii_mt=make_sct_image(1500),
+                                            nii_pd=make_sct_image(2000),
+                                            nii_t1=make_sct_image(1500),
+                                            tr_mt=0.030,
+                                            tr_pd=0.030,
+                                            tr_t1=0.015,
+                                            fa_mt=9,
+                                            fa_pd=9,
+                                            fa_t1=15
+                                            )
+    assert img_mtsat.data[0] == pytest.approx(1.5327, 0.0001)
+    assert img_t1map.data[0] == pytest.approx(0.8916, 0.0001)

--- a/testing/api/test_qmri.py
+++ b/testing/api/test_qmri.py
@@ -6,12 +6,6 @@ import pytest
 
 from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.sys import init_sct, set_loglevel
-
-
-# Set logger to "DEBUG"
-init_sct()
-set_loglevel(verbose=2, caller_module_name=__name__)
 
 
 def make_sct_image(data):
@@ -25,23 +19,24 @@ def make_sct_image(data):
     return img
 
 
-def test_compute_mtr():
-    img_mtr = mt.compute_mtr(nii_mt1=make_sct_image(10),
-                             nii_mt0=make_sct_image(20)
-                             )
-    assert img_mtr.data[0] == 0.5 * 100  # output is in percent
+@pytest.mark.usefixtures("verbose_logging")
+class TestQMRI:
+    def test_compute_mtr(self):
+        img_mtr = mt.compute_mtr(nii_mt1=make_sct_image(10),
+                                 nii_mt0=make_sct_image(20)
+                                 )
+        assert img_mtr.data[0] == 0.5 * 100  # output is in percent
 
-
-def test_compute_mtsat():
-    img_mtsat, img_t1map = mt.compute_mtsat(nii_mt=make_sct_image(1500),
-                                            nii_pd=make_sct_image(2000),
-                                            nii_t1=make_sct_image(1500),
-                                            tr_mt=0.030,
-                                            tr_pd=0.030,
-                                            tr_t1=0.015,
-                                            fa_mt=9,
-                                            fa_pd=9,
-                                            fa_t1=15
-                                            )
-    assert img_mtsat.data[0] == pytest.approx(1.5327, 0.0001)
-    assert img_t1map.data[0] == pytest.approx(0.8916, 0.0001)
+    def test_compute_mtsat(self):
+        img_mtsat, img_t1map = mt.compute_mtsat(nii_mt=make_sct_image(1500),
+                                                nii_pd=make_sct_image(2000),
+                                                nii_t1=make_sct_image(1500),
+                                                tr_mt=0.030,
+                                                tr_pd=0.030,
+                                                tr_t1=0.015,
+                                                fa_mt=9,
+                                                fa_pd=9,
+                                                fa_t1=15
+                                                )
+        assert img_mtsat.data[0] == pytest.approx(1.5327, 0.0001)
+        assert img_t1map.data[0] == pytest.approx(0.8916, 0.0001)

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -59,14 +59,7 @@ def test_timeit(false_atexit, caplog):
 
     # At this time, the last log should be the reported time; confirm this is correct
     most_recent_log = caplog.records[-1]
-    expected_text = "Total runtime;"
-    if expected_text not in most_recent_log.message:
-        last_5_logs = caplog.records[-5:]
-        log_buffer_str = '='*80
-        recent_log_msgs = (log_buffer_str + '\n').join([x.message for x in last_5_logs])
-        pytest.fail(
-            f"SCT's final log did not have '{expected_text}'. Last {min(5, len(caplog.records))} logs were as follows:"
-            f"\n\t{recent_log_msgs}\n{log_buffer_str}")
+    assert "Total runtime;" in most_recent_log.message
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -2,6 +2,7 @@
 
 import atexit
 import logging
+import textwrap
 import time
 from collections import namedtuple
 from typing import Callable
@@ -59,7 +60,14 @@ def test_timeit(false_atexit, caplog):
 
     # At this time, the last log should be the reported time; confirm this is correct
     most_recent_log = caplog.records[-1]
-    assert "Total runtime;" in most_recent_log.message
+    expected_text = "Total runtime;"
+    if expected_text not in most_recent_log.message:
+        last_5_logs = caplog.records[-5:]
+        log_buffer_str = '='*80
+        recent_log_msgs = (log_buffer_str + '\n').join([x.message for x in last_5_logs])
+        pytest.fail(
+            f"SCT's final log did not have '{expected_text}'. Last {min(5, len(caplog.records))} logs were as follows:"
+            f"\n\t{recent_log_msgs}\n{log_buffer_str}")
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -3,14 +3,13 @@
 import atexit
 import logging
 import time
-
 from collections import namedtuple
 from typing import Callable
 
 import pytest
 
-from spinalcordtoolbox.utils import profiling, shell
-
+from spinalcordtoolbox.utils import profiling
+from spinalcordtoolbox.utils.sys import init_sct
 
 # Named tuple to keep tabs on function arguments for us, in a `atexit` like way
 fn_tuple = namedtuple('fn_tuple', ['fn', 'args', 'kwargs'])
@@ -42,19 +41,12 @@ def false_atexit(monkeypatch):
     return _return_fn
 
 
-def test_timeit_by_cli(false_atexit, caplog):
-    """Confirm our profiling flags enable profiling correctly"""
+def test_timeit(false_atexit, caplog):
+    """Confirm that our timer starts and runs correctly"""
     # Capture all log input explicitly, so that we can test that the total runtime was run correctly
     caplog.set_level(logging.INFO)
 
-    # Initiate a dummy argument parser
-    parser = shell.SCTArgumentParser(description="Time-based profiling test parser.")
-
-    # Add our common argument
-    parser.add_common_args()
-
-    # Run an "analysis" with full-program time profiling
-    parser.parse_args(['-timeit'])
+    init_sct()
 
     # Confirm the timer initialized correctly
     assert profiling.PROFILING_TIMER is not None
@@ -67,7 +59,7 @@ def test_timeit_by_cli(false_atexit, caplog):
 
     # At this time, the last log should be the reported time; confirm this is correct
     most_recent_log = caplog.records[-1]
-    assert "PROFILER:" in most_recent_log.message
+    assert "Total runtime;" in most_recent_log.message
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -63,8 +63,9 @@ def test_timeit(false_atexit, caplog):
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])
-    allowed_margin = 0.15
-    assert prog_runtime == pytest.approx(sleep_time+allowed_margin, allowed_margin)
+    allowed_margin = 0.30
+    assert prog_runtime >= sleep_time
+    assert prog_runtime < sleep_time + allowed_margin
 
     # Clean up the global time so future `init_sct` runs work correctly
     profiling.PROFILING_TIMER = None

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -2,7 +2,6 @@
 
 import atexit
 import logging
-import textwrap
 import time
 from collections import namedtuple
 from typing import Callable

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -63,7 +63,7 @@ def test_timeit(false_atexit, caplog):
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])
-    assert prog_runtime == pytest.approx(sleep_time, 0.05)
+    assert prog_runtime == pytest.approx(sleep_time, 0.25)
 
     # Clean up the global time so future `init_sct` runs work correctly
     profiling.PROFILING_TIMER = None

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -64,3 +64,6 @@ def test_timeit(false_atexit, caplog):
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])
     assert prog_runtime == pytest.approx(sleep_time, 0.05)
+
+    # Clean up the global time so future `init_sct` runs work correctly
+    profiling.PROFILING_TIMER = None

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -63,7 +63,8 @@ def test_timeit(false_atexit, caplog):
 
     # Confirm the reported runtime is ~1 second
     prog_runtime = float(most_recent_log.message.split("; ")[-1].split(' ')[0])
-    assert prog_runtime == pytest.approx(sleep_time, 0.25)
+    allowed_margin = 0.15
+    assert prog_runtime == pytest.approx(sleep_time+allowed_margin, allowed_margin)
 
     # Clean up the global time so future `init_sct` runs work correctly
     profiling.PROFILING_TIMER = None

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -156,7 +156,7 @@ def test_data_integrity(request):
     request.addfinalizer(lambda: check_testing_data_integrity(files_checksums))
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def verbose_logging():
     """
     Temporarily sets the logging state to be verbose.

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -20,7 +20,7 @@ from nibabel import Nifti1Header
 from numpy import zeros
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.sys import sct_test_path, __sct_dir__, __data_dir__
+from spinalcordtoolbox.utils.sys import sct_test_path, __sct_dir__, __data_dir__, set_loglevel
 from spinalcordtoolbox.download import install_named_dataset
 from contrib.fslhd import generate_nifti_fields, generate_numpy_fields
 
@@ -154,6 +154,22 @@ def test_data_integrity(request):
             files_checksums[fname] = chksum
 
     request.addfinalizer(lambda: check_testing_data_integrity(files_checksums))
+
+
+@pytest.fixture(scope="class")
+def verbose_logging():
+    """
+    Temporarily sets the logging state to be verbose.
+    Class scoped to allow for tests to be run together w/o repeated calls to the logger
+    """
+    # Make logging verbose
+    set_loglevel(verbose=True, caller_module_name=__name__)
+
+    # Run our tests
+    yield
+
+    # Return the logger to be non-verbose
+    set_loglevel(verbose=False, caller_module_name=__name__)
 
 
 def checksum(fname: os.PathLike) -> str:


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] ~~I've linked relevant issues in the PR body~~ Requested during internal meeting, no issue
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

As requested by @sandrinebedard, made the functionality bound to the `-timeit` flag universal and applied to all SCT commands by default. Cheers!

## Linked issues
N/A, based on internal feedback
