### PR TITLE
Mask output of `sct_apply_transfo` when applying `-initwarp` during multimodal registration

### DIFF
--- a/spinalcordtoolbox/registration/core.py
+++ b/spinalcordtoolbox/registration/core.py
@@ -177,6 +177,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
                     '-d', dest[ifile],
                     '-o', add_suffix(src[ifile], '_reg'),
                     '-x', interp_step[ifile],
+                    '-crop', '3' if (i_step == 1 and fname_initwarp) else '0',
                     '-v', '0',
                     '-w'] + warp_forward
                 )

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -335,7 +335,7 @@ class Transform:
                 # Set zero to everything outside the warping field
                 cropper = ImageCropper(img_out)
                 cropper.get_bbox_from_ref(img_warp_ndim)
-                if crop_reference in 1:
+                if crop_reference == 1:
                     printv('Cropping strategy is: keep same matrix size, put 0 everywhere around warping field')
                     img_out = cropper.crop(background=0)
                 elif crop_reference == 2:

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -20,6 +20,7 @@ from spinalcordtoolbox.image import Image, generate_output_file, add_suffix
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import cubic_to_point
+from spinalcordtoolbox.resampling import resample_nib
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, get_interpolation, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, copy
@@ -344,7 +345,6 @@ class Transform:
                     img_out = cropper.crop()
             elif crop_reference == 3:
                 # Resample the warping field mask (in reference coordinates) into the space of the image to be cropped
-                from spinalcordtoolbox.resampling import resample_nib
                 img_ref_r = resample_nib(img_warp_ndim, image_dest=img_out, interpolation='nn', mode='constant')
                 # Simply mask the output image instead of doing a bounding-box-based crop
                 img_out.data = img_out.data * img_ref_r.data

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -14,6 +14,8 @@ import functools
 from typing import Sequence
 import textwrap
 
+import numpy as np
+
 from spinalcordtoolbox.image import Image, generate_output_file, add_suffix
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
@@ -317,12 +319,10 @@ class Transform:
         if not isLastAffine and crop_reference in [1, 2]:
             printv('Last transformation is not affine.')
             if crop_reference in [1, 2]:
-                # Extract only the first ndim of the warping field
+                # Extract only the first n dims of the warping field by creating a dummy image with the correct shape
                 img_warp = Image(warping_field)
-                if dim == '2':
-                    img_warp_ndim = Image(img_src.data[:, :], hdr=img_warp.hdr)
-                elif dim in ['3', '4']:
-                    img_warp_ndim = Image(img_src.data[:, :, :], hdr=img_warp.hdr)
+                warp_shape = img_warp.data.shape[:int(dim)]  # dim = {'2', '3', '4'}
+                img_warp_ndim = Image(np.ones(warp_shape), hdr=img_warp.hdr)
                 # Set zero to everything outside the warping field
                 cropper = ImageCropper(Image(fname_out))
                 cropper.get_bbox_from_ref(img_warp_ndim)

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -65,7 +65,15 @@ def get_parser():
         default=[])
     optional.add_argument(
         "-crop",
-        help="Crop Reference. 0: no reference, 1: sets background to 0, 2: use normal background, 3: mask the image.",
+        help="Crop the output image using the extents of the warping field.\n"
+             " - 0: no cropping (WARNING: may result in duplicated output if the destination image's FOV is "
+             "      larger than the FOV of the warping field)\n"
+             " - 1: crop using a rectangular bounding box around the warping field (setting outside voxels to 0)\n"
+             " - 2: crop using a rectangular bounding box around the warping field (changing the size of the output "
+             "      image)\n"
+             " - 3: mask the output image (setting outside voxels to 0) using the warping field directly instead of "
+             "      using a rectangular bounding box around the warping field. Useful if Option 1 does not zero out "
+             "      enough voxels.",
         type=int,
         default=0,
         choices=(0, 1, 2, 3))


### PR DESCRIPTION
## Checklist

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [X] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Context

Registration (e.g. `sct_register_to_template`) will produce warping fields that map the voxels in one coordinate space (e.g. the PAM50 template space) onto the space of another image. 

