### PR TITLE
Fix slice indexing for `-angle-corr-centerline`

### DIFF
--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -94,8 +94,8 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
                 dx, dy = deriv[iz]
             except KeyError:
                 raise ValueError(f"The provided angle correction centerline does not cover slice {iz} of "
-                                 "the input mask. Please supply a more extensive -angle-corr-centerline, "
-                                 "or set -angle-corr to 0.") from None
+                                 "the input mask. Please supply a more extensive '-angle-corr-centerline', "
+                                 "or disable angle correction ('-angle-corr 0').") from None
             # Extract tangent vector to the centerline (i.e. its derivative)
             tangent_vect = np.array([dx * px, dy * py, pz])
             # Compute the angle about AP axis between the centerline and the normal vector to the slice

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -101,13 +101,9 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
             # Normalize vector by its L2 norm
             tangent_vect = tangent_vect / np.linalg.norm(tangent_vect)
             # Compute the angle about AP axis between the centerline and the normal vector to the slice
-            v0 = [tangent_vect[0], tangent_vect[2]]
-            v1 = [0, 1]
-            angle_AP_rad = math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
+            angle_AP_rad = math.atan2(tangent_vect[0], tangent_vect[2])
             # Compute the angle about RL axis between the centerline and the normal vector to the slice
-            v0 = [tangent_vect[1], tangent_vect[2]]
-            v1 = [0, 1]
-            angle_RL_rad = math.atan2(np.linalg.det([v0, v1]), np.dot(v0, v1))
+            angle_RL_rad = math.atan2(tangent_vect[1], tangent_vect[2])
             # Apply affine transformation to account for the angle between the centerline and the normal to the patch
             tform = transform.AffineTransform(scale=(np.cos(angle_RL_rad), np.cos(angle_AP_rad)))
             # Convert to float64, to avoid problems in image indexation causing issues when applying transform.warp

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -65,7 +65,7 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
     min_z_index, max_z_index = min(Z), max(Z)
 
     # Initialize dictionary of property_list, with 1d array of nan (default value if no property for a given slice).
-    shape_properties = {key: np.full_like(np.empty(nz), np.nan, dtype=np.double) for key in property_list}
+    shape_properties = {key: np.full(nz, np.nan, dtype=np.double) for key in property_list}
 
     fit_results = None
 

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -80,6 +80,9 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
         # compute the spinal cord centerline based on the spinal cord segmentation
         _, arr_ctl, arr_ctl_der, fit_results = get_centerline(im_centerline_r, param=param_centerline, verbose=verbose,
                                                               remove_temp_files=remove_temp_files)
+        # the third column of `arr_ctl` contains the integer slice numbers, and the first two
+        # columns of `arr_ctl_der` contain the x and y components of the centerline derivative
+        deriv = {int(z_ref): arr_ctl_der[:2, index] for index, z_ref in enumerate(arr_ctl[2])}
 
     # Loop across z and compute shape analysis
     for iz in sct_progress_bar(range(min_z_index, max_z_index + 1), unit='iter', unit_scale=False, desc="Compute shape analysis",
@@ -87,10 +90,14 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
         # Extract 2D patch
         current_patch = im_segr.data[:, :, iz]
         if angle_correction:
+            try:
+                dx, dy = deriv[iz]
+            except KeyError:
+                raise ValueError(f"The provided angle correction centerline does not cover slice {iz} of "
+                                 "the input mask. Please supply a more extensive -angle-corr-centerline, "
+                                 "or set -angle-corr to 0.") from None
             # Extract tangent vector to the centerline (i.e. its derivative)
-            tangent_vect = np.array([arr_ctl_der[0][iz - min_z_index] * px,
-                                     arr_ctl_der[1][iz - min_z_index] * py,
-                                     pz])
+            tangent_vect = np.array([dx * px, dy * py, pz])
             # Normalize vector by its L2 norm
             tangent_vect = tangent_vect / np.linalg.norm(tangent_vect)
             # Compute the angle about AP axis between the centerline and the normal vector to the slice

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -78,7 +78,6 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
         else:
             im_centerline_r = im_segr
         # compute the spinal cord centerline based on the spinal cord segmentation
-        # here, param_centerline.minmax needs to be False because we need to retrieve the total number of input slices
         _, arr_ctl, arr_ctl_der, fit_results = get_centerline(im_centerline_r, param=param_centerline, verbose=verbose,
                                                               remove_temp_files=remove_temp_files)
 

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -98,8 +98,6 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
                                  "or set -angle-corr to 0.") from None
             # Extract tangent vector to the centerline (i.e. its derivative)
             tangent_vect = np.array([dx * px, dy * py, pz])
-            # Normalize vector by its L2 norm
-            tangent_vect = tangent_vect / np.linalg.norm(tangent_vect)
             # Compute the angle about AP axis between the centerline and the normal vector to the slice
             angle_AP_rad = math.atan2(tangent_vect[0], tangent_vect[2])
             # Compute the angle about RL axis between the centerline and the normal vector to the slice


### PR DESCRIPTION
Fixes #4807.

If the input mask supplied in `-i` and the custom centerline supplied in `-angle-corr-centerline` did not start at the same lowest SI slice, then the wrong slice index was used for angle correction.

With the proposed code, everything is indexed directly with SI slice numbers, rather than trying to do relative indexing. A quick manual test using the data from #4807 shows that this fixes the problem: for the slices which appear in both CSVs, they have the same `angle_AP` and `angle_RL`.

If the `-angle-corr-centerline` is too short, there's now an error message to explain the situation:

![image](https://github.com/user-attachments/assets/9c35197e-7912-4c69-9e56-7b8ef04e42c7)