### PR TITLE
Update `sct_label_vertebrae -discfile` by removing straightening

### DIFF
--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -579,16 +579,3 @@ def project_point_on_line(point, line):
     dist = np.sum((line - point) ** 2, axis=1)
 
     return line[np.argmin(dist)]
-
-if __name__=='__main__':
-    seg_path = "/Users/nathan/Desktop/sct-proj/sub-unf03_T2w_label-SC_seg.nii.gz"
-    discs_path = "/Users/nathan/Desktop/sct-proj/sub-unf03_T2w_label-discs_dlabel.nii.gz"
-
-    seg = Image(seg_path)
-    discs = Image(discs_path)
-
-    # Project discs orthogonally onto the centerline
-    discs_proj = project_centerline(seg, discs)
-
-    # Generate a labeled segmentation
-    labeled_seg, labeled_centerline = label_cord_from_discs(seg, discs_proj)

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -224,11 +224,12 @@ def labelize_from_discs(img: Image, ref: Image) -> Image:
     :returns: segmentation image with vertebral levels labelized
     """
 
-    img_orientation = img.orientation
-    if img_orientation != "RPI":
+    og_img_orientation = img.orientation
+    if og_img_orientation != "RPI":
         img.change_orientation("RPI")
 
-    if ref.orientation != "RPI":
+    og_ref_orientation = ref.orientation
+    if og_ref_orientation != "RPI":
         ref.change_orientation("RPI")
 
     out = zeros_like(img)
@@ -253,7 +254,12 @@ def labelize_from_discs(img: Image, ref: Image) -> Image:
                     out.data[int(x), int(y), int(z)] = coordinates_ref[j].value
 
     # Set back the original orientation
-    out.change_orientation(img_orientation)
+    if img.orientation != og_img_orientation:
+        img.change_orientation(og_img_orientation)
+        out.change_orientation(og_img_orientation)
+
+    if ref.orientation != og_ref_orientation:
+        ref.change_orientation(og_ref_orientation)
 
     return out
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -216,7 +216,7 @@ def label_regions_from_reference(img: Image, ref: Image, centerline: bool = Fals
     Create an image with regions labelized depending on values from reference.
     Typically, user inputs a segmentation image, and labels with discs position, and this function produces
     a segmentation image with vertebral levels labelized.
-    Note that no straightening is done. The labelization is only done based on the z coordinates of each projected voxel of the segmentation.
+    Note that no straightening is done. The labelization is done by projecting the labels onto the centerline (extracted from the segmentation).
     Input images do **not** need to be RPI (re-orientation is done within this function).
 
     :param img: segmentation

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -499,7 +499,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         p_resample_default = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         im_list = [Image(fname_in1), Image(fname_seg)]
-        action_list = [QcImage.label_utils]
+        action_list = [QcImage.label_vertebrae]
         def qcslice_layout(x): return x.single()
     #  Sagittal orientation, display posterior labels
     elif process in ['sct_label_utils']:

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -499,7 +499,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         p_resample_default = None
         dpi = 100  # bigger picture is needed for this special case, hence reduce dpi
         im_list = [Image(fname_in1), Image(fname_seg)]
-        action_list = [QcImage.label_vertebrae]
+        action_list = [QcImage.label_utils]
         def qcslice_layout(x): return x.single()
     #  Sagittal orientation, display posterior labels
     elif process in ['sct_label_utils']:

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -111,7 +111,7 @@ def get_parser():
     func_group.add_argument(
         '-project-centerline',
         metavar=Metavar.file,
-        help="Project disc labels onto the spinal cord centerline."
+        help="Project disc labels (`-project-centerline`) onto the spinal cord centerline using the spinal cord segmentation (`-i`)."
     )
     func_group.add_argument(
         '-display',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -205,6 +205,8 @@ def main(argv: Sequence[str]):
         if arg == '-create-seg' and len(argv) > i+1 and '-1,' in argv[i+1]:
             raise DeprecationWarning("The use of '-1' for '-create-seg' has been deprecated. Please use "
                                      "'-create-seg-mid' instead.")
+        if arg == '-disc':
+            raise DeprecationWarning("The use of '-disc' has been deprecated. Please use `sct_label_vertebrae -discfile`.")
 
     parser = get_parser()
     arguments = parser.parse_args(argv)

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -111,7 +111,7 @@ def get_parser():
     func_group.add_argument(
         '-project-centerline',
         metavar=Metavar.file,
-        help="Project disc labels (`-project-centerline`) onto the spinal cord centerline using the spinal cord segmentation (`-i`)."
+        help="Project labels (e.g., disc labels) provided by this argument (`-project-centerline`) onto the spinal cord centerline using the spinal cord segmentation (provided by the `-i` argument)."
     )
     func_group.add_argument(
         '-display',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -111,7 +111,8 @@ def get_parser():
     func_group.add_argument(
         '-project-centerline',
         metavar=Metavar.file,
-        help="Project labels (e.g., disc labels) provided by this argument (`-project-centerline`) onto the spinal cord centerline using the spinal cord segmentation (provided by the `-i` argument)."
+        help="Project labels (e.g. disc labels) onto a spinal cord segmentation or centerline. "
+             "Example: sct_label_utils -i spinalcord.nii.gz -project-centerline labels.nii.gz "
     )
     func_group.add_argument(
         '-display',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -109,18 +109,6 @@ def get_parser():
         help="Compute the center-of-mass for each label value."
     )
     func_group.add_argument(
-        '-disc',
-        metavar=Metavar.file,
-        help=textwrap.dedent("""
-            Project disc labels (`-disc`) onto a spinal cord segmentation (`-i`) within the axial plane to create a labeled segmentation.
-
-            - Note: Unlike `sct_label_vertebrae -discfile`, this function does NOT involve cord straightening.
-            - Note: This method does NOT involve orthogonal projection onto the cord centerline. Details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3395#issuecomment-1478435265
-
-            The disc labeling follows the convention: https://spinalcordtoolbox.com/user_section/tutorials/vertebral-labeling/labeling-conventions.html
-        """),  # noqa: E501 (line too long)
-    )
-    func_group.add_argument(
         '-project-centerline',
         metavar=Metavar.file,
         help="Project disc labels onto the spinal cord centerline."
@@ -250,9 +238,6 @@ def main(argv: Sequence[str]):
         return
     elif arguments.increment:
         out = sct_labels.increment_z_inverse(img)
-    elif arguments.disc is not None:
-        ref = Image(arguments.disc)
-        out = sct_labels.labelize_from_discs(img, ref)
     elif arguments.project_centerline is not None:
         ref = Image(arguments.project_centerline)
         try:

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -26,6 +26,7 @@ from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCrea
 from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_loglevel, __version__
 from spinalcordtoolbox.utils.fs import tmp_create, cache_signature, cache_valid, cache_save, copy, extract_fname, rmtree
 from spinalcordtoolbox.math import threshold, laplacian
+import spinalcordtoolbox.labels as sct_labels
 
 from spinalcordtoolbox.scripts import sct_straighten_spinalcord, sct_apply_transfo, sct_resample
 
@@ -286,66 +287,71 @@ def main(argv: Sequence[str]):
     curdir = os.getcwd()
     os.chdir(path_tmp)
 
-    # Straighten spinal cord
-    printv('\nStraighten spinal cord...', verbose)
-    # check if warp_curve2straight and warp_straight2curve already exist (i.e. no need to do it another time)
-    cache_sig = cache_signature(
-        input_files=[fname_in, fname_seg],
-        input_params={"version": __version__},
-    )
-    if (cache_valid(os.path.join(curdir, "straightening.cache"), cache_sig)
-            and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz"))
-            and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz"))
-            and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz"))):
-        # if they exist, copy them into current folder
-        printv('Reusing existing warping field which seems to be valid', verbose, 'warning')
-        copy(os.path.join(curdir, "straightening.cache"), 'straightening.cache')
-        copy(os.path.join(curdir, "warp_curve2straight.nii.gz"), 'warp_curve2straight.nii.gz')
-        copy(os.path.join(curdir, "warp_straight2curve.nii.gz"), 'warp_straight2curve.nii.gz')
-        copy(os.path.join(curdir, "straight_ref.nii.gz"), 'straight_ref.nii.gz')
-        # apply straightening
-        sct_apply_transfo.main(['-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii', '-v', '0'])
-    else:
-        sct_straighten_spinalcord.main(argv=[
-            '-i', 'data.nii',
-            '-s', 'segmentation.nii',
-            '-r', str(remove_temp_files),
-            '-v', '0',
-        ])
-        cache_save("straightening.cache", cache_sig)
-
-    # resample to 0.5mm isotropic to match template resolution
-    printv('\nResample to 0.5mm isotropic...', verbose)
-    sct_resample.main(['-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii', '-v', '0'])
-
-    # Apply straightening to segmentation
-    # N.B. Output is RPI
-    printv('\nApply straightening to segmentation...', verbose)
-    sct_apply_transfo.main(['-i', 'segmentation.nii',
-                            '-d', 'data_straightr.nii',
-                            '-w', 'warp_curve2straight.nii.gz',
-                            '-o', 'segmentation_straight.nii',
-                            '-x', 'linear',
-                            '-v', '0'])
-
-    # Threshold segmentation at 0.5
-    img = Image('segmentation_straight.nii')
-    img.data = threshold(img.data, 0.5)
-    img.save()
-
-    # If disc label file is provided, label vertebrae using that file instead of automatically
+    # Differentiate two use cases of the script: 
+    #   1: Use input discs and label the spinal cord without straightening, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4476
+    #   2: Detect discs automatically and label the spinal cord using straightening steps, based on DOI:10.1155/2014/719520
     if fname_disc:
-        # Apply straightening to disc-label
-        printv('\nApply straightening to disc labels...', verbose)
-        sct_apply_transfo.main(['-i', fname_disc, '-d', 'data_straightr.nii', '-w', 'warp_curve2straight.nii.gz',
-                                '-o', 'labeldisc_straight.nii.gz', '-x', 'label', '-v', '0'])
-        try:
-            label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz')
-        except MissingDiscsError as e:
-            printv(f"No disc labels found in straightened version of discfile {fname_disc}\n"
-                   f"    {e.__class__.__name__}: '{e}'", 1, 'error')
+        # Load spinal cord segmentation and input discs
+        seg = Image(fname_seg)
+        discs = Image(fname_disc)
 
+        # Project discs orthogonally onto the centerline
+        discs_proj = sct_labels.project_centerline(seg, discs)
+        discs_proj.save("segmentation_labeled_disc.nii")
+
+        # Generate a labeled segmentation
+        labeled_seg = sct_labels.labelize_from_discs(seg, discs_proj)
+        labeled_seg.save("segmentation_labeled.nii")        
+        
     else:
+
+        # Straighten spinal cord
+        printv('\nStraighten spinal cord...', verbose)
+        # check if warp_curve2straight and warp_straight2curve already exist (i.e. no need to do it another time)
+        cache_sig = cache_signature(
+            input_files=[fname_in, fname_seg],
+            input_params={"version": __version__},
+        )
+        if (cache_valid(os.path.join(curdir, "straightening.cache"), cache_sig)
+                and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz"))
+                and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz"))
+                and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz"))):
+            # if they exist, copy them into current folder
+            printv('Reusing existing warping field which seems to be valid', verbose, 'warning')
+            copy(os.path.join(curdir, "straightening.cache"), 'straightening.cache')
+            copy(os.path.join(curdir, "warp_curve2straight.nii.gz"), 'warp_curve2straight.nii.gz')
+            copy(os.path.join(curdir, "warp_straight2curve.nii.gz"), 'warp_straight2curve.nii.gz')
+            copy(os.path.join(curdir, "straight_ref.nii.gz"), 'straight_ref.nii.gz')
+            # apply straightening
+            sct_apply_transfo.main(['-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii', '-v', '0'])
+        else:
+            sct_straighten_spinalcord.main(argv=[
+                '-i', 'data.nii',
+                '-s', 'segmentation.nii',
+                '-r', str(remove_temp_files),
+                '-v', '0',
+            ])
+            cache_save("straightening.cache", cache_sig)
+
+        # resample to 0.5mm isotropic to match template resolution
+        printv('\nResample to 0.5mm isotropic...', verbose)
+        sct_resample.main(['-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii', '-v', '0'])
+
+        # Apply straightening to segmentation
+        # N.B. Output is RPI
+        printv('\nApply straightening to segmentation...', verbose)
+        sct_apply_transfo.main(['-i', 'segmentation.nii',
+                                '-d', 'data_straightr.nii',
+                                '-w', 'warp_curve2straight.nii.gz',
+                                '-o', 'segmentation_straight.nii',
+                                '-x', 'linear',
+                                '-v', '0'])
+
+        # Threshold segmentation at 0.5
+        img = Image('segmentation_straight.nii')
+        img.data = threshold(img.data, 0.5)
+        img.save()
+
         printv('\nCreate label to identify disc...', verbose)
         fname_labelz = os.path.join(path_tmp, 'labelz.nii.gz')
         if initcenter is not None:
@@ -417,14 +423,23 @@ def main(argv: Sequence[str]):
             printv(f'Vertebral detection failed: {e}', 1, 'error')
             sys.exit(1)
 
-    # un-straighten labeled spinal cord
-    printv('\nUn-straighten labeling...', verbose)
-    sct_apply_transfo.main(['-i', 'segmentation_straight_labeled.nii',
-                            '-d', 'segmentation.nii',
-                            '-w', 'warp_straight2curve.nii.gz',
-                            '-o', 'segmentation_labeled.nii',
-                            '-x', 'nn',
-                            '-v', '0'])
+        # un-straighten labeled spinal cord
+        printv('\nUn-straighten labeling...', verbose)
+        sct_apply_transfo.main(['-i', 'segmentation_straight_labeled.nii',
+                                '-d', 'segmentation.nii',
+                                '-w', 'warp_straight2curve.nii.gz',
+                                '-o', 'segmentation_labeled.nii',
+                                '-x', 'nn',
+                                '-v', '0'])
+        # un-straighten label discs
+        printv('\nLabel discs...', verbose)
+        printv('\nUn-straighten labeled discs...', verbose)
+        sct_apply_transfo.main(['-i', 'segmentation_straight_labeled_disc.nii',
+                                '-d', 'segmentation.nii',
+                                '-w', 'warp_straight2curve.nii.gz',
+                                '-o', 'segmentation_labeled_disc.nii',
+                                '-x', 'label',
+                                '-v', '0'])
 
     if clean_labels >= 1:
         printv('\nCleaning labeled segmentation:', verbose)
@@ -438,15 +453,6 @@ def main(argv: Sequence[str]):
         printv('Done cleaning.', verbose)
         im_labeled_seg.save()
 
-    # label discs
-    printv('\nLabel discs...', verbose)
-    printv('\nUn-straighten labeled discs...', verbose)
-    sct_apply_transfo.main(['-i', 'segmentation_straight_labeled_disc.nii',
-                            '-d', 'segmentation.nii',
-                            '-w', 'warp_straight2curve.nii.gz',
-                            '-o', 'segmentation_labeled_disc.nii',
-                            '-x', 'label',
-                            '-v', '0'])
     # come back
     os.chdir(curdir)
 
@@ -457,10 +463,11 @@ def main(argv: Sequence[str]):
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled.nii"), fname_seg_labeled)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg))
     # copy straightening files in case subsequent SCT functions need them
-    generate_output_file(os.path.join(path_tmp, "straightening.cache"), os.path.join(path_output, "straightening.cache"), verbose=verbose)
-    generate_output_file(os.path.join(path_tmp, "warp_curve2straight.nii.gz"), os.path.join(path_output, "warp_curve2straight.nii.gz"), verbose=verbose)
-    generate_output_file(os.path.join(path_tmp, "warp_straight2curve.nii.gz"), os.path.join(path_output, "warp_straight2curve.nii.gz"), verbose=verbose)
-    generate_output_file(os.path.join(path_tmp, "straight_ref.nii.gz"), os.path.join(path_output, "straight_ref.nii.gz"), verbose=verbose)
+    if not fname_disc:
+        generate_output_file(os.path.join(path_tmp, "straightening.cache"), os.path.join(path_output, "straightening.cache"), verbose=verbose)
+        generate_output_file(os.path.join(path_tmp, "warp_curve2straight.nii.gz"), os.path.join(path_output, "warp_curve2straight.nii.gz"), verbose=verbose)
+        generate_output_file(os.path.join(path_tmp, "warp_straight2curve.nii.gz"), os.path.join(path_output, "warp_straight2curve.nii.gz"), verbose=verbose)
+        generate_output_file(os.path.join(path_tmp, "straight_ref.nii.gz"), os.path.join(path_output, "straight_ref.nii.gz"), verbose=verbose)
 
     # Remove temporary files
     if remove_temp_files == 1:

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -441,7 +441,7 @@ def main(argv: Sequence[str]):
                                 '-o', 'segmentation_labeled_disc.nii',
                                 '-x', 'label',
                                 '-v', '0'])
-        
+
         # Generate labeled centerline
         seg = Image("segmentation.nii")
         discs_proj = Image("segmentation_labeled_disc.nii")

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -484,7 +484,7 @@ def main(argv: Sequence[str]):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         generate_qc(fname_in, fname_seg=fname_discs, args=argv, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
+                    dataset=qc_dataset, subject=qc_subject, process='sct_label_utils')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],
                           verbose=verbose)

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -462,10 +462,9 @@ def main(argv: Sequence[str]):
     # Generate output files
     path_seg, file_seg, ext_seg = extract_fname(fname_seg)
     fname_seg_labeled = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-    fname_discs = os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg)
     printv('\nGenerate output files...', verbose)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled.nii"), fname_seg_labeled)
-    generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), fname_discs)
+    generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg))
     # copy straightening files in case subsequent SCT functions need them
     if not fname_disc:
         generate_output_file(os.path.join(path_tmp, "straightening.cache"), os.path.join(path_output, "straightening.cache"), verbose=verbose)
@@ -483,7 +482,7 @@ def main(argv: Sequence[str]):
         path_qc = os.path.abspath(arguments.qc)
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
-        generate_qc(fname_in, fname_seg=fname_discs, args=argv, path_qc=os.path.abspath(path_qc),
+        generate_qc(fname_in, fname_seg=fname_seg_labeled, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -484,7 +484,7 @@ def main(argv: Sequence[str]):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         generate_qc(fname_in, fname_seg=fname_discs, args=argv, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process='sct_label_utils')
+                    dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],
                           verbose=verbose)

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -300,8 +300,10 @@ def main(argv: Sequence[str]):
         discs_proj.save("segmentation_labeled_disc.nii")
 
         # Generate a labeled segmentation
-        labeled_seg = sct_labels.labelize_from_discs(seg, discs_proj)
+        labeled_seg = sct_labels.label_regions_from_reference(seg, discs_proj)
+        labeled_centerline = sct_labels.label_regions_from_reference(seg, discs_proj, centerline=True)
         labeled_seg.save("segmentation_labeled.nii")
+        labeled_centerline.save("centerline_labeled.nii")
     else:
 
         # Straighten spinal cord
@@ -439,6 +441,12 @@ def main(argv: Sequence[str]):
                                 '-o', 'segmentation_labeled_disc.nii',
                                 '-x', 'label',
                                 '-v', '0'])
+        
+        # Generate labeled centerline
+        seg = Image("segmentation.nii")
+        discs_proj = Image("segmentation_labeled_disc.nii")
+        labeled_centerline = sct_labels.label_regions_from_reference(seg, discs_proj, centerline=True)
+        labeled_centerline.save("centerline_labeled.nii")
 
     if clean_labels >= 1:
         printv('\nCleaning labeled segmentation:', verbose)
@@ -458,8 +466,10 @@ def main(argv: Sequence[str]):
     # Generate output files
     path_seg, file_seg, ext_seg = extract_fname(fname_seg)
     fname_seg_labeled = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
+    fname_centerline_labeled = os.path.join(path_output, file_seg + '_labeled_centerline' + ext_seg)
     printv('\nGenerate output files...', verbose)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled.nii"), fname_seg_labeled)
+    generate_output_file(os.path.join(path_tmp, "centerline_labeled.nii"), fname_centerline_labeled)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg))
     # copy straightening files in case subsequent SCT functions need them
     if not fname_disc:
@@ -478,8 +488,7 @@ def main(argv: Sequence[str]):
         path_qc = os.path.abspath(arguments.qc)
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
-        labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-        generate_qc(fname_in, fname_seg=labeled_seg_file, args=argv, path_qc=os.path.abspath(path_qc),
+        generate_qc(fname_in, fname_seg=fname_seg_labeled, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -462,9 +462,10 @@ def main(argv: Sequence[str]):
     # Generate output files
     path_seg, file_seg, ext_seg = extract_fname(fname_seg)
     fname_seg_labeled = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
+    fname_discs = os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg)
     printv('\nGenerate output files...', verbose)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled.nii"), fname_seg_labeled)
-    generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg))
+    generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), fname_discs)
     # copy straightening files in case subsequent SCT functions need them
     if not fname_disc:
         generate_output_file(os.path.join(path_tmp, "straightening.cache"), os.path.join(path_output, "straightening.cache"), verbose=verbose)
@@ -482,7 +483,7 @@ def main(argv: Sequence[str]):
         path_qc = os.path.abspath(arguments.qc)
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
-        generate_qc(fname_in, fname_seg=fname_seg_labeled, args=argv, path_qc=os.path.abspath(path_qc),
+        generate_qc(fname_in, fname_seg=fname_discs, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], im_types=['anat', 'seg-labeled'], opacities=['1', '0.5'],

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -16,8 +16,8 @@ import numpy as np
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.vertebrae.core import (
     get_z_and_disc_values_from_label, vertebral_detection, expand_labels,
-    crop_labels, label_vert)
-from spinalcordtoolbox.types import EmptyArrayError, MissingDiscsError
+    crop_labels)
+from spinalcordtoolbox.types import EmptyArrayError
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
@@ -287,7 +287,7 @@ def main(argv: Sequence[str]):
     curdir = os.getcwd()
     os.chdir(path_tmp)
 
-    # Differentiate two use cases of the script: 
+    # Differentiate two use cases of the script:
     #   1: Use input discs and label the spinal cord without straightening, see https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4476
     #   2: Detect discs automatically and label the spinal cord using straightening steps, based on DOI:10.1155/2014/719520
     if fname_disc:
@@ -301,8 +301,7 @@ def main(argv: Sequence[str]):
 
         # Generate a labeled segmentation
         labeled_seg = sct_labels.labelize_from_discs(seg, discs_proj)
-        labeled_seg.save("segmentation_labeled.nii")        
-        
+        labeled_seg.save("segmentation_labeled.nii")
     else:
 
         # Straighten spinal cord

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -301,9 +301,7 @@ def main(argv: Sequence[str]):
 
         # Generate a labeled segmentation
         labeled_seg = sct_labels.label_regions_from_reference(seg, discs_proj)
-        labeled_centerline = sct_labels.label_regions_from_reference(seg, discs_proj, centerline=True)
         labeled_seg.save("segmentation_labeled.nii")
-        labeled_centerline.save("centerline_labeled.nii")
     else:
 
         # Straighten spinal cord
@@ -445,8 +443,6 @@ def main(argv: Sequence[str]):
         # Generate labeled centerline
         seg = Image("segmentation.nii")
         discs_proj = Image("segmentation_labeled_disc.nii")
-        labeled_centerline = sct_labels.label_regions_from_reference(seg, discs_proj, centerline=True)
-        labeled_centerline.save("centerline_labeled.nii")
 
     if clean_labels >= 1:
         printv('\nCleaning labeled segmentation:', verbose)
@@ -466,10 +462,8 @@ def main(argv: Sequence[str]):
     # Generate output files
     path_seg, file_seg, ext_seg = extract_fname(fname_seg)
     fname_seg_labeled = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-    fname_centerline_labeled = os.path.join(path_output, file_seg + '_labeled_centerline' + ext_seg)
     printv('\nGenerate output files...', verbose)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled.nii"), fname_seg_labeled)
-    generate_output_file(os.path.join(path_tmp, "centerline_labeled.nii"), fname_centerline_labeled)
     generate_output_file(os.path.join(path_tmp, "segmentation_labeled_disc.nii"), os.path.join(path_output, file_seg + '_labeled_discs' + ext_seg))
     # copy straightening files in case subsequent SCT functions need them
     if not fname_disc:

--- a/testing/api/test_labels.py
+++ b/testing/api/test_labels.py
@@ -117,7 +117,7 @@ def test_labelize_from_discs(test_seg, test_labels):
     seg = test_seg.copy()
     ref = test_labels.copy()
 
-    sct_labels.labelize_from_discs(seg, ref)
+    sct_labels.label_regions_from_reference(seg, ref)
     # TODO [AJ] implement test
 
 

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -26,11 +26,6 @@ def test_sct_label_vertebrae_consistent_disc(tmp_path):
     assert fp == []
     assert fn == []
 
-    # Ensure that the straightening files are correctly generated in the output directory
-    for file in ["straightening.cache", "straight_ref.nii.gz",
-                 "warp_straight2curve.nii.gz", "warp_curve2straight.nii.gz"]:
-        assert os.path.isfile(tmp_path/file)
-
 
 @pytest.mark.sct_testing
 def test_sct_label_vertebrae_initfile_qc_no_checks():


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://intranet.neuro.polymtl.ca/onboarding/software-development.html#software-development. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/onboarding/software-development.html#pr-labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR:
- removes the straightening step from `sct_label_vertebrae` when using the flag `-discfile`
- removes `sct_label_utils -disc` because it is a duplication of the new `sct_label_vertebrae`

Now when calling `sct_label_vertebrae` with the flag `-discfile`:
- Discs are [projected](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/6c2c6b4d879f27516b9b1bdd2d10a777d38208bb/spinalcordtoolbox/scripts/sct_label_vertebrae.py#L299) onto the spinal cord
- The segmentation is labeled by projecting individual voxels onto the centerline and comparing their z coordinate with the z coordinate of projected discs.

How to use:
```bash
sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz -c ${contrast}
```
See the new result below:
<img src="https://github.com/user-attachments/assets/82ab43d0-d71f-459a-9714-cdaa1e1177bb" alt="drawing" width="400"/>


## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4476
Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3395
Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4323
Related to https://github.com/valosekj/dcm-brno/issues/10#issuecomment-1948312202
