### PR TITLE
Update PAM50 release links to `r20250422` (ventral rootlets, Th1 level)

### DIFF
--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -66,8 +66,8 @@ DATASET_DICT = {
     },
     "PAM50": {
         "mirrors": [
-            "https://github.com/spinalcordtoolbox/PAM50/releases/download/r20250109/PAM50-r20250109.zip",
-            "https://osf.io/nkqtx/?action=download",
+            "https://github.com/spinalcordtoolbox/PAM50/releases/download/r20250422/PAM50-r20250422.zip",
+            "https://osf.io/q3m4t/?action=download",
         ],
         "default_location": os.path.join(__sct_dir__, "data", "PAM50"),
         "download_type": "Templates",


### PR DESCRIPTION
## Description

This PR integrates the following upstream changes into SCT:

- https://github.com/spinalcordtoolbox/PAM50/pull/34

PR https://github.com/spinalcordtoolbox/PAM50/pull/35 was planned for v7.0 as well, however the changes became more complex and nature, and require better testing before we can feel comfortable integrating them into SCT.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

N/A