### PR TITLE
`sct_analyze_lesion` QC restrict lesion to spinal cord

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -670,6 +670,8 @@ def sct_analyze_lesion(
         # Get the total number of lesions; this will represent the number of rows in the figure. For example, if we have
         # 2 lesions, we will have two rows. One row per lesion.
         num_of_lesions = len(label_lst)
+        # Restrict the lesion mask to the spinal cord mask, as lesions should not occur outside the cord
+        im_lesion_data = im_lesion_data * im_sc_data
         # Get the sagittal lesion slices
         sagittal_lesion_slices = np.unique(np.where(im_lesion_data)[0])
         # Get the minimum sagittal slice with lesion. For example, if a lesion cover slices 7,8,9, get 7

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -406,8 +406,7 @@ class AnalyzeLesion:
         im_sc = Image(self.fname_sc)
         im_sc_data = im_sc.data
 
-        # Restrict the lesion mask to the spinal cord mask (from anatomical level, it does not make sense to have lesion
-        # outside the spinal cord mask)
+        # Restrict the lesion mask to the spinal cord mask, as lesions should not occur outside the cord
         im_lesion_data = im_lesion_data * im_sc_data
 
         # Get the dimensions of the lesion mask


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [ ] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

This is a tiny PR fixing an indexing error when generating tissue bridges QC for `sct_analyze_lesion`.

### Context:

I added the restriction of the lesion mask to the spinal cord mask -- the same operation is also done in the main `sct_analyze_lesion` script. In (rare) cases where the lesion mask contains slices outside spinal cord mask, the QC generation would fail because we are getting unique sag slices with lesions using `np.unique(np.where(im_lesion_data)[0])` and using the slice numbers to fetch tissue bridges from the XLSX file (which, however, was created from the restricted lesion and thus doesn't contain lesion slices outside the cord):

```
*** Generating Quality Control (QC) html report ***
Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3802, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5745, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5753, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'slice_7_dorsal_bridge_width [mm]'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 1216, in <module>
    main(sys.argv[1:])
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/scripts/sct_analyze_lesion.py", line 1179, in main
    sct_analyze_lesion(
  File "/Users/valosek/code/sct_latest/spinalcordtoolbox/reports/qc2.py", line 753, in sct_analyze_lesion
    dorsal_bridge_width_mm = measure_pd[col_name_dorsal][idx_row]
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.10/site-packages/pandas/core/frame.py", line 3807, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/Users/valosek/code/sct_latest/python/envs/venv_sct/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3804, in get_loc
    raise KeyError(key) from err
KeyError: 'slice_7_dorsal_bridge_width [mm]'
Total runtime; 3.865 seconds.
```

