### PR TITLE
Automatically reset the `stable` docs branch when creating a new release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -225,6 +225,4 @@ jobs:
       # - NOTE: This will wipe out all the previous backported changes, so make sure to also update `master`
       #   whenever we backport changes (so that they will be preserved when resetting the branch to the release).
       run: |
-        git checkout stable
-        git reset --hard ${{ github.event.inputs.milestone_title }}
-        git push --force
+        git push --force origin refs/tags/"${{ github.event.inputs.milestone_title }}":refs/heads/stable

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -216,3 +216,15 @@ jobs:
                     install_sct-${{ github.event.inputs.milestone_title }}_macos.sh,\
                     sct_apptainer_${{ github.event.inputs.milestone_title }}.tar.gz"
         draft: true
+
+    - name: Update `stable` docs branch to point to new release
+      # - We use a manual `stable` branch instead of ReadTheDocs' automated `stable` system.
+      # - This allows us to backport simple doc changes (e.g. typo fixes) to our `stable` branch
+      #   without having to create any new tags or releases.
+      # - When a new release is created, it becomes the new base of the `stable` branch.
+      # - NOTE: This will wipe out all the previous backported changes, so make sure to also update `master`
+      #   whenever we backport changes (so that they will be preserved when resetting the branch to the release).
+      run: |
+        git checkout stable
+        git reset --hard ${{ github.event.inputs.milestone_title }}
+        git push --force


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

This is a tiny PR that saves us a manual step when creating a new release.

I had done this manually when creating the 7.0 release:

![image](https://github.com/user-attachments/assets/2dcc1ee1-d366-4002-948c-778736f3e89e)

We could go even further with [`!stable-docs`](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4798#issue-2858234540) feature that would allow us to tag PRs for automatic backporting to `stable`? But, this comes up infrequently enough that I'm happy to perform `stable` docs backporting manually. (I think I'd feel more comfortable that way, too, given the public-facing nature of our docs.)

(Given this, I've [updated our dev Wiki](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Websites:-spinalcordtoolbox.com) as well to describe the procedure.)

## Linked issues

Fixes #4798.
