### PR TITLE
Retire the model `sc_t2star` from `sct_deepseg` (and move its model gallery entry)

### DIFF
--- a/documentation/source/user_section/command-line/deepseg/sc_t2star.rst
+++ b/documentation/source/user_section/command-line/deepseg/sc_t2star.rst
@@ -1,9 +1,0 @@
-
-
-sc_t2star
-=========
-
-.. argparse::
-   :ref: spinalcordtoolbox.scripts.sct_deepseg.sc_t2star
-   :prog: sct_deepseg sc_t2star
-   :markdownhelp:

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -17,9 +17,6 @@ Spinal cord
 .. |sc_epi| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/epi_bold.png
    :target: deepseg/sc_epi.html
 
-.. |sc_t2star| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/sc_t2star.png
-    :target: deepseg/sc_t2star.html
-
 .. |sc_mouse_t1| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/mouse_t1.png
    :target: deepseg/sc_mouse_t1.html
 
@@ -38,8 +35,8 @@ You can replace "``spinalcord``" with any of the task names in the table below t
    * - |spinalcord| ``spinalcord``
      - |sc_lumbar_t2| ``sc_lumbar_t2``
      - |sc_epi| ``sc_epi``
-   * - |sc_t2star| ``sc_t2star``
-     - |sc_mouse_t1| ``sc_mouse_t1``
+   * - |sc_mouse_t1| ``sc_mouse_t1``
+     -
      -
 
 Gray matter
@@ -181,15 +178,18 @@ If you absolutely require these models, you can downgrade to version of SCT list
    :align: center
    :widths: 33 33 33
 
-   * - Model
-     - Last available
-     - Superseded by
+   * - **Model**
+     - **Last available**
+     - **Superseded by**
    * - |seg_sc_ms_lesion_stir_psir| ``seg_sc_ms_lesion_stir_psir``
      - SCT Version ``6.4``
      - ``lesion_ms`` (contrast-agnostic MS lesion segmentation)
    * - |ms_sc_mp2rage| ``ms_sc_mp2rage``
      - SCT Version ``6.4``
      - ``spinalcord`` (contrast-agnostic SC segmentation)
+   * - |sc_t2star| ``sc_t2star``
+     - SCT Version ``6.5``
+     - ``spinalcord`` (contrast-agnostic SC segmentation) and ``sc_epi`` (for EPI-BOLD fMRI SC segmentation)
 
 .. toctree::
    :hidden:
@@ -198,7 +198,6 @@ If you absolutely require these models, you can downgrade to version of SCT list
    deepseg/spinalcord
    deepseg/seg_ms_sc_mp2rage
    deepseg/sc_epi
-   deepseg/sc_t2star
    deepseg/sc_mouse_t1
    deepseg/sc_lumbar_t2
    deepseg/gm_wm_exvivo_t2

--- a/documentation/source/user_section/command-line/sct_deepseg.rst
+++ b/documentation/source/user_section/command-line/sct_deepseg.rst
@@ -170,6 +170,9 @@ Retired models
 .. |ms_sc_mp2rage| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/ms_sc_mp2rage.png
    :target: deepseg/seg_ms_sc_mp2rage.html
 
+.. |sc_t2star| image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/sct_deepseg/sc_t2star.png
+    :target: deepseg/sc_t2star.html
+
 These models have been replaced by newer, more advanced models. We recommend switching to the model listed in the table below.
 
 If you absolutely require these models, you can downgrade to version of SCT listed in the table below. If you do this, please let us know on the SCT Forum so we can better understand your use-case, and potentially reinstate the model if necessary.

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -30,15 +30,6 @@ logger = logging.getLogger(__name__)
 #     2) A dict of <mirror URL lists>, where each list corresponds to a different seed (for model ensembling), and
 #        each dictionary key corresponds to the seed's name (seed names are used to create subfolders per-seed)
 MODELS = {
-    "t2star_sc": {
-        "url": [
-            "https://github.com/ivadomed/t2star_sc/releases/download/r20231004/r20231004_t2star_sc.zip",
-            "https://osf.io/8nk5w/download",
-        ],
-        "description": "Cord segmentation model on T2*-weighted contrast.",
-        "contrasts": ["t2star"],
-        "default": True,
-    },
     "mice_uqueensland_sc": {
         "url": [
             "https://github.com/ivadomed/mice_uqueensland_sc/releases/download/r20200622/r20200622_mice_uqueensland_sc.zip",
@@ -219,19 +210,6 @@ CROP_MESSAGE = (
     'resolution, for images with another resolution divide 30/your_axial_resolution.'
 )
 TASKS = {
-    'sc_t2star':
-        {'description': 'Cord segmentation on T2*-weighted contrast',
-         'long_description': 'This segmentation model for T2*w spinal cords uses the UNet architecture, and was '
-                             'created with the `ivadomed` package. A subset of a private dataset (sct_testing_large) '
-                             'was used, and consists of 236 subjects across 9 different sessions. A total of 388 pairs '
-                             'of T2* images were used (anatomical image + manual cord segmentation). The image '
-                             'properties include various orientations (superior, inferior) and crops (C1-C3, C4-C7, '
-                             'etc.). The dataset was comprised of both non-pathological (healthy) and pathological (MS '
-                             'lesion) adult patients.',
-         'url': 'https://github.com/ivadomed/t2star_sc',
-         'models': ['t2star_sc'],
-         'citation': None
-         },
     'sc_mouse_t1':
         {'description': 'Cord segmentation on mouse MRI',
          'long_description': 'This segmentation model for T1w mouse spinal cord segmentation uses the UNet '

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -38,11 +38,6 @@ def test_model_dict():
 
 
 @pytest.mark.parametrize('fname_image, fname_seg_manual, fname_out, task, thr', [
-    (sct_test_path('t2s', 't2s.nii.gz'),
-     sct_test_path('t2s', 't2s_seg-deepseg.nii.gz'),
-     't2s_seg_deepseg.nii.gz',
-     'sc_t2star',
-     0.9),
     (sct_test_path('t2', 't2.nii.gz'),
      sct_test_path('t2', 't2_seg-manual.nii.gz'),
      't2_seg_deepseg.nii.gz',


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

As discussed in the recent SCT developer meeting, the `sc_t2star` model has been rendered obsolete by the addition of the `spinalcord` contrast-agnostic model and `sc_epi` EPI-BOLD fMRI model. This PR implements that decision into SCT formally.

## Linked issues

Resolved #4800 
