### PR TITLE
`sct_compute_compression`: add MSCC support for lesions

### DIFF
--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -174,7 +174,7 @@ def get_slice_thickness(img):
 def get_compressed_slice(img):
     """
     Get all the compression labels (voxels of value: '1') that are contained in the input image.
-    :param img: Image: source image
+    :param img: Image: RPI-oriented source image
     :return list: list of slices number
     """
     # Get all coordinates
@@ -183,8 +183,8 @@ def get_compressed_slice(img):
     # Check it coordinates is empty
     if not coordinates:
         raise ValueError('No compression labels found.')
-    # Return only slices number
-    return [int(coordinate.z) for coordinate in coordinates]
+    # Return only axial slice numbers (z coordinate in RPI orientation)
+    return set([int(coordinate.z) for coordinate in coordinates])
 
 
 def get_verterbral_level_from_slice(slices, df_metrics):

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -585,6 +585,9 @@ def main(argv: Sequence[str]):
     # If vertebral labeling file is provided, use it for the sct_process_segmentation call
     if arguments.vertfile:
         sct_process_segmentation.main(argv=['-i', fname_segmentation, '-vertfile', fname_vertfile, '-perslice', '1', '-o', fname_metrics])
+    # But sometimes, the vertebral labeling file is not available (e.g., in severe injuries)
+    else:
+        sct_process_segmentation.main(argv=['-i', fname_segmentation, '-perslice', '1', '-o', fname_metrics])
     # Fetch metrics of subject
     df_metrics = pd.read_csv(fname_metrics).astype({metric: float})
     # Get vertebral level corresponding to the slice with the compression

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -610,6 +610,8 @@ def main(argv: Sequence[str]):
     centerline = get_centerline_object(img_seg, verbose=verbose)
     # Get healthy slices to average for level above and below
     z_range_centerline_above, z_range_centerline_below = get_slices_upper_lower_level_from_centerline(centerline, distance, extent, slice_compressed, z_ref)
+    logger.debug(f'Slice range above: {z_range_centerline_above}')
+    logger.debug(f'Slice range below: {z_range_centerline_below}')
 
     # Step 2: Get normalization metrics and slices (using PAM50 and reference dataset)
     # -----------------------------------------------------------

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -76,9 +76,11 @@ def get_parser():
         '-l',
         metavar=Metavar.file,
         help=textwrap.dedent("""
-            NIfTI file that includes labels at the compression sites. Each compression site is denoted by a single voxel of value `1`. Example: `sub-001_T2w_compression_labels.nii.gz`
+            NIfTI file that includes i) compression labels or ii) lesion mask.
+              i) compression labels = labels at the compression sites. Each compression site is denoted by a single voxel of value `1`. Example: `sub-001_T2w_compression_labels.nii.gz`
+              ii) lesion mask = binary mask of the lesion. Currently only a single lesion is supported. Example: `sub-001_T2w_lesion.nii.gz`
 
-            Note: The input and the compression label file must be in the same voxel coordinate system and must match the dimensions between each other.
+            Note: The '-i' and '-l' files must be in the same voxel coordinate system and must match the dimensions between each other.
         """),  # noqa: E501 (line too long)
     )
 

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -465,7 +465,7 @@ def average_metric(df, metric, z_range_above, z_range_below, slices_avg):
     :param metric: str: metric to perform normalization
     :param z_range_above: list: list of slices of level above compression.
     :param z_range_below: list: list of slices of level below compression.
-    :param slices_avg: Slices in PAM50 space to average metrics.
+    :param slices_avg: list: list of slices at the level of compression.
     :return: ma: float64: Metric above the compression
     :retrun: mb: float64: Metric below the compression
     :retrun: mi: float64: Metric at the compression level

--- a/spinalcordtoolbox/scripts/sct_compute_compression.py
+++ b/spinalcordtoolbox/scripts/sct_compute_compression.py
@@ -635,7 +635,7 @@ def main(argv: Sequence[str]):
         compressed_levels_dict_PAM50 = get_slices_in_PAM50(compressed_levels_dict, df_metrics, df_metrics_PAM50)
         z_range_PAM50_below, z_range_PAM50_above = get_slices_upper_lower_level_from_PAM50(compressed_levels_dict_PAM50, df_metrics_PAM50, distance, extent, slice_thickness_PAM50)
 
-    # Step 3. Compute MSCC metrics for each compressed level
+    # Step 3a. Compute MSCC metrics for each compressed level
     # ------------------------------------------------------
     if compressed_levels_dict:
         # Loop through all compressed levels (compute one MSCC per compressed level)


### PR DESCRIPTION
## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Currently, `sct_compute_compression` was designed to work with compression labels (single voxels of value `1` at compression sites) provided by the `-l` arg.

This PR extends the `sct_compute_compression` functionality to also support the computation of MSCC for lesions, for example, in traumatic spinal cord injury (tSCI). The morphometrics (e.g., AP diameter) are computed from:
- Lesion center (`mi`) – single slice at the center of the lesion
- Above lesion (`ma`) – 20 mm region located 10 mm above the uppermost lesion slice
- Below lesion (`mb`) – 20 mm region located 10 mm below the lowermost lesion slice

<img width="400" alt="image" src="https://github.com/user-attachments/assets/04d90ac1-e015-47e7-93ba-afdd2169165e" />

(compare with [Fig 1 in this paper](https://www.sciencedirect.com/science/article/pii/S1529943025001597#fig0001))

As it might be difficult to obtain disc labeling in tSCI, I made the `-vertfile` arg optional in https://github.com/spinalcordtoolbox/spinalcordtoolbox/commit/20ce867b0acd6262b0f3d1307f00507b44a68404.

 

