### PR TITLE
Update contrast-agnostic model from v2.5 to v3.0 

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -105,9 +105,9 @@ MODELS = {
     #       - Models do not have a `.json` sidecar file, since they were not developed with ivadomed
     #       - So, threshold value is stored here, within the model dict
     #       - Binarization is applied within SCT code
-    "model_seg_sc_contrast_agnostic_softseg_nnunet": {
+    "model_seg_sc_contrast_agnostic_nnunet": {
         "url": [
-            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.5/model_contrast-agnostic_20240930-1002.zip"
+            "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v3.0/model_contrast_agnostic_20250123.zip"
         ],
         "description": "Spinal cord segmentation agnostic to MRI contrasts",
         "contrasts": ["any"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -334,7 +334,7 @@ TASKS = {
                              '[T1w, T2w, T2star, MTon_MTS, GRE_T1w, DWI, mp2rage_UNIT1, PSIR, STIR, EPI], but '
                              'other contrasts that are close visual matches may also work well with this model.',
          'url': 'https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/',
-         'models': ['model_seg_sc_contrast_agnostic_softseg_nnunet'],
+         'models': ['model_seg_sc_contrast_agnostic_nnunet'],
          'citation': textwrap.dedent("""
              ```bibtex
              @misc{bédard2024contrastagnosticsoftsegmentationspinal,

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -111,7 +111,7 @@ MODELS = {
         ],
         "description": "Spinal cord segmentation agnostic to MRI contrasts",
         "contrasts": ["any"],
-        "thr": 0.5,  # Softseg model -> threshold at 0.5
+        "thr": None,  # We're now using an nnUNet model, which does not need a threshold
         "default": False,
     },
     "model_seg_sci_multiclass_sc_lesion_nnunet": {


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

This minor PR updates the model url to point to the latest release of the contrast-agnostic model. Previous SCT PRs failing because of the tag not being found, should be resolved now! 

The full history is as follows:

- #4783 (v2.5 -> v3.1)
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/83422ffeb484cff57239b15dd49343eca23090ea (Emergency hotfix, v3.1 -> v2.5, due to deletion of v3.1)
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4843 (v2.5 -> v3.0)