### PR TITLE
Add a blanket exclusion for `403 - Forbidden` responses to our broken link checker

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -3,6 +3,9 @@ name: Check for broken links
 on:
   schedule:
     - cron:  '0 10 * * *'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   check_broken_links:

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -3,9 +3,6 @@ name: Check for broken links
 on:
   schedule:
     - cron:  '0 10 * * *'
-  pull_request:
-    branches:
-      - master
 
 jobs:
   check_broken_links:

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -52,7 +52,7 @@ fi
 #   out any sites that raise 403 with just a warning instead of an error.
 if [[ $status_code -eq 403 ]];then
     echo "($status_code) $URL ($filename)" >> valid_urls.txt
-    echo -e "$filename: \x1B[32m⚠️  Warning - Forbidden - status code: $status_code for domain $URL  \x1B[0m"
+    echo -e "$filename: \x1B[33m⚠️  Warning - Forbidden - status code: $status_code for domain $URL  \x1B[0m"
     exit 0
 fi
 
@@ -69,7 +69,7 @@ fi
 # So, for now, we just filter out this response, as there's a good chance that this is still accessible via browsers.
 if [[ $status_code -eq 406 ]];then
     echo "($status_code) $URL ($filename)" >> valid_urls.txt
-    echo -e "$filename: \x1B[32m⚠️  Warning - Not Acceptable - status code: $status_code for domain $URL  \x1B[0m"
+    echo -e "$filename: \x1B[33m⚠️  Warning - Not Acceptable - status code: $status_code for domain $URL  \x1B[0m"
     exit 0
 fi
 

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -16,10 +16,12 @@ HTTP_CODE_ONLY=(--write-out '%{http_code}' --output /dev/null)
 # We still keep a 5m limit, though, because --retry respects the Retry-After field, which may be greater than 30s.
 RETRY_ARGS=(--retry 2 --retry-delay 30 --retry-max-time 300 --retry-all-errors)
 
-# Make sure to check both URL *and* redirections (--location) for excluded domains
+# Make sure to check both URL *and* redirections (--location) for excluded patterns
+# FIXME: Exclusion list temporarily disabled to test how many exclusions were due entirely to 403.
+#        See: 'twitter.com'|'spiedigitallibrary.org'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'thejns.org'|'rosped.ru'|'ajnr.org'|'bmj.com'|'biorxiv.org'|
 full_info=$(curl "${CURL_ARGS[@]}" --location -- "$URL")
 LOCATION=$(curl "${CURL_ARGS[@]}" -- "$URL" | perl -n -e '/^[Ll]ocation: (.*)$/ && print "$1\n"')
-if [[ "$full_info + $URL" =~ 'twitter.com'|'spiedigitallibrary.org'|'pipeline-hemis'|'sciencedirect.com'|'wiley.com'|'sagepub.com'|'ncbi.nlm.nih.gov'|'oxfordjournals.org'|'docker.com'|'ieeexplore.ieee.org'|'liebertpub.com'|'tandfonline.com'|'pnas.org'|'neurology.org'|'academic.oup.com'|'science.org'|'pubs.rsna.org'|'direct.mit.edu'|'thejns.org'|'rosped.ru'|'ajnr.org'|'bmj.com'|'biorxiv.org'|'%s' ]]; then
+if [[ "$full_info + $URL" =~ '%s' ]]; then
     echo -e "$filename: \x1B[33m⚠️  Warning - Skipping: $URL --> $LOCATION\x1B[0m"
     exit 0
 fi

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -42,6 +42,18 @@ if [[ $status_code -ge 200 && $status_code -le 299 ]];then
     exit 0
 fi
 
+# Check for "403 Forbidden" error code (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403)
+# From https://http.dev/403: "The client does not have access to the requested resource."
+# - Due to the rise of AI and LLMs, many sites are now blocking automated access to their content.
+# - Often there is no way to bypass this, so in the past we hardcoded the domains to an exclusion list.
+#   However, manually editing the blacklist is not a sustainable solution, so we now automatically filter
+#   out any sites that raise 403 with just a warning instead of an error.
+if [[ $status_code -eq 403 ]];then
+    echo "($status_code) $URL ($filename)" >> valid_urls.txt
+    echo -e "$filename: \x1B[32m⚠️  Warning - Forbidden - status code: $status_code for domain $URL  \x1B[0m"
+    exit 0
+fi
+
 # Check for "406 Not Acceptable" error code (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406)
 # From https://http.dev/406: "In practice, this error is rarely used because the server supplies a default
 #                             representation instead."


### PR DESCRIPTION
## Description

Because of the rise of AI/LLM web scrapers, more and more sites are forbidding access to automated checks. It's quite tedious to manually blacklist each site every time this happens. Sure, there's a small chance that we could manually find an alternate URL for a 403'ing URL. But, for most cases, if a site is giving us 403 Forbidden, there's not much we'll be able to do.

In theory, we could set up a system where we continue to blacklist domains, but manually check the URLs once they get blacklisted (so we at least know which domains to manually test). But, I fear that this is a lot of effort for a relatively minor nuisance. So, I'm content to just filter out 403 domains for now?

## Linked issues

Fixes #4897.
