### PR TITLE
[HOTFIX] Moved `graymatter` model to `gray_matter` group

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -552,6 +552,8 @@ TASKS = {
          'url': 'https://github.com/ivadomed/model-gm-contrast-region-agnostic',
          'models': ['model_seg_gm_contrast_region_agnostic'],
          'citation': None,
+         'group': 'gray_matter',
+         'priority': 1  # Push gray matter to the top of its eponymous category
          },
 }
 


### PR DESCRIPTION
Just a hot-fix to put the 'graymatter' model in its eponymous group. Also slightly increases its priority, so it will appear at the top of its own group (and push gray matter segmentation up as well).