If a warping field is originally determined using an image with one FOV (e.g. a T2 image with dimensions (40, 515, 512)), but then the warping field is applied to an image with a different FOV (e.g. a dMRI image with dimensions (256, 256, 13)), then the ANTs tool `antsApplyTransforms` may hallucinate phantom copies of the image in areas where the initial warping field was not valid.

<details>
<summary> Warping field FOV (blue) vs. dMRI FOV (red) </summary>

![image](https://github.com/user-attachments/assets/058de15c-1ef1-4c23-afb5-bc829316abad)

</details>

<details>
<summary> Hallucinated copy outside of the warping field FOV </summary>

![image](https://github.com/user-attachments/assets/d774b8b6-1c72-4f65-836a-54b9907c35f4)

</details>

When would a warping field be applied to an image with a different FOV? Well, in fact, we do it all the time when we specify the `-initwarp` and `-initwarpinv` arguments [as a "pre-registration" step](https://spinalcordtoolbox.com/stable/user_section/tutorials/diffusion-weighted-mri/template-registration-for-dmri.html#registering-the-template-to-the-dti-space). 

(Side note: More often than not, this will affect `-initwarp` specifically, because the template -> anat will have different anat FOVs. `-initwarpinv` is spared, because the anat -> template uses the same destination space (the template) in both cases. However, in the case of e.g. multimodal non-template registration, `-ref template`, etc. this assumption may not hold.)

## Description

To mitigate this issue, because we have the warping field, it's possible to mask out any output voxels beyond the warping field FOV (considering them "invalid"), which removes this phantom copy:

<details>
<summary> Output warped image with phantom copy masked out </summary>

![image](https://github.com/user-attachments/assets/4eba1348-709f-4a2e-b1d7-cf70b1fde0b6)

</details> 

And as it turns out, `sct_apply_transfo` has an option called `-crop` which was already designed to perform this exact masking step, added all the way back in 2015. However, `-crop` is broken in several ways:

- It uses the wrong mask when cropping the image (data dimensions, rather than warping field dimensions)
- It uses a rectangular bounding box derived from the min/max coords of the warping field. This acts as a sort of [convex hull](https://scikit-image.org/docs/0.24.x/auto_examples/edges/plot_convex_hull.html), covering an area that's a little larger than the warping field itself, which may be too large and not mask out enough voxels.

To address these two issues, this PR adds the following fixes:

- Use the correct dimensions when creating the mask to use for `-crop`.
- Adds a new option to the `-crop` flag (`-crop 3`) to mask out voxels instead of just cropping with a rectangular bbox.

While `-crop 3` will solve the issue for user calls to `sct_apply_transfo`, it won't actually fix the problem in any scripts that internally call `sct_apply_transfo`. Because this issue is commonly seen inside `sct_register_multimodal` with `-initwarp`, I decided to turn on this flag when `-initwarp` is used (e.g. `step=1`).

I don't think changing this default should have any effect unless these phantom copies were present, and even then, the effect should only ever be positive. This should hopefully be confirmed by the fact that the `batch_processing` results should not change despite the use of `-initwarp`.

## Alternative approaches

In theory, we could crop the destination image to the same extents as the warping field instead (_before_ we apply `antsApplyTransform`, rather than after). Then, we would update the dimensions of the cropped output image to match the full FOV of the destination image. This would be more thorough and likely prevent phantom copies from appearing at all, which might be relevant in situations where the phantom copy [overlaps](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4876#issuecomment-2959955246) the true copy.

Note: The destination image would have to be truly cropped (i.e. changing the dimensions) and not just masking the voxels to `0`, since `antsApplyTransform` only cares about the destination FOV and not the contents of the destination image.

However, this is a more complicated approach that requires some care, because cropping the image changes the origin of the array (and thus the affine). I couldn't quite wrap my head around how to do this properly. (Something like generating the warping field mask, passing it to `sct_crop_image -mask`, running `antsApplyTransforms` on the cropped image, then... well, I'm not sure how to fix the dimensions of the output image. I thought about combining it with a `zeros_like` image, but `sct_maths -add` imposes a "same dimensions" restriction.)

Because of this, I stuck with the simpler approach of masking the output instead, which seems to work [well enough](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4876#issuecomment-2966803339) on the "overlapping" phantom copy cases.

## Linked issues

Fixes #4876.