### PR TITLE
Implement anisotropic dilation and erosion

### DIFF
--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -63,7 +63,7 @@ def _get_footprint(shape, size, dim):
         fp_x = ((r_y * np.arange(-r_x, r_x+1))**2).reshape((2*r_x+1, 1))
         fp_y = ((r_x * np.arange(-r_y, r_y+1))**2).reshape((1, 2*r_y+1))
         footprint = ((fp_x + fp_y) <= (r_x * r_y)**2).astype(np.uint8)
-    elif shape == 'cube':
+    elif shape == 'ball':
         # ellipsoid equation, after clearing denominators:
         # ((x - center_x)*radius_y*radius_z)**2
         # + ((y - center_y)*radius_x*radius_z)**2

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -8,7 +8,7 @@ License: see the file LICENSE
 import logging
 
 import numpy as np
-from skimage.morphology import erosion, dilation, disk, ball, footprint_rectangle
+from skimage.morphology import erosion, dilation
 from skimage.filters import threshold_local, threshold_otsu, rank
 from scipy.ndimage import gaussian_filter, gaussian_laplace, label, generate_binary_structure
 
@@ -32,24 +32,51 @@ def _get_footprint(shape, size, dim):
     Create footprint (prev. terminology: structuring element) of desired shape and radius
 
     :param shape: str: Shape of the footprint. See available options below in the code
-    :param size: int: size of the element.
+    :param size: int or list[int]: size of the element.
+            Can be specified as 2 or 3 values (depending on the 2D/3D shape) for anisotropic images.
     :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
     :return: numpy array: footprint
     """
-    # TODO: enable custom footprint
-    if shape in ['square', 'cube']:
-        n_dim = {'square': 2, 'cube': 3}[shape]
-        footprint = footprint_rectangle(shape=[size] * n_dim)
-    elif shape == 'disk':
-        footprint = disk(size)
-    elif shape == 'ball':
-        footprint = ball(size)
-    else:
-        raise ValueError("This shape is not a valid entry: {}".format(shape))
+    dimensionality = {
+        'square': 2,
+        'disk': 2,
+        'cube': 3,
+        'ball': 3,
+    }
+    if shape not in dimensionality:
+        raise ValueError(f"This shape is not a valid entry: {shape}")
 
-    if not (len(footprint.shape) in [2, 3] and footprint.shape[0] == footprint.shape[1]):
-        raise ValueError("Invalid shape")
+    # normalize `size` to be a list or 2 or 3 ints, depending on the 2D/3D kernel
+    if isinstance(size, int):
+        size = [size]
+    if len(size) == 1:
+        size = list(size) * dimensionality[shape]
+    if len(size) != dimensionality[shape]:
+        raise ValueError(f"Invalid size for shape {shape}: {size}")
+
+    if shape == 'disk':
+        # ellipse equation is: ((x - center_x)/radius_x)**2 + ((y - center_y)/radius_y)**2 <= 1
+        # clearing denominators: ((x - center_x)*radius_y)**2 + ((y - center_y)*radius_x)**2 <= (radius_x*radius_y)**2
+        r_x, r_y = size
+        # the thin arrays fp_x and fp_y will be efficiently broadcast to a full rectangle by numpy
+        fp_x = ((r_y * np.arange(-r_x, r_x+1))**2).reshape((2*r_x+1, 1))
+        fp_y = ((r_x * np.arange(-r_y, r_y+1))**2).reshape((1, 2*r_y+1))
+        footprint = ((fp_x + fp_y) <= (r_x * r_y)**2).astype(np.uint8)
+    elif shape == 'cube':
+        # ellipsoid equation, after clearing denominators:
+        # ((x - center_x)*radius_y*radius_z)**2
+        # + ((y - center_y)*radius_x*radius_z)**2
+        # + ((z - center_z)*radius_x*radius_y)**2
+        # <= (radius_x*radius_y*radius_z)**2
+        r_x, r_y, r_z = size
+        fp_x = ((r_y * r_z * np.arange(-r_x, r_x+1))**2).reshape((2*r_x+1, 1, 1))
+        fp_y = ((r_x * r_z * np.arange(-r_y, r_y+1))**2).reshape((1, 2*r_y+1, 1))
+        fp_z = ((r_x * r_y * np.arange(-r_z, r_z+1))**2).reshape((1, 1, 2*r_z+1))
+        footprint = ((fp_x + fp_y + fp_z) <= (r_x * r_y * r_z)**2).astype(np.uint8)
+    else:
+        assert shape in ['square', 'cube']
+        footprint = np.ones(size, dtype=np.uint8)
 
     # If 2d kernel, replicate it along the specified dimension
     if len(footprint.shape) == 2:
@@ -96,8 +123,9 @@ def dilate(data, size, shape, dim=None, islabel=False):
     Dilate data using ball structuring element
 
     :param data: Image or numpy array: 2d or 3d array
-    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).\
+    :param size: int or list[int]: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).\
         If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
+        Can be specified as 2 or 3 values (depending on the 2D/3D shape) for anisotropic images.
     :param shape: {'square', 'cube', 'disk', 'ball'}
     :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if\
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
@@ -195,8 +223,9 @@ def erode(data, size, shape, dim=None):
     Dilate data using ball structuring element
 
     :param data: Image or numpy array: 2d or 3d array
-    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).\
-    If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
+    :param size: int or list[int]: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).\
+        If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
+        Can be specified as 2 or 3 values (depending on the 2D/3D shape) for anisotropic images.
     :param shape: {'square', 'cube', 'disk', 'ball'}
     :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if\
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -257,20 +257,23 @@ def get_parser():
         metavar=Metavar.int,
         type=one_two_three_ints,
         action=AppendTodo,
-        help="Dilate binary or greyscale image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
-             "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
-             "the center element (size=0 has no effect). "
-             "If shape={'square', 'disk'}: size can be a single number of voxels, "
-             "or 2 numbers separated by `x` to get a rectangle/ellipse footprint (useful for anisotropic images). "
-             "If shape={'cube', 'ball'}: size can be a single number, or 3 numbers separated by `x` to get a box/ellipsoid.",
+        help="Dilate binary or greyscale image.\n"
+             "You can customize the structural element by combining the arguments `-dilate`, `-shape`, and `-dim`. "
+             "(The values passed to `-dilate` will control the side length or radius of whatever shape is chosen.)\n"
+             "You can provide either a single number, or 2/3 numbers separated by `x` (depending on the shape).\n"
+             "\n"
+             "Examples:\n"
+             "  - `-shape cube -dilate 3`            -> Side length 3   -> A 3x3x3 cube.\n"
+             "  - `-shape ball -dilate 2x2x5`        -> Radius 2x2x5    -> A 5x5x11 ball.\n"
+             "  - `-shape disk -dilate 3 -dim 2`     -> Radius 3        -> An 7x7 disk in the X-Y plane, applied to each Z slice.\n"
+             "  - `-shape square -dilate 1x4 -dim 0` -> Side length 1x4 -> A 1x4 rectangle in the Y-Z plane, applied to each X slice.",
         )
     mathematical.add_argument(
         '-erode',
         metavar=Metavar.int,
         type=one_two_three_ints,
         action=AppendTodo,
-        help="Erode binary or greyscale image with specified size. "
-             "The argument is interpreted the same way as for `-dilate`.",
+        help="Erode binary or greyscale image. The argument is interpreted the same way as for `-dilate`.",
         )
     mathematical.add_argument(
         '-shape',

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -69,6 +69,18 @@ def one_or_three_sigmas(arg: str) -> list[float]:
     return values
 
 
+def one_two_three_ints(arg: str) -> list[int]:
+    """
+    Parse the arguments for `-dilate` and `-erode`.
+
+    Returns a list of 1, 2, or 3 ints, measured in voxels.
+    """
+    values = [int(v) for v in arg.split('x')]
+    if len(values) not in [1, 2, 3]:
+        raise ValueError(f"expected 1, 2, or 3 values, got {len(values)}")
+    return values
+
+
 class AppendTodo(argparse.Action):
     """
     Store the arguments of an sct_maths operation in `arguments.todo`.
