### PR TITLE
Filter out `Version` and `CodeURL` when diffing JSON sidecars

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -37,6 +37,9 @@ jobs:
     # Add any file patterns you want ignored to 'check_url_blacklist.txt'
     - name: Check for broken links
       run: |
+        # Fail outright if any failure occurs, rather than attempting to proceed
+        set -eu -o pipefail
+
         # Get a list of files which have been changed from master on this branch
         git_diff_files=$(git diff origin/master... --name-only)
         
@@ -53,10 +56,11 @@ jobs:
           exit 0
         fi
         
-        git_diff_urls=$(grep -HEio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files")
+        # Get all urls within the changed files; the '||' is to prevent grep from crashing the entire script if it finds nothing
+        git_diff_urls=$(grep -HEio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files" || echo "")
         
         # If no URLs were found within, end early to avoid an error
-        if [[ "$?" == "1" ]]; then
+        if [[ "$git_diff_urls" == "" ]]; then
           echo "No URLs found in changed files, ending URL checks."
           exit 0
         fi


### PR DESCRIPTION
## Description

In https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4759, I added a highly sensitive test for `batch_processing.sh` that outputs warnings whenever file properties differ between `master` and PRs.

Because the test checks against filesize and md5 hashes, any sort of branch-specific metadata will throw false-positives. We already encountered this with output `.csv` files that report the SCT version (fixed in #4803), but we didn't catch the output `.json` sidecar files that also report the SCT version.

So, this PR mimics our CSV filtering to also filter JSON sidecar files, which should eliminate the remaining 12 false positives currently reported in PR warnings. From now on, if there are warnings on PRs, it will actually mean something. :)

![Screenshot from 2025-05-29 15-15-07](https://github.com/user-attachments/assets/32fc5e10-3730-4072-9abf-871d0d3bb5a1)

## Linked issues

Fixes #4886.