### PR TITLE
Fix check for user's labels against template's labels by adopting `issubset` 

### DIFF
--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -439,10 +439,12 @@ def main(argv: Sequence[str]):
     image_label_template = Image(ftmp_template_label)
 
     labels_template = image_label_template.getNonZeroCoordinates(sorting='value')
-    if labels[-1].value > labels_template[-1].value:
-        printv('ERROR: Wrong landmarks input. Labels must have correspondence in template space. \nLabel max '
-               'provided: ' + str(labels[-1].value) + '\nLabel max from template: ' +
-               str(labels_template[-1].value), verbose, 'error')
+    max_label = max(label.value for label in labels if label.value not in [60])  # exclude cauda equina (60) from check
+    max_label_template = max(label.value for label in labels_template if label.value not in [60])
+    if max_label > max_label_template:
+        printv(f'ERROR: Wrong landmarks input. Labels must have correspondence in template space.\n'
+               f'Label max provided: {max_label}\n'
+               f'Label max from template: {max_label_template}', verbose, 'error')
 
     # if only one label is present, force affine transformation to be Tx,Ty,Tz only (no scaling)
     if len(labels) == 1:


### PR DESCRIPTION

## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

The presence of label `60` in the template was preventing this check from raising an error for any labels between 22 and 60 (e.g. a user had labels 22-25, which should have raised an error, but didn't).

Before: [Script would run until it hit an unrelated error]
After:

![image](https://github.com/user-attachments/assets/80d9b9a8-05e8-4738-abf9-263613f87299)


## Linked issues

Fixes #4872.
