### PR TITLE
Limit `onnx<1.16.2` to fix CI failures on Windows runners (Python 3.9)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,9 +39,9 @@ numpy<2
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
 onnxruntime>=1.7.0,!=1.16.0
-# onnx==1.18.0 causes errors for Python 3.9 + Windows (https://github.com/onnx/onnx/issues/6267#issuecomment-2877327002)
-# We can probably unpin this once we upgrade to Python 3.10.
-onnx<1.18.0
+# onnx==[1.16.2,1.17.0,1.18.0] all cause errors for Python 3.9 + Windows (https://github.com/onnx/onnx/issues/6267#issuecomment-2877327002)
+# 1.17.0 can partially work as long as SCT doesn't import it, but this is flaky.
+onnx<1.16.2
 pandas
 portalocker
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,9 @@ numpy<2
 # So, pin to >=1.7.0 to avoid having to ask users to install libomp.
 # Avoid version 1.16.0 due to: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4225
 onnxruntime>=1.7.0,!=1.16.0
+# onnx==1.18.0 causes errors for Python 3.9 + Windows (https://github.com/onnx/onnx/issues/6267#issuecomment-2877327002)
+# We can probably unpin this once we upgrade to Python 3.10.
+onnx<1.18.0
 pandas
 portalocker
 psutil

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -73,7 +73,9 @@ def resolve_module(framework_name):
         # Importing `matplotlib_inline` requires IPython, but we don't install IPython (on purpose). This is because
         # `matplotlib_inline` is only needed to run SCT scripts in Jupyter notebooks, and IPython would already be
         # installed in the parent context. So, we map `matplotlib-inline` to None to skip import (which would fail).
-        'matplotlib-inline': (None, False)
+        'matplotlib-inline': (None, False),
+        # We specify the version of `onnx` on behalf of ivadomed -- we don't import it directly. So, skip checking its version.
+        'onnx': (None, False),
     }
 
     try:

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -74,8 +74,6 @@ def resolve_module(framework_name):
         # `matplotlib_inline` is only needed to run SCT scripts in Jupyter notebooks, and IPython would already be
         # installed in the parent context. So, we map `matplotlib-inline` to None to skip import (which would fail).
         'matplotlib-inline': (None, False),
-        # We specify the version of `onnx` on behalf of ivadomed -- we don't import it directly. So, skip checking its version.
-        'onnx': (None, False),
     }
 
     try:


### PR DESCRIPTION
## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

- `onnx` recently released version `1.18.0`, which breaks when imported by `monai` on Windows.
- However, versions `1.16.2` and `1.17.0` also had buggy behavior on Windows, but `1.17.0` kind of worked (as long as SCT itself never imported it), so it's been fine for a while now.
- Given the circumstances, though, I think now is a good time to also avoid these buggy versions, too.

Additional context: https://github.com/onnx/onnx/issues/6267#issuecomment-2877327002

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #4900.
