### PR TITLE
Add detailed time and memory profiling for CLI scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ test.sh
 sct_course-london19/
 sct_example_data/
 
+# Profiling output
+**/*.prof
+**/time_profiler_results.txt
+**/peak_memory.txt
+**/memory_snapshots.txt
+
 # Documentation
 documentation/build
 

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -53,8 +53,8 @@ def get_parser():
         default='')
     optional.add_argument(
         '-method',
-        help="Method to use to compute the SNR (default: diff):\n"
-             "  - diff: Substract two volumes (defined by -vol) and estimate noise variance within the ROI "
+        help="Method to use to compute the SNR:\n"
+             "  - `diff`: Substract two volumes (defined by -vol) and estimate noise variance within the ROI "
              "(flag `-m` is required). Requires a 4D volume.\n"
              "  - `mult`: Estimate noise variance over time across volumes specified with `-vol`. Requires a 4D volume.\n"
              "  - `single`: Compute the mean signal in the mask specified by `-m` and estimate the noise variance in a "

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -150,6 +150,7 @@ class RepeatCallTimer(threading.Timer):
         while not self.finished.wait(self.interval):
             self.function(*self.args, **self.kwargs)
 
+
 class MemoryTracingManager:
 
     default_output = Path('memory_tracer_results.tsv')
@@ -177,6 +178,7 @@ class MemoryTracingManager:
 
         # Function to assess the current memory use
         self._start_time = time.time()
+
         def sample_memory():
             current_mem, _ = tracemalloc.get_traced_memory()
             current_kib = current_mem/1024

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -3,6 +3,7 @@ import cProfile
 import inspect
 import io
 import logging
+import os
 import pstats
 import time
 import tracemalloc
@@ -209,7 +210,9 @@ class MemoryTracingManager:
             ofp.write(f"PEAK; {traced_peak / 1024:.3f}")
 
         # Report that the file was written, and where to
-        logging.info(f"Saved memory tracing results to '{self._timed_outputs.resolve()}'.")
+        logging.info(f"Saved peak memory result to '{self._timed_outputs.resolve()}'.")
+        if self._snapshot_outputs.exists():
+            logging.info(f"Saved memory snapshot results to '{self._snapshot_outputs.resolve()}'")
 
 
 def begin_tracing_memory(out_path: Path = None):

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -148,7 +148,7 @@ class TimeProfilingAction(Action):
 # == Memory-based Profiling == #
 class MemoryTracingManager:
 
-    time_file = Path('memory_across_time.txt')
+    time_file = Path('peak_memory.txt')
     snapshot_file = Path('memory_snapshots.txt')
 
     def __init__(self, out_path=Path('.')):

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -252,15 +252,10 @@ class MemoryTracingAction(Action):
 
         # If no value as provided, set the output path to be in the current directory
         if values is None:
-            out_path = MemoryTracingManager.time_file
+            out_path = Path('.')
         else:
             # Otherwise, try to get the path associated with this parameter, and confirm its root exists
             out_path = Path(values)
-
-        # Check to see if the file exists and is a directory
-        if out_path.exists() and out_path.is_dir():
-            # If so, set the result to be saved to our default file output
-            out_path /= MemoryTracingManager.time_file
 
         # Finally, initiate the memory tracer, designating it's output file to be the user specified one
         begin_tracing_memory(out_path)

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -11,7 +11,7 @@ from argparse import Action
 from pathlib import Path
 
 
-PROFILING_TIMER = None
+GLOBAL_TIMER = None
 TIME_PROFILER = None
 MEMORY_TRACER = None
 
@@ -38,10 +38,10 @@ class Timer:
 
 def begin_global_timer():
     # Fetch the PROFILING_TIMER from the global space
-    global PROFILING_TIMER
+    global GLOBAL_TIMER
     # If it hasn't already been set, start the timer
-    if PROFILING_TIMER is None:
-        PROFILING_TIMER = Timer()
+    if GLOBAL_TIMER is None:
+        GLOBAL_TIMER = Timer()
     # Otherwise, skip and warn the user
     else:
         logging.warning(

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -179,7 +179,6 @@ class MemoryTracingManager:
             fp.writelines([str(x) + '\n' for x in mem_stats])
             fp.write('\n')
 
-
     def _finish_tracing(self):
         # Get the peak memory consumed during the program, and save it
         _, traced_peak = tracemalloc.get_traced_memory()
@@ -212,7 +211,6 @@ def begin_tracing_memory(out_path: Path = None):
 
 def snapshot_memory():
     # Return early if memory tracing is not active
-    global MEMORY_TRACER
     if MEMORY_TRACER is None:
         return
 

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -3,7 +3,6 @@ import cProfile
 import inspect
 import io
 import logging
-import os
 import pstats
 import time
 import tracemalloc

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -76,14 +76,19 @@ class TimeProfilingManager:
         self._profiler.disable()
 
         # Grab the stats, and organize them from most to least time-consuming (cumulatively)
-        io_stream = io.StringIO()
-        profiling_stats = pstats.Stats(self._profiler, stream=io_stream)
-        profiling_stats = profiling_stats.sort_stats(pstats.SortKey.CUMULATIVE)
-        profiling_stats.print_stats()
-
-        # Save the results to the desired file
-        with open(self._output_file, 'w') as out_stream:
-            out_stream.write(io_stream.getvalue())
+        if self._output_file.suffix == '.prof':
+            # If we want binary profiler output, dump the stats to file with the built-in
+            profiling_stats = pstats.Stats(self._profiler)
+            profiling_stats = profiling_stats.sort_stats(pstats.SortKey.CUMULATIVE)
+            profiling_stats.dump_stats(self._output_file)
+        else:
+            # Otherwise, dump the stats in a human-readable format
+            io_stream = io.StringIO()
+            profiling_stats = pstats.Stats(self._profiler, stream=io_stream)
+            profiling_stats = profiling_stats.sort_stats(pstats.SortKey.CUMULATIVE)
+            profiling_stats.print_stats()
+            with open(self._output_file, 'w') as out_stream:
+                out_stream.write(io_stream.getvalue())
 
         # Report that the file was written, and where to
         logging.info(f"Saved time profiling results to '{self._output_file.resolve()}'.")

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -153,7 +153,7 @@ class RepeatCallTimer(threading.Timer):
 
 class MemoryTracingManager:
 
-    default_output = Path('memory_tracer_results.tsv')
+    default_output = Path('memory_tracer_results.txt')
     default_interval = .1
 
     def __init__(self, out_file=None, interval=default_interval):
@@ -208,10 +208,9 @@ class MemoryTracingManager:
         header = f"=== {label} ===\n"
 
         # Save the stats to file with this header
-        with open(self._output_file, 'a') as fp:
-            fp.write(header)
-            fp.writelines([str(x) + '\n' for x in mem_stats])
-            fp.write('\n')
+        self._open_output.write(header)
+        self._open_output.writelines([str(x) + '\n' for x in mem_stats])
+        self._open_output.write('\n')
 
     def _finish_tracing(self):
         # End the non-blocking timer to prevent any race conditions

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 PROFILING_TIMER = None
 TIME_PROFILER = None
-MEMORY_PROFILER = None
+MEMORY_TRACER = None
 
 
 # == Time-based Profiling == #
@@ -137,9 +137,9 @@ class TimeProfilingAction(Action):
 
 
 # == Memory-based Profiling == #
-class MemoryProfilingManager:
+class MemoryTracingManager:
 
-    default_output = Path('./memory_profiler_results.txt')
+    default_output = Path('./memory_tracer_results.txt')
 
     def __init__(self, out_file=None):
         # Initialize and enable the profiler
@@ -150,14 +150,14 @@ class MemoryProfilingManager:
         else:
             self._output_file = self.default_output
         # Ensure the profiler completes its runtime at program exit
-        atexit.register(self._finish_profiling)
+        atexit.register(self._finish_tracing)
 
     def __del__(self):
         # If the profiler is deleted explicitly, just clean up without reporting anything
-        atexit.unregister(self._finish_profiling)
+        atexit.unregister(self._finish_tracing)
         tracemalloc.stop()
 
-    def _finish_profiling(self):
+    def _finish_tracing(self):
         # Get the peak memory consumed during the program, and save it
         _, traced_peak = tracemalloc.get_traced_memory()
 
@@ -169,16 +169,16 @@ class MemoryProfilingManager:
             fp.write(f"PEAK MEMORY USE; {traced_peak} KiB")
 
         # Report that the file was written, and where to
-        logging.info(f"Saved memory profiling results to '{self._output_file.resolve()}'.")
+        logging.info(f"Saved memory tracing results to '{self._output_file.resolve()}'.")
 
 
-def begin_profiling_memory(out_path: Path = None):
+def begin_tracing_memory(out_path: Path = None):
     # Fetch the MEMORY_PROFILER from the global space
-    global MEMORY_PROFILER
+    global MEMORY_TRACER
     # If it hasn't already been set, initiate and set up the profiler
-    if MEMORY_PROFILER is None:
+    if MEMORY_TRACER is None:
         # Initialize the profiler
-        MEMORY_PROFILER = MemoryProfilingManager(out_path)
+        MEMORY_TRACER = MemoryTracingManager(out_path)
     # Otherwise, skip and warn the user
     else:
         logging.warning(

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -4,7 +4,6 @@ import inspect
 import io
 import logging
 import pstats
-import threading
 import time
 import tracemalloc
 

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -76,9 +76,12 @@ class TimeProfilingManager:
         # Finish profiling
         self._profiler.disable()
 
+        # Ensure the parent folder for the output exists before trying to save it
+        self._output_file.parent.mkdir(exist_ok=True, parents=True)
+
         # Grab the stats, and organize them from most to least time-consuming (cumulatively)
         if self._output_file.suffix == '.prof':
-            # If we want binary profiler output, dump the stats to file with the built-in
+            # If we want binary profiler output, dump the stats to file with the built-in `dump_stats` method
             profiling_stats = pstats.Stats(self._profiler)
             profiling_stats = profiling_stats.sort_stats(pstats.SortKey.CUMULATIVE)
             profiling_stats.dump_stats(self._output_file)

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -189,7 +189,7 @@ class MemoryTracingManager:
 
         # Save the peak results to the output file
         with open(self._output_file, 'a') as fp:
-            fp.write(f"PEAK MEMORY USE; {traced_peak} KiB")
+            fp.write(f"PEAK MEMORY USE; {traced_peak / 1024:.3f} KiB")
 
         # Report that the file was written, and where to
         logging.info(f"Saved memory tracing results to '{self._output_file.resolve()}'.")

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -139,7 +139,7 @@ class TimeProfilingAction(Action):
 # == Memory-based Profiling == #
 class MemoryTracingManager:
 
-    default_output = Path('./memory_tracer_results.txt')
+    default_output = Path('memory_tracer_results.txt')
 
     def __init__(self, out_file=None):
         # Initialize and enable the profiler
@@ -185,3 +185,33 @@ def begin_tracing_memory(out_path: Path = None):
             "Tried to start the memory profiler twice; you should leave generally leave this to be handled by the CLI, "
             "rather than calling 'begin_profiling_memory' directly!"
         )
+
+
+class MemoryTracingAction(Action):
+    """
+    ArgParse action, which initialized the memory tracer when the argument is present.
+
+    The user can specify either the output directory or file, if they want the results saved somewhere specific.
+    If not, the file will be saved in the current working directory (unless the 'const' is explicitly set otherwise)
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        # If the length of the values provided is greater than 1, raise an error
+        if values is not None and not isinstance(values, str) and len(values) > 1:
+            raise ValueError("Only one output file can be specified for profiler outputs!")
+
+        # If no value as provided, set the output path to be in the current directory
+        if values is None:
+            out_path = MemoryTracingManager.default_output
+        else:
+            # Otherwise, try to get the path associated with this parameter, and confirm its root exists
+            out_path = Path(values)
+
+        # Check to see if the file exists and is a directory
+        if out_path.exists() and out_path.is_dir():
+            # If so, set the result to be saved to our default file output
+            out_path /= MemoryTracingManager.default_output
+
+        # Finally, initiate the memory tracer, designating it's output file to be the user specified one
+        begin_tracing_memory(out_path)
+
+        setattr(namespace, self.dest, out_path)

--- a/spinalcordtoolbox/utils/profiling.py
+++ b/spinalcordtoolbox/utils/profiling.py
@@ -1,12 +1,22 @@
 import atexit
+import cProfile
+import io
 import logging
+import pstats
 import time
 
+from pathlib import Path
+
+
 PROFILING_TIMER = None
+TIME_PROFILER = None
 
 
-# Wrapper class which manages our profiling timer
+# == Time-based Profiling == #
 class Timer:
+    """
+    Wrapper class which manages our total runtime timer
+    """
     def __init__(self):
         self._t0 = time.time()
         atexit.register(self.stop)
@@ -33,4 +43,55 @@ def begin_global_timer():
         logging.warning(
             "Tried to start the global profiling timer twice; you should leave generally leave this initialization to "
             "SCT itself, rather than calling 'begin_global_timer' explicitly!"
+        )
+
+
+class TimeProfilingManager:
+
+    default_output = Path('./time_profiler_results.txt')
+
+    def __init__(self, out_file=None):
+        # Initialize and enable the profiler
+        self._profiler = cProfile.Profile()
+        self._profiler.enable()
+        # Track the output file, if it was provided
+        if out_file is not None:
+            self._output_file = out_file
+        else:
+            self._output_file = self.default_output
+        # Ensure the profiler completes its runtime at program exit
+        atexit.register(self._finish_profiling)
+
+    def __del__(self):
+        # If the profiler is deleted explicitly, just clean up without reporting anything
+        atexit.unregister(self._finish_profiling)
+        self._profiler.disable()
+
+    def _finish_profiling(self):
+        # Finish profiling
+        self._profiler.disable()
+
+        # Grab the stats, and organize them from most to least time-consuming (cumulatively)
+        io_stream = io.StringIO()
+        profiling_stats = pstats.Stats(self._profiler, stream=io_stream)
+        profiling_stats = profiling_stats.sort_stats(pstats.SortKey.CUMULATIVE)
+        profiling_stats.print_stats()
+
+        # Save the results to the desired file
+        with open(self._output_file, 'w') as out_stream:
+            out_stream.write(io_stream.getvalue())
+
+
+def begin_profiling_time(out_path: Path = None):
+    # Fetch the PROFILING_TIMER from the global space
+    global TIME_PROFILER
+    # If it hasn't already been set, initiate and set up the profiler
+    if TIME_PROFILER is None:
+        # Initialize the profiler
+        TIME_PROFILER = TimeProfilingManager(out_path)
+    # Otherwise, skip and warn the user
+    else:
+        logging.warning(
+            "Tried to start the time profiler twice; you should leave generally leave this to be handled by the CLI, "
+            "rather than calling 'begin_profiling_time' directly!"
         )

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -305,23 +305,30 @@ class SCTArgumentParser(argparse.ArgumentParser):
             nargs='?',
             metavar=Metavar.file,
             action=TimeProfilingAction,
-            help="Enables time-based profiling of the program, dumping the results to the specified file. "
-                 "If no file is specified, the results are placed into a 'time_profiling_results.txt' document in the "
-                 "current directory. If the specified file is a `.prof` file, the file will be in binary format, "
-                 "ready for use with common post-profiler utilities (such as `snakeviz`)."
+            help="Enables time-based profiling of the program, dumping the results to the specified file.\n"
+                 "\n"
+                 "If no file is specified, human-readable results are placed into a 'time_profiling_results.txt' "
+                 f"document in the current directory ('{os.getcwd()}'). If the specified file is a `.prof` file, the "
+                 "file will instead be in binary format, ready for use with common post-profiler utilities (such as "
+                 "`snakeviz`)."
         )
         arg_group.add_argument(
             '-trace-memory',
             nargs='?',
-            metavar=Metavar.file,
+            metavar=Metavar.folder,
             action=MemoryTracingAction,
-            help="Enables memory tracing of the program, dumping the results to the specified directory. "
-                 "If no directory is specified, the results are placed into the current directory."
-                 "When active, two files can be produced: `memory_across_time.tsv`, which tracks the memory used "
-                 "over time in the program (sampled every 10th of a second), and `memory_snapshots.txt`, which tracks "
-                 "the memory trace at any point within the program which has a `snapshot_memory` call."
+            help="Enables memory tracing of the program.\n"
+                 "\n"
+                 "When active, a measure of the peak memory (in KiB) will be output to the file `peak_memory.txt`. "
+                 "Optionally, developers can also modify the SCT code to add additional `snapshot_memory()` calls. "
+                 "These calls will 'snapshot' the memory usage at that moment, saving the memory trace at that point "
+                 "into a second file (`memory_snapshots.txt`).\n"
+                 "\n"
+                 f"By default, both outputs will be placed in the current directory ('{os.getcwd()}'). Optionally, you "
+                 "may provide an alternative directory (`-trace-memory <dir_name>`), in which case all files will "
+                 "be placed in that directory instead.\n"
                  "Note that this WILL incur an overhead to runtime, so it is generally advised that you do not run "
-                 "this in conjunction with the time profiler."
+                 "this in conjunction with the time profiler or in time-sensitive contexts."
         )
 
         # Return the arg_group to allow for chained operations

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -307,7 +307,8 @@ class SCTArgumentParser(argparse.ArgumentParser):
             action=TimeProfilingAction,
             help="Enables time-based profiling of the program, dumping the results to the specified file. "
                  "If no file is specified, the results are placed into a 'time_profiling_results.txt' document in the "
-                 "current directory."
+                 "current directory. If the specified file is a `.prof` file, the file will be in binary format, "
+                 "ready for use with common post-profiler utilities (such as `snakeviz`)."
         )
         arg_group.add_argument(
             '-trace-memory',

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -18,7 +18,7 @@ from functools import cached_property, partial
 
 from .sys import check_exe, printv, removesuffix, ANSIColors16
 from .fs import relpath_or_abspath
-from .profiling import TimeProfilingAction
+from .profiling import TimeProfilingAction, MemoryTracingAction
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +307,15 @@ class SCTArgumentParser(argparse.ArgumentParser):
             action=TimeProfilingAction,
             help="Enables time-based profiling of the program, dumping the results to the specified file. "
                  "If no file is specified, the results are placed into a 'time_profiling_results.txt' document in the "
+                 "current directory."
+        )
+        arg_group.add_argument(
+            '-trace-memory',
+            nargs='?',
+            metavar=Metavar.file,
+            action=MemoryTracingAction,
+            help="Enables memory tracing of the program, dumping the results to the specified file. "
+                 "If no file is specified, the results are placed into a 'memory_tracer_results.txt' document in the "
                  "current directory."
         )
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -18,6 +18,7 @@ from functools import cached_property, partial
 
 from .sys import check_exe, printv, removesuffix, ANSIColors16
 from .fs import relpath_or_abspath
+from .profiling import TimeProfilingAction
 
 logger = logging.getLogger(__name__)
 
@@ -296,6 +297,17 @@ class SCTArgumentParser(argparse.ArgumentParser):
             default=1,
             # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
             help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode."
+        )
+
+        # Add a flag which allows time-based profiling the profiler
+        arg_group.add_argument(
+            '-profile-time',
+            nargs='?',
+            metavar=Metavar.file,
+            action=TimeProfilingAction,
+            help="Enables time-based profiling of the program, dumping the results to the specified file. "
+                 "If no file is specified, the results are placed into a 'time_profiling_results.txt' document in the "
+                 "current directory."
         )
 
         # Return the arg_group to allow for chained operations

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -316,8 +316,9 @@ class SCTArgumentParser(argparse.ArgumentParser):
             metavar=Metavar.file,
             action=MemoryTracingAction,
             help="Enables memory tracing of the program, dumping the results to the specified file. "
-                 "If no file is specified, the results are placed into a 'memory_tracer_results.txt' document in the "
-                 "current directory."
+                 "If no file is specified, the results are placed into a 'memory_tracer_results.tsv' document in the "
+                 "current directory. Not that this WILL incur an overhead to runtime, as the profiler samples memory "
+                 "use within the program every tenth of a second."
         )
 
         # Return the arg_group to allow for chained operations

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -316,7 +316,7 @@ class SCTArgumentParser(argparse.ArgumentParser):
     def add_tempfile_args(self, arg_group=None):
         """
         Adds a single argument:
-            -r: The help flag. If present, denotes that temporary files should be removed after the program ends.
+            -r: The remove_temp flag. If present, denotes that temporary files should be removed after the program ends.
 
         If no argument group is provided, the arguments are placed into the "MISC" argument group
         """

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -315,10 +315,13 @@ class SCTArgumentParser(argparse.ArgumentParser):
             nargs='?',
             metavar=Metavar.file,
             action=MemoryTracingAction,
-            help="Enables memory tracing of the program, dumping the results to the specified file. "
-                 "If no file is specified, the results are placed into a 'memory_tracer_results.tsv' document in the "
-                 "current directory. Not that this WILL incur an overhead to runtime, as the profiler samples memory "
-                 "use within the program every tenth of a second."
+            help="Enables memory tracing of the program, dumping the results to the specified directory. "
+                 "If no directory is specified, the results are placed into the current directory."
+                 "When active, two files can be produced: `memory_across_time.tsv`, which tracks the memory used "
+                 "over time in the program (sampled every 10th of a second), and `memory_snapshots.txt`, which tracks "
+                 "the memory trace at any point within the program which has a `snapshot_memory` call."
+                 "Note that this WILL incur an overhead to runtime, so it is generally advised that you do not run "
+                 "this in conjunction with the time profiler."
         )
 
         # Return the arg_group to allow for chained operations

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -281,10 +281,19 @@ def test_memory_snapshot(false_atexit, tmp_path):
     false_atexit()
 
     # Confirm that the memory tracer saved the snapshot correctly
+    found_snapshot = False
     with open(out_path, 'r') as fp:
-        first_line = fp.readline()
-        # We don't test for the exact line, as it is prone to being changed
-        assert "test_memory_snapshot (test_utils_profiling.py, line " in first_line
+        # See if any line has our snapshot header; which line can change from run to run, unfortunately
+        for l in fp.readlines():
+            # We don't test for the exact line, as it is prone to being changed
+            print(l)
+            if "test_memory_snapshot (test_utils_profiling.py, line " in l:
+                found_snapshot = True
+                break
+
+    if not found_snapshot:
+        pytest.fail("No snapshot was captured during the test, despite a snapshot call being made!")
+
 
 
 def test_cli_memory_tracer(false_atexit, tmp_path):

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -50,7 +50,7 @@ def test_timeit(false_atexit, caplog):
     init_sct()
 
     # Confirm the timer initialized correctly
-    assert profiling.PROFILING_TIMER is not None
+    assert profiling.GLOBAL_TIMER is not None
 
     # Wait 1 second to give us some "time" to actually measure
     sleep_time = 1
@@ -69,7 +69,7 @@ def test_timeit(false_atexit, caplog):
     assert prog_runtime < sleep_time + allowed_margin
 
     # Clean up the global time so future `init_sct` runs work correctly
-    profiling.PROFILING_TIMER = None
+    profiling.GLOBAL_TIMER = None
 
 
 def test_time_profiler(false_atexit, tmp_path):

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -92,7 +92,7 @@ def test_time_profiler(false_atexit, tmp_path):
         logging.info(f"{i}: {num}")
 
     for i in range(no_calls):
-        num = i * (i + 1)
+        num = i * (i-1)
         logging.info(f"{i}: {num}")
 
     total_calls = no_calls*2

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -166,14 +166,9 @@ def test_time_profiler_prof_out(false_atexit, tmp_path):
 
     # Confirm the file is in the correct binary format and references the recursive call
     with open(out_path, 'rb') as ofp:
-        # Get the "lead" of the file
-        part1 = ofp.read(4)
-        # Confirm it matches the signature of a .prof file
-        assert part1 == b'\xfb\xa9\x03\xda'
-
-        # Get the rest of the "binary chunk" to see if it tracked the recursive call
-        part2 = ofp.read(1020)
-        assert b"tmp_recurse" in part2
+        # Read the file in binary, and confirm the `tmp_recurse` function is in the first chunk
+        part = ofp.read(1024)
+        assert b"tmp_recurse" in part
 
 
 def test_cli_time_profiling(false_atexit, tmp_path):

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -2,7 +2,6 @@
 
 import atexit
 import logging
-import re
 import time
 from collections import namedtuple
 from typing import Callable

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -221,7 +221,7 @@ def test_memory_snapshot(false_atexit, tmp_path):
 
     # Generate a gigantic list with a ton of integers (which are each 16 bits, or one byte)
     n_numbers = 1000000
-    big_list = list(range(n_numbers))
+    big_list = list(range(n_numbers))  # noqa: F841 (necessary evil to prevent garbage collection messing w/ test)
 
     # Snapshot the memory, which should update the output
     profiling.snapshot_memory()

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -166,6 +166,9 @@ def test_memory_profiler(false_atexit, tmp_path):
     # Initiate time profiling directly
     profiling.begin_profiling_memory(out_path)
 
+    # Confirm the memory profiler was initialized
+    assert profiling.MEMORY_PROFILER is not None
+
     # Generate a gigantic list with a ton of integers (which are each 16 bits, or one byte)
     n_numbers = 1000000
     big_list = list(range(n_numbers))
@@ -183,10 +186,14 @@ def test_memory_profiler(false_atexit, tmp_path):
     # "End" the program
     false_atexit()
 
+    # Confirm that profiling has ceased at this point
+    import tracemalloc
+    assert not tracemalloc.is_tracing()
+
     # Confirm the output file now exists
     assert out_path.exists()
 
-    # Confirm that the last line in the file is the peak memory use
+    # Confirm that the last line in the output file is the peak memory use
     with open(out_path, 'r') as fp:
         last_line = [l for l in fp.readlines()][-1]
 

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -215,14 +215,8 @@ def test_memory_tracer(false_atexit, tmp_path):
     n_numbers = 1000000
     big_list = list(range(n_numbers))
 
-    # Wait for a bit so the memory profiler can sample at this point
-    time.sleep(.1)
-
     # Explicit delete the big list to ensure the reported peak was still measured correctly
     del big_list
-
-    # Wait another second for sampling
-    time.sleep(.1)
 
     # Calculate the minimum amount of memory this should have required, account for pointers as well;
     #   n ints
@@ -241,19 +235,9 @@ def test_memory_tracer(false_atexit, tmp_path):
     # Confirm the output file now exists
     assert out_file.exists()
 
-    # Get some samples to ensure the file is formatted correctly
+    # Get the last line in the file
     with open(out_file, 'r') as fp:
-        first_line = fp.readline()
-        second_line = fp.readline()
         last_line = [x for x in fp.readlines()][-1]
-
-    # Confirm the first line matches out header
-    assert first_line == "Time (s)\tMemory (KiB)\n"
-
-    # Confirm the second line is formatted correctly
-    assert '\t' in second_line
-    # Pattern is looking for two floating point values with 3 decimal places, separated by a tab
-    assert re.match(r"\d{1,}\.\d{1,3}\t\d{1,}\.\d{1,3}", second_line)
 
     # Confirm the last line is correct
     assert "PEAK" in last_line

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -163,7 +163,7 @@ def test_memory_tracer(false_atexit, tmp_path):
     # For sanity's sake, ensure the file does not already exist yet
     assert not out_path.exists()
 
-    # Initiate time profiling directly
+    # Initiate memory tracing directly
     profiling.begin_tracing_memory(out_path)
 
     # Confirm the memory profiler was initialized
@@ -205,6 +205,35 @@ def test_memory_tracer(false_atexit, tmp_path):
     profiling.MEMORY_TRACER = None
 
 
+def test_memory_snapshot(false_atexit, tmp_path):
+    # Generate a path we want to save the results too
+    out_path = tmp_path / "pytest_memory_snapshot.txt"
+
+    # For sanity's sake, ensure the file does not already exist yet
+    assert not out_path.exists()
+
+    # Initiate memory tracing directly
+    profiling.begin_tracing_memory(out_path)
+
+    # Generate a gigantic list with a ton of integers (which are each 16 bits, or one byte)
+    n_numbers = 1000000
+    big_list = list(range(n_numbers))
+
+    # Snapshot the memory, which should update the output
+    profiling.snapshot_memory()
+
+    # "End" the program
+    false_atexit()
+
+    # Confirm that the memory tracer saved the snapshot correctly
+    with open(out_path, 'r') as fp:
+        first_line = fp.readline()
+        assert "test_memory_snapshot (test_utils_profiling.py, line 223)" in first_line
+
+    # Clean up our global changes
+    profiling.MEMORY_TRACER = None
+
+
 def test_cli_memory_tracer(false_atexit, tmp_path):
     # Generate a path we want to save the results too
     out_path = tmp_path / "pytest_memory_traced.txt"
@@ -228,4 +257,3 @@ def test_cli_memory_tracer(false_atexit, tmp_path):
 
     # Clean up our global changes
     profiling.MEMORY_TRACER = None
-

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -304,6 +304,5 @@ def test_cli_memory_tracer(false_atexit, tmp_path):
     assert profiling.MEMORY_TRACER is not None
 
     # Confirm that it writes a file on exit, but not before
-    assert not out_path.exists()
     false_atexit()
     assert out_path.exists()

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -156,18 +156,18 @@ def test_cli_arguments_present(false_atexit, tmp_path):
     profiling.TIME_PROFILER = None
 
 
-def test_memory_profiler(false_atexit, tmp_path):
+def test_memory_tracer(false_atexit, tmp_path):
     # Generate a path we want to save the results too
-    out_path = tmp_path / "pytest_memory_profiled.txt"
+    out_path = tmp_path / "pytest_memory_traced.txt"
 
     # For sanity's sake, ensure the file does not already exist yet
     assert not out_path.exists()
 
     # Initiate time profiling directly
-    profiling.begin_profiling_memory(out_path)
+    profiling.begin_tracing_memory(out_path)
 
     # Confirm the memory profiler was initialized
-    assert profiling.MEMORY_PROFILER is not None
+    assert profiling.MEMORY_TRACER is not None
 
     # Generate a gigantic list with a ton of integers (which are each 16 bits, or one byte)
     n_numbers = 1000000

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -49,14 +49,17 @@ def cleanup_globals():
     yield
 
     # Once the fixture is done being "used", clean up the global space
-    del profiling.GLOBAL_TIMER
-    profiling.GLOBAL_TIMER = None
+    if profiling.GLOBAL_TIMER is not None:
+        profiling.GLOBAL_TIMER.__del__()
+        profiling.GLOBAL_TIMER = None
 
-    del profiling.TIME_PROFILER
-    profiling.TIME_PROFILER = None
+    if profiling.TIME_PROFILER is not None:
+        profiling.TIME_PROFILER.__del__()
+        profiling.TIME_PROFILER = None
 
-    del profiling.MEMORY_TRACER
-    profiling.MEMORY_TRACER = None
+    if profiling.MEMORY_TRACER is not None:
+        profiling.MEMORY_TRACER.__del__()
+        profiling.MEMORY_TRACER = None
 
 
 def test_timeit(false_atexit, caplog):

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -141,6 +141,41 @@ def test_time_profiler(false_atexit, tmp_path):
         assert float(cval1) >= float(cval2)
 
 
+def test_time_profiler_prof_out(false_atexit, tmp_path):
+    # Generate a path we want to save the results too, with a .prof extension
+    out_path = tmp_path / "pytest_time_profiled.prof"
+
+    # Initiate time profiling directly
+    profiling.begin_profiling_time(out_path)
+
+    # Run a recursive loop
+    def tmp_recurse(i: int):
+        if i > 0:
+            tmp_recurse(i-1)
+
+    # Run a short loop
+    no_calls = 100
+    tmp_recurse(no_calls)
+
+    # "End" the program
+    false_atexit()
+
+    # Confirm the output file was created, and that it has the correct extension
+    assert out_path.exists()
+    assert out_path.suffix == '.prof'
+
+    # Confirm the file is in the correct binary format and references the recursive call
+    with open(out_path, 'rb') as ofp:
+        # Get the "lead" of the file
+        part1 = ofp.read(4)
+        # Confirm it matches the signature of a .prof file
+        assert part1 == b'\xfb\xa9\x03\xda'
+
+        # Get the rest of the "binary chunk" to see if it tracked the recursive call
+        part2 = ofp.read(1020)
+        assert b"tmp_recurse" in part2
+
+
 def test_cli_time_profiling(false_atexit, tmp_path):
     # Generate a path we want to save the results too
     out_path = tmp_path / "pytest_time_profiled.txt"

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -199,7 +199,7 @@ def test_memory_tracer(false_atexit, tmp_path):
 
     assert "PEAK MEMORY USE" in last_line
     recorded_mem_kib = float(last_line.split('; ')[-1].split(' ')[0])
-    assert recorded_mem_kib > min_n_bits
+    assert recorded_mem_kib > (min_n_bits / 1024)
 
     # Clean up our memory profiler
     profiling.MEMORY_TRACER = None

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -195,7 +195,7 @@ def test_memory_profiler(false_atexit, tmp_path):
 
     # Confirm that the last line in the output file is the peak memory use
     with open(out_path, 'r') as fp:
-        last_line = [l for l in fp.readlines()][-1]
+        last_line = [x for x in fp.readlines()][-1]
 
     assert "PEAK MEMORY USE" in last_line
     recorded_mem_kib = float(last_line.split('; ')[-1].split(' ')[0])

--- a/testing/api/test_utils_profiling.py
+++ b/testing/api/test_utils_profiling.py
@@ -131,7 +131,7 @@ def test_time_profiler(false_atexit, tmp_path):
     profiling.TIME_PROFILER = None
 
 
-def test_cli_arguments_present(false_atexit, tmp_path):
+def test_cli_time_profiling(false_atexit, tmp_path):
     # Generate a path we want to save the results too
     out_path = tmp_path / "pytest_time_profiled.txt"
 
@@ -200,3 +200,32 @@ def test_memory_tracer(false_atexit, tmp_path):
     assert "PEAK MEMORY USE" in last_line
     recorded_mem_kib = float(last_line.split('; ')[-1].split(' ')[0])
     assert recorded_mem_kib > min_n_bits
+
+    # Clean up our memory profiler
+    profiling.MEMORY_TRACER = None
+
+
+def test_cli_memory_tracer(false_atexit, tmp_path):
+    # Generate a path we want to save the results too
+    out_path = tmp_path / "pytest_memory_traced.txt"
+
+    # Generate a "dummy" parser with the common command-line arguments
+    dummy_parser = SCTArgumentParser(
+        description="A dummy parser for PyTest profiling tests"
+    )
+    dummy_parser.add_common_args()
+
+    # Parse some arguments using it
+    dummy_parser.parse_args(["-trace-memory", str(out_path)])
+
+    # Confirm the time profiler was initialized
+    assert profiling.MEMORY_TRACER is not None
+
+    # Confirm that it writes a file on exit, but not before
+    assert not out_path.exists()
+    false_atexit()
+    assert out_path.exists()
+
+    # Clean up our global changes
+    profiling.MEMORY_TRACER = None
+


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [x] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

As discussed in #4795, we've been meaning to add methods of empirically evaluated SCT's runtime performance for a while. This PR adds two new faculties to accomplish this implicitly:

### Time-Based Profiling

When activated through the command-line (by adding the `-profile-time` argument), the total runtime inside each call made in the program is tracked. Once the program terminates, the total results are placed in an output file for later review. By default, this file is named `time_profiler_results.txt`, but the user can provide an alternative path after the argument if they wish to save it elsewhere.


### Memory-Based Tracing

When activated through the command-line (by adding the `-trace-memory` argument), memory tracing functionality is activated. This does two things by default:

1. The ability to "snapshot" the memory state of the program becomes available via the `profiling.snapshot_memory` function. As the name implies, calling this function will snapshot the state of memory at that moment, and save it to a results file. 
1. As the program runs, the peak memory use (in bits) is tracked, and upon program termination saved to a the same file for reference.

Similarly to the `-profile-time` function, the output file will be saved to `memory_trace_results.txt` unless otherwise specified by the user.

### Other Notes:

The `snapshot_memory` call needs to be made explicitly within the code-base, **by the programmer**, either during debugging or assessment. To account for this, it acts similar to a "debug" logging call; if memory tracing is not active, the call is ignored entirely (with a negligible effect on runtime).

Both profilers _will_ impact the runtime and memory traces slightly in and of themselves, though this impact is very minimal. Nevertheless, this should be kept in mind when making conclusions about the program's efficiency! 

## Linked issues

Step towards resolving #4795