@@ -243,20 +255,22 @@ def get_parser():
     mathematical.add_argument(
         '-dilate',
         metavar=Metavar.int,
-        type=int,
+        type=one_two_three_ints,
         action=AppendTodo,
         help="Dilate binary or greyscale image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
              "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
-             "the center element (size=0 has no effect).",
+             "the center element (size=0 has no effect). "
+             "If shape={'square', 'disk'}: size can be a single number of voxels, "
+             "or 2 numbers separated by `x` to get a rectangle/ellipse footprint (useful for anisotropic images). "
+             "If shape={'cube', 'ball'}: size can be a single number, or 3 numbers separated by `x` to get a box/ellipsoid.",
         )
     mathematical.add_argument(
         '-erode',
         metavar=Metavar.int,
-        type=int,
+        type=one_two_three_ints,
         action=AppendTodo,
-        help="Erode binary or greyscale image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
-             "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
-             "the center element (size=0 has no effect).",
+        help="Erode binary or greyscale image with specified size. "
+             "The argument is interpreted the same way as for `-dilate`.",
         )
     mathematical.add_argument(
         '-shape',
@@ -410,6 +424,24 @@ def main(argv: Sequence[str]):
             dim = None
         else:
             parser.error(f"-dim should not be specified for -shape {shape}")
+
+    for arg_name, arg_value in arguments.todo:
+        if arg_name in ['dilate', 'erode']:
+            if shape in ['disk', 'square']:
+                # 2D kernels need 1 or 2 values for the size argument
+                # if 1 value is supplied, we repeat it to get 2 values
+                if len(arg_value) == 1:
+                    arg_value.extend(arg_value)
+                elif len(arg_value) == 3:
+                    parser.error(f"-{arg_name} needs 1 or 2 values for -shape {shape}, but got 3")
+            else:
+                assert shape in ['ball', 'cube']
+                # 3D kernels need 1 or 3 values for the size argument
+                # if 1 value is supplied, we repeat it to get 3 values
+                if len(arg_value) == 1:
+                    arg_value.extend(arg_value + arg_value)
+                elif len(arg_value) == 2:
+                    parser.error(f"-{arg_name} needs 1 or 3 values for -shape {shape}, but got 2")
 
     # Check that the list of operations makes sense
     if not arguments.todo:


### PR DESCRIPTION
This allows using the `sct_maths -dilate` and `-erode` operations with a single number of voxels (as before), or a list of 2 or 3 numbers separated by `x`, like `1x2x3`, which can be useful for anisotropic images.

While `skimage.morphology.footprint_rectangle` works for 2D and 3D box shapes, the `disk` and `ball` functions only take a single radius. The `ellipse` function could have worked for 2D, but not for 3D, and it confusingly turns (width, height) arguments into a (height, width) resulting array. I decided that it was simpler to just generate the correct numpy array directly.

Fixes #4936.