### PR TITLE
Enable `macos-15` and `windows-2025` in all CI workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
     needs: generate-requirements-freeze
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2019, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/test-batch-processing.yml
+++ b/.github/workflows/test-batch-processing.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, windows-2022 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2022, windows-2025 ]
     runs-on: ${{ matrix.os }}
     # NB: Setting `bash` as the default shell is a bit of a hack workaround for Windows to allow it to run .sh scripts.
     #     Normally, we would ask the user to install a Windows-compatible bash via either Cygwin or Git for Windows.

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         sct_version: [ "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3.0", "5.2.0", "5.1.0" ]
-        os: [ ubuntu-latest, macos-latest, windows-2019 ]
+        os: [ ubuntu-latest, macos-latest, macos-15, windows-2019, windows-2025 ]
         exclude:
           # Windows support was only properly introduced in 5.7
           - sct_version: "5.6"
@@ -42,6 +42,18 @@ jobs:
             os: windows-2019
           - sct_version: "5.1.0"
             os: windows-2019
+          - sct_version: "5.6"
+            os: windows-2025
+          - sct_version: "5.5"
+            os: windows-2025
+          - sct_version: "5.4"
+            os: windows-2025
+          - sct_version: "5.3.0"
+            os: windows-2025
+          - sct_version: "5.2.0"
+            os: windows-2025
+          - sct_version: "5.1.0"
+            os: windows-2025
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -284,6 +284,28 @@ jobs:
         run: |
           ./.ci.sh -t
 
+  macos-15:
+    name: macOS 15.0 (Sequoia)
+    # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
+    #if: ${{ env.NIGHTLY }}
+    # in the meantime, copy-paste this:
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: macos-15
+    steps:
+      - name: Dependencies
+        run: |
+          # github runners come with dev-tools pre-installed
+      - uses: actions/checkout@v4
+      - name: Install SCT
+        run: |
+          ./.ci.sh -i
+      - name: Check dependencies
+        run: |
+          ./.ci.sh -c
+      - name: Run pytest test suite
+        run: |
+          ./.ci.sh -t
+
   windows-wsl-ubuntu-24_04:
     # with the help of https://github.com/marketplace/actions/setup-wsl
     name: WSL [Ubuntu 24.04]
@@ -391,6 +413,46 @@ jobs:
         export GITHUB_REF_NAME="${{ github.ref_name }}"
         cd ~/spinalcordtoolbox
         ./.ci.sh -t
+
+
+  windows-native-2025:
+    name: Windows (Native) 2025
+    runs-on: windows-2025
+    defaults:
+      run:
+        shell: cmd
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install SCT
+      # NB: In real-world usage, it's assumed that the user would download the
+      # install_sct.bat file from the Downloads page, and _not_ the full repo.
+      # Then, the repo would be cloned to a tmpdir, then copied to the destination folder.
+      # However, this only really works on `master`, since for PRs, there is a chance
+      # that the PR is coming from a fork. And, in that case, we won't be able to clone
+      # the proper branch, as it exists only on the fork.
+      run: |
+        if "%GITHUB_REF_NAME%"=="master" (
+          if not exist %USERPROFILE%\Downloads mkdir %USERPROFILE%\Downloads
+          cp install_sct.bat %USERPROFILE%\Downloads
+          cd /d %USERPROFILE%\Downloads
+        )
+        install_sct.bat
+    - name: Add SCT to path
+      # NB: I'm not sure what GHA's syntax is for cmd.exe, so we use bash just for this one change
+      # In a user install, the user would perform this step using the Windows PATH-changing GUI.
+      shell: bash
+      run: |
+        if [ "$GITHUB_REF_NAME" = "master" ]; then
+          export SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+          echo "$USERPROFILE\sct_$SCT_VERSION\bin" >> $GITHUB_PATH
+        else
+          echo "$GITHUB_WORKSPACE\bin" >> $GITHUB_PATH
+        fi
+    - name: Check dependencies
+      run: sct_check_dependencies
+    - name: Run pytest test suite
+      run: sct_testing
+
 
   windows-native-2022:
     name: Windows (Native) 2022


### PR DESCRIPTION
## Description

Draft PR for testing.

I've temporarily enabled them on PRs, even if we don't plan to *always* enable them on PRs right now, so that I can test the current `master` on these OSs.

## Linked issues

Fixes #4853.
