### PR TITLE
Retire our obsolete shim for `str.removesuffix`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -16,7 +16,7 @@ from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel, removesuffix
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
 
 
 def get_parser():
@@ -243,7 +243,7 @@ def main(argv: Sequence[str]):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         generate_qc(fname_straight, args=argv, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process=removesuffix(os.path.basename(__file__), ".py"))
+                    dataset=qc_dataset, subject=qc_subject, process=os.path.basename(__file__).removesuffix(".py"))
 
     display_viewer_syntax([fname_straight], verbose=verbose)
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -16,7 +16,7 @@ import itertools
 from enum import Enum
 from functools import cached_property, partial
 
-from .sys import check_exe, printv, removesuffix, ANSIColors16
+from .sys import check_exe, printv, ANSIColors16
 from .fs import relpath_or_abspath
 from .profiling import TimeProfilingAction, MemoryTracingAction
 
@@ -218,7 +218,7 @@ class SCTArgumentParser(argparse.ArgumentParser):
         )
 
         # Update "usage:" message to match how SCT scripts are actually called (no '.py')
-        self.prog = removesuffix(self.prog, ".py")
+        self.prog = self.prog.removesuffix(".py")
 
     # == OVERRIDES == #
     def error(self, message):

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -142,19 +142,6 @@ def set_loglevel(verbose, caller_module_name):
         pass
 
 
-def removesuffix(self: str, suffix: str) -> str:
-    """
-    Source: https://www.python.org/dev/peps/pep-0616/
-
-    TODO: Replace with built-in str.removesuffix method after upgrading to Python 3.9
-    """
-    # suffix='' should not call self[:-0].
-    if suffix and self.endswith(suffix):
-        return self[:-len(suffix)]
-    else:
-        return self[:]
-
-
 # TODO: add test
 def init_sct():
     """
@@ -188,7 +175,7 @@ def init_sct():
     # Display command (Only if called from CLI: check for .py in first arg)
     # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
     if '.py' in next(iter(sys.argv), None):
-        script = removesuffix(os.path.basename(sys.argv[0]), ".py")
+        script = os.path.basename(sys.argv[0]).removesuffix(".py")
         arguments = ' '.join(sys.argv[1:])
         logger.info(f"{script} {arguments}\n"
                     f"--\n")


### PR DESCRIPTION
We don't need it anymore, since we're on Python 3.9 (soon, 3.10!)

(Noticed while reviewing #4869.)