### PR TITLE
Remove default value from Apptainer bundling script to fix CI error

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       milestone_title:
         description: 'Milestone title (this release)'
-        required: true  # This does nothing! https://github.com/actions/runner/issues/1070
+        required: true
       dry_run:
         description: "Dry Run; if True, no changes are made on the repo and no release is made (but everything else is run!)"
         type: choice

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,9 @@ on:
     # > Scheduled workflows run on the latest commit on the default or base branch
     # i.e. this can only run on master
     - cron: '0 11 * * *'
+  pull_request:
+    branches:
+      - master
 
 env:
   MAIN_BRANCH: "master"

--- a/contrib/apptainer/bundle_for_release.sh
+++ b/contrib/apptainer/bundle_for_release.sh
@@ -3,11 +3,6 @@
 
 SCT_VERSION="$1"
 
-if [[ -z "$SCT_VERSION" ]]; then
-  echo "WARNING: No SCT version specified, defaulting to v7.0"
-  SCT_VERSION="7.0"
-fi
-
 # Change the version of SCT the installation task to be the requested version
 sed_str='s|sct_version="X.Y"|sct_version='"$SCT_VERSION"'|g'
 sed -e "$sed_str" "sct.def" > "sct_$SCT_VERSION.def"


### PR DESCRIPTION
## Description

Typically, automated (non-manual) runs of the `create-release.yml` workflow have used an empty (null) value for `milestone_title`. This has worked okay, since all of the steps are compatible with having an empty string in that place. 

However, in #4857, we added a new script that bundles the Apptainer files as well. And, this bundling script will fallback to a default value of 7.0. This works in the context of the script, but in the GitHub Actions workflow context, the default is still `""`, meaning the 7.0 file can't be found.

This PR removes the default value to allow it to run with `""` as per the norm.

> [!NOTE]
> Ideally, instead of allowing an empty version (""), we would set a default version in the outer GitHub Actions workflow context. However, GitHub makes it hard on us -- we can't just use the `default:` field of the workflow_dispatch trigger: https://github.com/orgs/community/discussions/26322
>
> So, instead, we begrudgingly allow empty values for `$SCT_VERSION`.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Amends #4857.
Fixes #4593.