### PR TITLE
Fix `check-url` Github CI failing when no new URLs are present

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -37,9 +37,6 @@ jobs:
     # Add any file patterns you want ignored to 'check_url_blacklist.txt'
     - name: Check for broken links
       run: |
-        # Fail outright if any failure occurs, rather than attempting to proceed
-        set -eu -o pipefail
-        
         # Get a list of files which have been changed from master on this branch
         git_diff_files=$(git diff origin/master... --name-only)
         
@@ -56,17 +53,18 @@ jobs:
           exit 0
         fi
         
-        # Find any and all URLs contained within the remaining files
-        git_diff_urls=$(
-          grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files" |
-          sed 's/:/;/'
-        )
+        git_diff_urls=$(grep -HEio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files")
         
         # If no URLs were found within, end early to avoid an error
-        if [[ "$git_diff_urls" == "" ]]; then
+        if [[ "$?" == "1" ]]; then
           echo "No URLs found in changed files, ending URL checks."
           exit 0
         fi
+
+        # Replace all colons with semi-colons...
+        git_diff_urls=${git_diff_urls//":"/";"}
+        # ... then replace the https signatures to use colons again. Jank, but fast.
+        git_diff_urls=${git_diff_urls//"https;//"/"https://"}
         
         # Check each remaining file in the URL for validity
         xargs -rn 1 ".github/workflows/check-url.sh" <<< "$git_diff_urls"

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -39,19 +39,34 @@ jobs:
       run: |
         # Fail outright if any failure occurs, rather than attempting to proceed
         set -eu -o pipefail
-
-        # Generate list of URLs which exist within files which have changed
-        git_diff_urls=$(git diff origin/master... --name-only | 
-          xargs grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' |
-          sed 's/:/;/'
-        )
-                
-        # Filter out files which are in the blacklist
+        
+        # Get a list of files which have been changed from master on this branch
+        git_diff_files=$(git diff origin/master... --name-only)
+        
+        # Filter out any which are in the blacklist
         while read l; do
-          git_diff_urls=$(grep -v "$l" <<< "$git_diff_urls")
+          git_diff_files=$(grep -v "$l" <<< "$git_diff_files")
         # This `cat` call MUST be here; otherwise a subshell is created, and recursive variable updating is not possible
         #   Thank you to JN for figuring this out: https://stackoverflow.com/a/16854326
         done <<< $(cat ".github/workflows/check_url_blacklist.txt")
+        
+        # If no files remain, end here to avoid an error
+        if [[ "$git_diff_files" == "" ]]; then
+          echo "No files outside the blacklist were changed, ending URL checks."
+          exit 0
+        fi
+        
+        # Find any and all URLs contained within the remaining files
+        git_diff_urls=$(
+          grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files" |
+          sed 's/:/;/'
+        )
+        
+        # If no URLs were found within, end early to avoid an error
+        if [[ "$git_diff_urls" == "" ]]; then
+          echo "No URLs found in changed files, ending URL checks."
+          exit 0
+        fi
         
         # Check each remaining file in the URL for validity
         xargs -rn 1 ".github/workflows/check-url.sh" <<< "$git_diff_urls"


### PR DESCRIPTION
Mini-PR to fix a bug spotted by @joshuacwnewton, as described [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4857#pullrequestreview-2879399588).

Wasn't caught during initial testing, as the bug crops up only when a GitHub PR is made which happens to edit files without any URLs in it.