### PR TITLE
Temporarily test branch `jv/33-remove_pixels_outside_of_cord`

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -66,7 +66,7 @@ DATASET_DICT = {
     },
     "PAM50": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/PAM50/releases/download/r20250109/PAM50-r20250109.zip",
+            "https://github.com/spinalcordtoolbox/PAM50/archive/refs/heads/jv/33-remove_pixels_outside_of_cord.zip",
             "https://osf.io/nkqtx/?action=download",
         ],
         "default_location": os.path.join(__sct_dir__, "data", "PAM50"),


### PR DESCRIPTION
> @joshuacwnewton, do we have any Github workflow in SCT which uses the atlas that we could use to quickly test whether we get the same results?

I think the `batch_processing.sh` test will help here, especially now that we have the "detailed analysis" secondary step that checks the exact properties of each file generated during `batch_processing.sh`. 

So, this PR runs all of our usual tests (including `batch_processing.sh`)

For context: @valosekj's PR https://github.com/spinalcordtoolbox/PAM50/pull/35