### PR TITLE
Add safeguards to handle when `type=imseg` is used with `rot_method=pca`

### DIFF
--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -327,6 +327,13 @@ def register(src, dest, step, param):
     printv('  smoothWarpXY ... ' + step.smoothWarpXY, param.verbose)
     printv('  rot_method ..... ' + step.rot_method, param.verbose)
 
+    # validate `-param` here to fail early if invalid (but after displaying them to the user)
+    if step.algo == 'centermassrot':
+        valid_types = {'pca': 'seg', 'hog': 'imseg', 'pcahog': 'imseg'}
+        if step.type != valid_types[step.rot_method]:
+            raise ValueError(f"Parameter 'rot_method={step.rot_method}' is only valid for type={valid_types[step.rot_method]}', "
+                             f"not '{step.type}'. Please update your `-param` settings to use a valid combination.")
+
     # set metricSize
     if step.metric == 'MI':
         metricSize = '32'  # corresponds to number of bins

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -213,9 +213,9 @@ def get_parser():
               f"  - rot_method {{pca, hog, pcahog}}: rotation method to be used with algo=centermassrot. If using hog "
               f"or pcahog, type should be set to imseg. Default={DEFAULT_PARAMREGMULTI.steps['1'].rot_method}\n"
               f"    * pca: approximate cord segmentation by an ellipse and finds it orientation using PCA's "
-              f"eigenvectors\n"
-              f"    * hog: finds the orientation using the symmetry of the image\n"
-              f"    * pcahog: tries method pca and if it fails, uses method hog.\n")
+              f"eigenvectors (use with `type=seg`)\n"
+              f"    * hog: finds the orientation using the symmetry of the image (use with `type=imseg`)\n"
+              f"    * pcahog: tries method pca and if it fails, uses method hog (use with `type=imseg`).\n")
     )
     optional.add_argument(
         '-identity',


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] ~~**Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).~~
    - I'm a little concerned about writing a test for the new error, since it would be a fairly expensive test, as the error is thrown partway through the registration. Maybe this is a smell to move the check to `register_wrapper()`? See my extended commit message in abc700e78959ad6369d3c148e24334ad68c171fa.
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

If `type=imseg` is supplied with `rot_method=pca`, the wrong image (`im`) will be used instead of the required image (`seg`). This is due to some ambiguous filenaming conventions, which we fix in commit 2c21ae1f4fcbb15c6685fc0ef645df5a85903ca6.

However, that fix still allows the possibility for the user to erroneously specify `type=im` instead. So, we go even further and add an explicit check for each step to enforce `type=seg` for `rot_method=pca`.

Perhaps only the latter change is needed? But, I liked the idea of having redundancy, in the case that there's some other entry point to `register_slicewise()` besides the core `register()` function.

## Alternative solutions

Whether or not these are the correct fixes is totally up for discussion. But, I wanted to make minimal changes that didn't require a large refactor, e.g.:

- Explicitly passing `type` to the `register_slicewise` function (many layers deep!)
- Parsing the input filenames for `_seg` to determine filetype (brittle!)
- Updating the `register_slicewise()` arguments to have explicit values for `fname_src_im`, `fname_src_seg`, etc.

## Linked issues

Fixes #4873.
