### PR TITLE
Use `Path.resolve()` instead of `Path.absolute()`

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -603,7 +603,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     # Get the aspect ratio (height/width) based on pixel size. Consider only the first 2 slices.
     qc_image.aspect_img, qc_image.aspect_mask = qcslice.aspect()[:2]
 
-    path_input = Path(fname_in1).absolute()
+    path_input = Path(fname_in1).resolve()
     path_qc = Path(path_qc)
     command = process
     cmdline = [command]

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -165,7 +165,7 @@ def sct_register_multimodal(
 
     # Axial orientation, switch between two input images
     with create_qc_entry(
-        path_input=Path(fname_input).absolute(),
+        path_input=Path(fname_input).resolve(),
         path_qc=Path(path_qc),
         command=command,
         cmdline=list2cmdline(cmdline),
@@ -255,7 +255,7 @@ def sct_deepseg(
     cmdline.extend(argv)
 
     with create_qc_entry(
-        path_input=Path(fname_input).absolute(),
+        path_input=Path(fname_input).resolve(),
         path_qc=Path(path_qc),
         command=command,
         cmdline=list2cmdline(cmdline),
@@ -646,7 +646,7 @@ def sct_analyze_lesion(
 
     # Axial orientation, switch between one anat image and 1-2 seg images
     with create_qc_entry(
-        path_input=Path(fname_input).absolute(),
+        path_input=Path(fname_input).resolve(),
         path_qc=Path(path_qc),
         command=command,
         cmdline=list2cmdline(cmdline),

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -257,7 +257,7 @@ def relpath_or_abspath(child_path, parent_path):
     Try to find a relative path between a child path and its parent path. If it doesn't exist,
     then the child path is not within the parent path, so return its abspath instead.
     """
-    abspath = Path(child_path).absolute()
+    abspath = Path(child_path).resolve()
     try:
         return abspath.relative_to(parent_path)
     except ValueError:


### PR DESCRIPTION
Unlike `os.path.abspath()`, `pathlib.Path.absolute()` does _not_ remove `..` components from the path. This is unexpected, and causes subtle problems.

In contrast, `pathlib.Path.resolve()` removes `..` components (and also de-references symlinks along the path, which may lead to different surprises, but less likely).

`git grep 'absolute('` only found these instances to fix, and some unrelated uses of `np.absolute()`.

Fixes #4916.