### PR TITLE
Make it easier to manually check QC reports produced by `pytest`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -154,7 +154,14 @@ jobs:
 
     - name: Run sct_testing
       run: |
-        sct_testing
+        sct_testing --basetemp="$GITHUB_WORKSPACE/tempdir"
+
+    - name: Upload QC
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Pytest QC (${{ matrix.os }})
+        path: "${{ github.workspace }}/tempdir/qc-report-current"
 
   create-release:
     needs: [test-release, generate-install-methods]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,6 +224,12 @@ jobs:
       - name: Run pytest test suite
         run: |
           ./.ci.sh -t
+      - name: Upload QC
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pytest QC (${{ matrix.os }})
+          path: "/tmp/pytest-of-runner/pytest-current/qc-report-current"
 
   ubuntu-22_04:
     name: Ubuntu 24.04 (Noble Numbat)

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -163,7 +163,7 @@ def compute_expected_measurements(lesion_params, path_seg=None):
     # Lesion partly outside the spinal cord segmentation (z (LR) slice 19 is outside the SC seg)
     ([(29, 40, 19), (3, 3, 5)], 0.001)
 ], indirect=["dummy_lesion"])
-def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements(dummy_lesion, rtol, tmp_path):
+def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements(dummy_lesion, rtol, tmp_path, tmp_path_qc):
     """Run the CLI script and verify that the lesion measurements match
     expected values."""
     # Run the analysis on the dummy lesion file
@@ -172,7 +172,7 @@ def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements(dummy_les
     sct_analyze_lesion.main(argv=['-m', path_lesion,
                                   '-s', path_seg,
                                   '-ofolder', str(tmp_path),
-                                  '-qc', str(tmp_path / "qc")])
+                                  '-qc', tmp_path_qc])
 
     # Test presence of output files
     _, fname, _ = extract_fname(path_lesion)
@@ -229,14 +229,14 @@ def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements(dummy_les
       [(29, 45, 25), (3, 10, 2)]], 0.01)
 ], indirect=["dummy_lesion"])
 def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements_without_segmentation(dummy_lesion, rtol,
-                                                                                            tmp_path):
+                                                                                            tmp_path, tmp_path_qc):
     """Run the CLI script without providing SC segmentation -- only volume is computed. Max_equivalent_diameter and
     length are nan."""
     # Run the analysis on the dummy lesion file
     path_lesion, lesion_params = dummy_lesion
     sct_analyze_lesion.main(argv=['-m', path_lesion,
                                   '-ofolder', str(tmp_path),
-                                  '-qc', str(tmp_path / 'qc')])  # A warning will be printed because no SC seg
+                                  '-qc', tmp_path_qc])  # A warning will be printed because no SC seg
 
     # Test presence of output files
     _, fname, _ = extract_fname(path_lesion)

--- a/testing/cli/test_cli_sct_deepseg_gm.py
+++ b/testing/cli/test_cli_sct_deepseg_gm.py
@@ -11,11 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_deepseg_gm_check_dice_coefficient_against_groundtruth():
+def test_sct_deepseg_gm_check_dice_coefficient_against_groundtruth(tmp_path_qc):
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
     fname_out = 'output.nii.gz'
     fname_gt = sct_test_path('t2s', 't2s_uncropped_gmseg_manual.nii.gz')
     sct_deepseg_gm.main(argv=['-i', sct_test_path('t2s', 't2s_uncropped.nii.gz'),
-                              '-o', fname_out, '-qc', 'testing-qc'])
+                              '-o', fname_out, '-qc', tmp_path_qc])
     dice_segmentation = compute_dice(Image(fname_out), Image(fname_gt), mode='3d', zboundaries=False)
     assert dice_segmentation >= 0.85

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -28,8 +28,7 @@ def test_sct_deepseg_sc_check_output_qform_sform(tmp_path):
 
 
 @pytest.mark.sct_testing
-def test_sct_deepseg_sc_qc_report_exists():
-    dir_qc = 'testing-qc'
+def test_sct_deepseg_sc_qc_report_exists(tmp_path_qc):
     with pytest.deprecated_call():
-        sct_deepseg_sc.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', dir_qc])
-    assert os.path.isfile(os.path.join(dir_qc, 'index.html'))
+        sct_deepseg_sc.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', tmp_path_qc])
+    assert os.path.isfile(os.path.join(tmp_path_qc, 'index.html'))

--- a/testing/cli/test_cli_sct_deepseg_sc.py
+++ b/testing/cli/test_cli_sct_deepseg_sc.py
@@ -13,11 +13,11 @@ from spinalcordtoolbox.image import Image
 logger = logging.getLogger(__name__)
 
 
-def test_sct_deepseg_sc_check_output_qform_sform(tmp_path):
+def test_sct_deepseg_sc_check_output_qform_sform(tmp_path, tmp_path_qc):
     fname_in = sct_test_path('t2', 't2.nii.gz')
     fname_out = str(tmp_path / 'test_seg.nii.gz')
     with pytest.deprecated_call():
-        sct_deepseg_sc.main(argv=['-i', fname_in, '-c', 't2', '-o', fname_out])
+        sct_deepseg_sc.main(argv=['-i', fname_in, '-c', 't2', '-o', fname_out, '-qc', tmp_path_qc])
     # Ensure sform/qform of the segmentation matches that of the input images
     im_in = Image(fname_in)
     im_seg = Image(fname_out)

--- a/testing/cli/test_cli_sct_detect_pmj.py
+++ b/testing/cli/test_cli_sct_detect_pmj.py
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_detect_pmj_check_euclidean_distance_against_groundtruth():
+def test_sct_detect_pmj_check_euclidean_distance_against_groundtruth(tmp_path_qc):
     """Run the CLI script and verify that euclidean distances between predicted and ground truth coordinates
     are within a certain threshold."""
     fname_in = sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz')
     fname_out = 'PAM50_small_t2_pmj.nii.gz'
     fname_gt = sct_test_path('template', 'template', 'PAM50_small_t2_pmj_manual.nii.gz')
-    sct_detect_pmj.main(argv=['-i', fname_in, '-o', fname_out, '-c', 't2', '-qc', 'testing-qc'])
+    sct_detect_pmj.main(argv=['-i', fname_in, '-o', fname_out, '-c', 't2', '-qc', tmp_path_qc])
 
     im_pmj = Image(fname_out)
     im_pmj_manual = Image(fname_gt)

--- a/testing/cli/test_cli_sct_fmri_compute_tsnr.py
+++ b/testing/cli/test_cli_sct_fmri_compute_tsnr.py
@@ -31,7 +31,7 @@ def img_mask(tmp_path):
     return fname_out
 
 
-def test_sct_sct_fmri_compute_tsnr_with_mask(tmp_path, img_mask):
+def test_sct_sct_fmri_compute_tsnr_with_mask(tmp_path, tmp_path_qc, img_mask):
     """Run the CLI script using a mask image (to test the QC)."""
     sct_fmri_compute_tsnr.main(argv=['-i', sct_test_path('fmri', 'fmri.nii.gz'), '-m', img_mask,
-                                     '-o', 'out_fmri_tsnr.nii.gz', '-qc', str(tmp_path)])
+                                     '-o', 'out_fmri_tsnr.nii.gz', '-qc', tmp_path_qc])

--- a/testing/cli/test_cli_sct_fmri_compute_tsnr.py
+++ b/testing/cli/test_cli_sct_fmri_compute_tsnr.py
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 def test_sct_sct_fmri_compute_tsnr_no_checks():
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_fmri_compute_tsnr.main(argv=['-i', sct_test_path('fmri', 'fmri.nii.gz'),
-                                     '-o', 'out_fmri_tsnr.nii.gz'])
+    sct_fmri_compute_tsnr.main(argv=['-i', sct_test_path('fmri', 'fmri.nii.gz'), '-o', 'out_fmri_tsnr.nii.gz'])
 
 
 @pytest.fixture()

--- a/testing/cli/test_cli_sct_fmri_moco.py
+++ b/testing/cli/test_cli_sct_fmri_moco.py
@@ -3,14 +3,28 @@
 import pytest
 import logging
 
-from spinalcordtoolbox.scripts import sct_fmri_moco
+from spinalcordtoolbox.scripts import sct_fmri_moco, sct_deepseg, sct_maths
 from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='module')
+def fmri_mean_seg(tmp_path_factory):
+    """Mean segmented image for QC report generation."""
+    tmp_path = tmp_path_factory.mktemp('fmri_mean_seg')
+    path_mean = str(tmp_path / 'fmri_mean.nii.gz')
+    path_out = str(tmp_path / 'fmri_mean_seg.nii.gz')
+
+    sct_maths.main(argv=['-i', sct_test_path('fmri', 'fmri.nii.gz'), '-mean', 't',
+                         '-o', path_mean])
+    sct_deepseg.main(argv=['spinalcord', '-i', path_mean, '-o', path_out, '-qc', str(tmp_path)])
+    return path_out
+
+
 @pytest.mark.sct_testing
-def test_sct_fmri_moco_no_checks():
+def test_sct_fmri_moco_no_checks(tmp_path_qc, fmri_mean_seg):
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_fmri_moco.main(argv=['-i', sct_test_path('fmri', 'fmri_r.nii.gz'), '-g', '4', '-x', 'nn', '-r', '0'])
+    sct_fmri_moco.main(argv=['-i', sct_test_path('fmri', 'fmri_r.nii.gz'), '-g', '4', '-x', 'nn', '-r', '0',
+                             '-qc', tmp_path_qc, '-qc-seg', fmri_mean_seg])

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize('space', ["pix", "phys"])
-def test_sct_get_centerline_output_file_exists(tmp_path, space):
+def test_sct_get_centerline_output_file_exists(tmp_path, tmp_path_qc, space):
     """This test checks the output file using default usage of the CLI script.
 
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)
@@ -24,17 +24,17 @@ def test_sct_get_centerline_output_file_exists(tmp_path, space):
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774/commits/5e6bd57abf6bcf825cd110e0d74b8e465d298409
        * https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/2774#discussion_r450546434"""
     sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-space', space,
-                                  '-qc', str(tmp_path)])
+                                  '-qc', tmp_path_qc])
     for file in [sct_test_path('t2s', 't2s_centerline.nii.gz'), sct_test_path('t2s', 't2s_centerline.csv')]:
         assert os.path.exists(file)
 
 
 @pytest.mark.sct_testing
 @pytest.mark.parametrize('ext', ["", ".nii.gz"])
-def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, ext):
+def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, tmp_path_qc, ext):
     """This test checks the '-o' argument with and without an extension to
     ensure that the correct output file is created either way."""
-    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-qc', str(tmp_path),
+    sct_get_centerline.main(argv=['-i', sct_test_path('t2s', 't2s.nii.gz'), '-c', 't2s', '-qc', tmp_path_qc,
                                   '-o', os.path.join(tmp_path, 't2s_centerline'+ext)])
     for file in [sct_test_path('t2s', 't2s_centerline.nii.gz'), sct_test_path('t2s', 't2s_centerline.csv')]:
         assert os.path.exists(file)

--- a/testing/cli/test_cli_sct_get_centerline.py
+++ b/testing/cli/test_cli_sct_get_centerline.py
@@ -41,7 +41,7 @@ def test_sct_get_centerline_output_file_exists_with_o_arg(tmp_path, tmp_path_qc,
 
 
 @pytest.mark.sct_testing
-def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
+def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path, tmp_path_qc):
     """
     This test checks two necessary conditions of the soft centerline:
 
@@ -51,7 +51,8 @@ def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
     # Condition 1: All slices of the soft centerline sum to 1
     sct_get_centerline.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                   '-method', 'fitseg', '-centerline-soft', '1', '-o',
-                                  os.path.join(tmp_path, 't2_seg_centerline_soft.nii.gz')])
+                                  os.path.join(tmp_path, 't2_seg_centerline_soft.nii.gz'),
+                                  '-qc', tmp_path_qc])
     im_soft = Image(os.path.join(tmp_path, 't2_seg_centerline_soft.nii.gz'))
     # Sum soft centerline intensities in the (x,y) plane, across all slices
     sum_over_slices = np.apply_over_axes(np.sum, im_soft.data, [0, 2]).flatten()
@@ -61,7 +62,8 @@ def test_sct_get_centerline_soft_sums_to_one_and_overlaps_with_bin(tmp_path):
     # Condition 2: The max voxels of the soft centerline overlap with the binary centerline
     sct_get_centerline.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                   '-method', 'fitseg', '-centerline-soft', '0', '-o',
-                                  os.path.join(tmp_path, 't2_seg_centerline_bin.nii.gz')])
+                                  os.path.join(tmp_path, 't2_seg_centerline_bin.nii.gz'),
+                                  '-qc', tmp_path_qc])
     im_bin = Image(os.path.join(tmp_path, 't2_seg_centerline_bin.nii.gz'))
     # Find the maximum intensity voxel across all slices in soft centerline and binary centerline
     max_over_slices_soft = np.apply_over_axes(np.max, im_soft.data, [0, 2])

--- a/testing/cli/test_cli_sct_image.py
+++ b/testing/cli/test_cli_sct_image.py
@@ -86,7 +86,7 @@ def test_sct_image_display_warp_check_output_exists():
     assert os.path.exists(sct_test_path('t2', fname_out))
 
 
-def test_sct_image_stitch(tmp_path):
+def test_sct_image_stitch(tmp_path, tmp_path_qc):
     """Run the CLI script and check that the stitched file was generated."""
     # crop images for testing stitching function
     path_in = sct_test_path('t2', 't2.nii.gz')
@@ -98,5 +98,5 @@ def test_sct_image_stitch(tmp_path):
                               '-ymin', '0', '-ymax', '20', '-zmin', '0', '-zmax', '51'])
 
     fname_out = os.path.join(tmp_path, 'stitched.nii.gz')
-    sct_image.main(argv=['-i', fname_roi1, fname_roi2, '-o', fname_out, '-stitch', '-qc', str(tmp_path)])
+    sct_image.main(argv=['-i', fname_roi1, fname_roi2, '-o', fname_out, '-stitch', '-qc', tmp_path_qc])
     assert os.path.exists(fname_out)

--- a/testing/cli/test_cli_sct_label_utils.py
+++ b/testing/cli/test_cli_sct_label_utils.py
@@ -14,28 +14,30 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_label_utils_cubic_to_point():
+def test_sct_label_utils_cubic_to_point(tmp_path_qc):
     """Run the CLI script and verify the resulting center of mass coordinate."""
     fname_out = 'test_centerofmass.nii.gz'
-    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-cubic-to-point', '-o', fname_out])
+    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-cubic-to-point', '-o', fname_out,
+                               '-qc', tmp_path_qc])
     # Note: Old, broken 'sct_testing' test used '31,28,25,1' as ground truth. Is this a regression?
     assert Image(fname_out).getNonZeroCoordinates() == [Coordinate([31, 27, 25, 1])]
 
 
 @pytest.mark.sct_testing
-def test_sct_label_utils_create():
+def test_sct_label_utils_create(tmp_path_qc):
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
-    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-create', '1,1,1,1:2,2,2,2'])
+    sct_label_utils.main(argv=['-i', sct_test_path('t2', 't2_seg-manual.nii.gz'), '-create', '1,1,1,1:2,2,2,2',
+                               '-qc', tmp_path_qc])
 
 
-def test_create_seg_mid(tmp_path):
+def test_create_seg_mid(tmp_path, tmp_path_qc):
     """Test the '-create-seg-mid' option in sct_label_utils."""
     input = sct_test_path('t2', 't2_seg-manual.nii.gz')
     output = str(tmp_path/'t2_seg_labeled.nii.gz')
 
     # Create a single label using the new syntax
-    sct_label_utils.main(['-i', input, '-create-seg-mid', '3', '-o', output])
+    sct_label_utils.main(['-i', input, '-create-seg-mid', '3', '-o', output, '-qc', tmp_path_qc])
     output_img = Image(output)
     labels = np.argwhere(output_img.data)
     assert len(labels) == 1
@@ -50,7 +52,7 @@ def test_create_seg_mid(tmp_path):
         sct_label_utils.main(['-i', input, '-create-seg', '-1,3', '-o', output])
 
 
-def test_project_centerline(tmp_path):
+def test_project_centerline(tmp_path, tmp_path_qc):
     """Test the '-project-centerline' option in sct_label_utils"""
     # Use an image as a shape reference
     img = str(tmp_path/'t2.nii.gz')
@@ -71,7 +73,8 @@ def test_project_centerline(tmp_path):
     sct_label_utils.main([
         '-i', img,
         '-o', ref,
-        '-create', '1,1,1,1:1,2,3,4:10,11,25,25'
+        '-create', '1,1,1,1:1,2,3,4:10,11,25,25',
+        '-qc', tmp_path_qc
         ])
 
     # Project the ref point on the previous line
@@ -79,7 +82,8 @@ def test_project_centerline(tmp_path):
     sct_label_utils.main([
         '-i', mask,
         '-o', out,
-        '-project-centerline', ref
+        '-project-centerline', ref,
+        '-qc', tmp_path_qc
         ])
 
     # The coordinates of this projection should be equal to x=20, y=15, z=1

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -28,14 +28,14 @@ def test_sct_label_vertebrae_consistent_disc(tmp_path):
 
 
 @pytest.mark.sct_testing
-def test_sct_label_vertebrae_initfile_qc_no_checks():
+def test_sct_label_vertebrae_initfile_qc_no_checks(tmp_path_qc):
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
     sct_label_vertebrae.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
                                    '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                    '-c', 't2',
                                    '-initfile', sct_test_path('t2', 'init_label_vertebrae.txt'),
-                                   '-t', sct_test_path('template'), '-qc', 'testing-qc'])
+                                   '-t', sct_test_path('template'), '-qc', tmp_path_qc])
 
 
 def test_sct_label_vertebrae_initz_error():

--- a/testing/cli/test_cli_sct_label_vertebrae.py
+++ b/testing/cli/test_cli_sct_label_vertebrae.py
@@ -14,12 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_label_vertebrae_consistent_disc(tmp_path):
+def test_sct_label_vertebrae_consistent_disc(tmp_path, tmp_path_qc):
     """Check that all expected output labeled discs exist"""
     fname_ref = sct_test_path('t2', 'labels.nii.gz')
     sct_label_vertebrae.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
                                    '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
-                                   '-c', 't2', '-discfile', fname_ref, '-ofolder', str(tmp_path)])
+                                   '-c', 't2', '-discfile', fname_ref, '-ofolder', str(tmp_path),
+                                   '-qc', tmp_path_qc])
     ref = Image(fname_ref)
     pred = Image(os.path.join(tmp_path, 't2_seg-manual_labeled_discs.nii.gz'))
     fp, fn = check_missing_label(pred, ref)
@@ -118,7 +119,7 @@ def test_sct_label_vertebrae_initial_disc_too_low(capsys, tmp_path):
     assert 'Initial disc is not in template.' in capsys.readouterr().out
 
 
-def test_sct_label_vertebrae_clean_labels(tmp_path):
+def test_sct_label_vertebrae_clean_labels(tmp_path, tmp_path_qc):
     im_seg = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
     dice_score = {}
     for i in [0, 1, 2]:
@@ -127,7 +128,8 @@ def test_sct_label_vertebrae_clean_labels(tmp_path):
                                   '-c', 't2',
                                   '-initz', '40,3',
                                   '-clean-labels', str(i),
-                                  '-ofolder', str(tmp_path/str(i))])
+                                  '-ofolder', str(tmp_path/str(i)),
+                                  '-qc', tmp_path_qc])
         im_labeled_seg = Image(str(tmp_path/str(i)/'t2_seg-manual_labeled.nii.gz'))
         # binarization (because labels are 2.0, 3.0, 4.0)
         im_labeled_seg.data = im_labeled_seg.data > 0.5
@@ -137,7 +139,7 @@ def test_sct_label_vertebrae_clean_labels(tmp_path):
     assert dice_score[1] >= dice_score[0]
 
 
-def test_sct_label_vertebrae_disc_discontinuity_center_of_mass_error(tmp_path, caplog):
+def test_sct_label_vertebrae_disc_discontinuity_center_of_mass_error(tmp_path, tmp_path_qc, caplog):
     # Generate a discontinuity next to an intervertebral disc
     t2_seg = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
     t2_seg.data[:, 16, :] = 0
@@ -147,5 +149,5 @@ def test_sct_label_vertebrae_disc_discontinuity_center_of_mass_error(tmp_path, c
     # Ensure the discontinuity is detected and an interpolated centerline is used instead
     sct_label_vertebrae.main(['-i', sct_test_path('t2', 't2.nii.gz'), '-s', path_out, '-c', 't2',
                               '-initfile', sct_test_path('t2', 'init_label_vertebrae.txt'),
-                              '-ofolder', str(tmp_path)])
+                              '-ofolder', str(tmp_path), '-qc', tmp_path_qc])
     assert "Using interpolated centerline" in caplog.text

--- a/testing/cli/test_cli_sct_process_segmentation.py
+++ b/testing/cli/test_cli_sct_process_segmentation.py
@@ -34,11 +34,12 @@ def dummy_3d_pmj_label():
     return filename
 
 
-def test_sct_process_segmentation_check_pmj(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path):
+def test_sct_process_segmentation_check_pmj(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path, tmp_path_qc):
     """ Run sct_process_segmentation with -pmj, -pmj-distance and -pmj-extent and check the results"""
     filename = str(tmp_path / 'tmp_file_out.csv')
     sct_process_segmentation.main(argv=['-i', dummy_3d_mask_nib, '-pmj', dummy_3d_pmj_label,
-                                        '-pmj-distance', '8', '-pmj-extent', '4', '-o', filename])
+                                        '-pmj-distance', '8', '-pmj-extent', '4', '-o', filename,
+                                        '-qc', tmp_path_qc, '-qc-image', dummy_3d_mask_nib])
     with open(filename, "r") as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         row = next(reader)
@@ -48,7 +49,7 @@ def test_sct_process_segmentation_check_pmj(dummy_3d_mask_nib, dummy_3d_pmj_labe
         assert row['SUM(length)'] == '4.0'
 
 
-def test_sct_process_segmentation_check_pmj_reoriented(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path):
+def test_sct_process_segmentation_check_pmj_reoriented(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path, tmp_path_qc):
     """
     Make sure that the results are the same regardless of the input orientation.
 
@@ -75,7 +76,8 @@ def test_sct_process_segmentation_check_pmj_reoriented(dummy_3d_mask_nib, dummy_
     results = []
     for fnames in fname_dict.values():
         sct_process_segmentation.main(argv=['-i', fnames["i"], '-pmj', fnames["i"], '-o', fnames["out"],
-                                            '-pmj-distance', '8', '-pmj-extent', '4'])
+                                            '-pmj-distance', '8', '-pmj-extent', '4',
+                                            '-qc', tmp_path_qc, '-qc-image', dummy_3d_mask_nib])
         with open(fnames["out"], "r") as csvfile:
             reader = csv.DictReader(csvfile, delimiter=',')
             results.append(next(reader))
@@ -85,11 +87,12 @@ def test_sct_process_segmentation_check_pmj_reoriented(dummy_3d_mask_nib, dummy_
             assert results[0][key] == results[1][key]
 
 
-def test_sct_process_segmentation_check_pmj_perslice(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path):
+def test_sct_process_segmentation_check_pmj_perslice(dummy_3d_mask_nib, dummy_3d_pmj_label, tmp_path, tmp_path_qc):
     """ Run sct_process_segmentation with -pmj, -perslice and check the results"""
     filename = str(tmp_path / 'tmp_file_out.csv')
     sct_process_segmentation.main(argv=['-i', dummy_3d_mask_nib, '-pmj', dummy_3d_pmj_label,
-                                        '-perslice', '1', '-o', filename])
+                                        '-perslice', '1', '-o', filename,
+                                        '-qc', tmp_path_qc, '-qc-image', dummy_3d_mask_nib])
     with open(filename, "r") as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         rows = list(reader)

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
 @pytest.mark.sct_testing
-def test_sct_propseg_check_dice_coefficient_against_groundtruth():
+def test_sct_propseg_check_dice_coefficient_against_groundtruth(tmp_path_qc):
     """Run the CLI script and verify that dice (computed against ground truth) is within a certain threshold."""
-    sct_propseg.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', 'testing-qc'])
+    sct_propseg.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-qc', tmp_path_qc])
 
     # open output segmentation
     im_seg = Image('t2_seg.nii.gz')

--- a/testing/cli/test_cli_sct_propseg.py
+++ b/testing/cli/test_cli_sct_propseg.py
@@ -43,17 +43,18 @@ def test_isct_propseg_compatibility():
 
 
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
-def test_sct_propseg_o_flag(tmp_path):
+def test_sct_propseg_o_flag(tmp_path, tmp_path_qc):
     sct_propseg.main(['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-ofolder', str(tmp_path),
-                      '-o', 'test_seg.nii.gz'])
+                      '-o', 'test_seg.nii.gz', '-qc', tmp_path_qc])
     output_files = {f for f in os.listdir(tmp_path)}
     assert output_files == {'t2_centerline.nii.gz', 'test_seg.nii.gz'}
 
 
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="sct_propseg is not supported on Windows")
-def test_sct_propseg_optional_output_files(tmp_path):
+def test_sct_propseg_optional_output_files(tmp_path, tmp_path_qc):
     sct_propseg.main(['-i', sct_test_path('t2', 't2.nii.gz'), '-c', 't2', '-ofolder', str(tmp_path),
-                      '-mesh', '-CSF', '-centerline-coord', '-cross', '-init-tube', '-low-resolution-mesh'])
+                      '-mesh', '-CSF', '-centerline-coord', '-cross', '-init-tube', '-low-resolution-mesh',
+                      '-qc', tmp_path_qc])
     output_files = {f for f in os.listdir(tmp_path)}
     assert output_files == {
         't2_seg.nii.gz', 't2_centerline.nii.gz',     # default output files

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -155,7 +155,7 @@ def test_sct_register_multimodal_with_labels(capsys, tmp_path, algo):
     assert "has no effect for 'type=label' registration." in capsys.readouterr().out
 
 
-def test_sct_register_multimodal_with_qc_without_dseg(capsys, tmp_path):
+def test_sct_register_multimodal_with_qc_without_dseg(capsys, tmp_path, tmp_path_qc):
     """
     Test if an error is raised when using QC ('-qc') without providing a destination segmentation ('-dseg').
     """
@@ -163,5 +163,5 @@ def test_sct_register_multimodal_with_qc_without_dseg(capsys, tmp_path):
         sct_register_multimodal.main(['-i', sct_test_path('t2', 't2.nii.gz'),
                                       '-d', sct_test_path('t2', 't2.nii.gz'),
                                       '-ofolder', str(tmp_path),
-                                      '-qc', str(tmp_path)])
+                                      '-qc', tmp_path_qc])
     assert pytest_wrapped_e.value.code == 2

--- a/testing/cli/test_cli_sct_register_multimodal.py
+++ b/testing/cli/test_cli_sct_register_multimodal.py
@@ -13,7 +13,7 @@ from spinalcordtoolbox.scripts import sct_register_multimodal, sct_create_mask
 logger = logging.getLogger(__name__)
 
 
-def test_sct_register_multimodal_mask_files_exist(tmp_path):
+def test_sct_register_multimodal_mask_files_exist(tmp_path, tmp_path_qc):
     """
     Run the script without validating results.
 
@@ -34,7 +34,7 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
         '-param', 'step=1,type=seg,algo=centermass:step=2,type=seg,algo=bsplinesyn,slicewise=1,iter=3',
         '-m', fname_mask,
         '-initwarp', sct_test_path('t2', 'warp_template2anat.nii.gz'),
-        '-ofolder', str(tmp_path)
+        '-ofolder', str(tmp_path), '-qc', tmp_path_qc
     ])
 
     for path in ["PAM50_t2_reg.nii.gz", "warp_PAM50_t22mt1.nii.gz"]:
@@ -57,7 +57,7 @@ def test_sct_register_multimodal_mask_files_exist(tmp_path):
     (True, 'step=1,algo=centermassrot,type=imseg,rot_method=pcahog', None),
     (True, 'step=1,algo=columnwise,type=seg,smooth=1', None),
 ])
-def test_sct_register_multimodal_mt0_image_data_within_threshold(use_seg, param, fname_gt, tmp_path):
+def test_sct_register_multimodal_mt0_image_data_within_threshold(use_seg, param, fname_gt, tmp_path, tmp_path_qc):
     """Run the CLI script and verify that the output image data is close to a reference image (within threshold)."""
     fname_out_src = str(tmp_path/'mt0_reg.nii.gz')
     fname_out_dest = str(tmp_path/'mt0_reg_inv.nii.gz')
@@ -68,7 +68,8 @@ def test_sct_register_multimodal_mt0_image_data_within_threshold(use_seg, param,
             '-d', sct_test_path('mt', 'mt1.nii.gz'), '-x', 'linear', '-r', '0', '-param', param,
             '-o', fname_out_src, '-owarp', fname_owarp, '-owarpinv', fname_owarpinv]
     seg_argv = ['-iseg', sct_test_path('mt', 'mt0_seg.nii.gz'),
-                '-dseg', sct_test_path('mt', 'mt1_seg.nii.gz')]
+                '-dseg', sct_test_path('mt', 'mt1_seg.nii.gz'),
+                '-qc', tmp_path_qc]  # qc requires -dseg
     sct_register_multimodal.main(argv=(argv + seg_argv) if use_seg else argv)
 
     for f in [fname_out_src, fname_out_dest, fname_owarp, fname_owarpinv]:
@@ -89,7 +90,7 @@ def test_sct_register_multimodal_mt0_image_data_within_threshold(use_seg, param,
     #     assert abs(np.sum(diff)) < threshold  # FIXME: Use np.linalg.norm when this test is fixed
 
 
-def test_sct_register_multimodal_with_softmask(tmp_path):
+def test_sct_register_multimodal_with_softmask(tmp_path, tmp_path_qc):
     """
     Verify that softmask is actually applied during registration.
 
@@ -107,7 +108,7 @@ def test_sct_register_multimodal_with_softmask(tmp_path):
                           '-o', fname_mask, '-f', 'gaussian'])
     sct_register_multimodal.main(['-i', fname_t1, '-d', fname_t2, '-dseg', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                   '-param', "step=1,type=im,algo=slicereg,metric=CC", '-m', fname_mask,
-                                  '-ofolder', str(tmp_path), '-r', '0', '-v', '2'])
+                                  '-ofolder', str(tmp_path), '-r', '0', '-v', '2', '-qc', tmp_path_qc])
 
     # If registration was successful, the warping field should be non-empty
     assert np.any(Image(fname_warp).data)
@@ -126,7 +127,7 @@ def test_sct_register_multimodal_with_softmask(tmp_path):
 
 
 @pytest.mark.parametrize('algo', [',algo=rigid', ''])
-def test_sct_register_multimodal_with_labels(capsys, tmp_path, algo):
+def test_sct_register_multimodal_with_labels(capsys, tmp_path, tmp_path_qc, algo):
     """
     Test registration with '-param type=label' set.
 

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -79,17 +79,18 @@ def test_sct_register_to_template_non_rpi_data(tmp_path, template_lpi):
 @pytest.mark.sct_testing
 @pytest.mark.parametrize("fname_gt, remaining_args", [
     (sct_test_path('template', 'template', 'PAM50_small_cord.nii.gz'),
-     ['-l', sct_test_path('t2', 'labels.nii.gz'), '-t', sct_test_path('template'), '-qc', 'qc-testing', '-param',
+     ['-l', sct_test_path('t2', 'labels.nii.gz'), '-t', sct_test_path('template'), '-param',
       'step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares']),
     (os.path.join(__sct_dir__, 'data/PAM50/template/PAM50_cord.nii.gz'),
      ['-ldisc', sct_test_path('t2', 'labels.nii.gz'), '-ref', 'subject'])
 ])
-def test_sct_register_to_template_dice_coefficient_against_groundtruth(fname_gt, remaining_args, tmp_path):
+def test_sct_register_to_template_dice_coefficient_against_groundtruth(fname_gt, remaining_args, tmp_path, tmp_path_qc):
     """Run the CLI script and verify transformed images have expected attributes."""
     fname_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
     dice_threshold = 0.9
     sct_register_to_template.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
-                                        '-s', fname_seg, '-ofolder', str(tmp_path)]
+                                        '-s', fname_seg, '-ofolder', str(tmp_path),
+                                        '-qc', tmp_path_qc]
                                   + remaining_args)
 
     # Straightening files are only generated for `-ref template`. They should *not* exist for `-ref subject`.

--- a/testing/cli/test_cli_sct_register_to_template.py
+++ b/testing/cli/test_cli_sct_register_to_template.py
@@ -43,7 +43,7 @@ def labels_discs(tmp_path_factory):
     return file_out
 
 
-def test_sct_register_to_template_non_rpi_template(tmp_path, template_lpi):
+def test_sct_register_to_template_non_rpi_template(tmp_path, tmp_path_qc, template_lpi):
     """Test registration with option -ref subject when template is not RPI orientation, causing #3300."""
     # Run registration to template using the RPI template as input file
     sct_register_to_template.main(argv=['-i', sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'),
@@ -51,14 +51,15 @@ def test_sct_register_to_template_non_rpi_template(tmp_path, template_lpi):
                                         '-ldisc', sct_test_path('template', 'template', 'PAM50_small_label_disc.nii.gz'),
                                         '-c', 't2', '-t', template_lpi, '-ref', 'subject',
                                         '-param', 'step=1,type=seg,algo=centermass',
-                                        '-ofolder', str(tmp_path), '-r', '0', '-v', '2'])
+                                        '-ofolder', str(tmp_path), '-r', '0', '-v', '2',
+                                        '-qc', tmp_path_qc])
     img_orig = Image(sct_test_path('template', 'template', 'PAM50_small_t2.nii.gz'))
     img_reg = Image(str(tmp_path/'template2anat.nii.gz'))
     # Check if both images almost overlap. If they are right-left flipped, distance should be above threshold
     assert np.linalg.norm(img_orig.data - img_reg.data) < 1
 
 
-def test_sct_register_to_template_non_rpi_data(tmp_path, template_lpi):
+def test_sct_register_to_template_non_rpi_data(tmp_path, tmp_path_qc, template_lpi):
     """
     Test registration with option -ref subject when data is not RPI orientation.
     This test uses the temporary dataset created in test_sct_register_to_template_non_rpi_template().
@@ -69,7 +70,8 @@ def test_sct_register_to_template_non_rpi_data(tmp_path, template_lpi):
                                         '-ldisc', f'{template_lpi}/template/PAM50_small_label_disc.nii.gz',
                                         '-c', 't2', '-t', sct_test_path('template'), '-ref', 'subject',
                                         '-param', 'step=1,type=seg,algo=centermass',
-                                        '-ofolder', str(tmp_path), '-r', '0', '-v', '2'])
+                                        '-ofolder', str(tmp_path), '-r', '0', '-v', '2',
+                                        '-qc', tmp_path_qc])
     img_orig = Image(f'{template_lpi}/template/PAM50_small_t2.nii.gz')
     img_reg = Image(str(tmp_path/'template2anat.nii.gz'))
     # Check if both images almost overlap. If they are right-left flipped, distance should be above threshold
@@ -148,7 +150,7 @@ def test_sct_register_to_template_mismatched_xforms(tmp_path, caplog):
     assert "has different qform and sform matrices" in caplog.text
 
 
-def test_sct_register_to_template_more_than_2_labels(tmp_path, labels_discs):
+def test_sct_register_to_template_more_than_2_labels(tmp_path, tmp_path_qc, labels_discs):
     """
     Test registration with >2 labels. This test (and the custom disc label file) are needed because the existing
     `t2/labels.nii.gz` file only contains 2 labels. But, registration will be performed differently depending on
@@ -162,7 +164,8 @@ def test_sct_register_to_template_more_than_2_labels(tmp_path, labels_discs):
                                         '-t', sct_test_path('template'),
                                         '-param', 'step=1,type=seg,algo=centermassrot,metric=MeanSquares:'
                                                   'step=2,type=seg,algo=bsplinesyn,iter=0,metric=MeanSquares',
-                                        '-ofolder', str(tmp_path)])
+                                        '-ofolder', str(tmp_path),
+                                        '-qc', tmp_path_qc])
     # Apply transformation to source labels
     sct_apply_transfo.main(argv=['-i', labels_discs,
                                  '-d', str(tmp_path/'anat2template.nii.gz'),
@@ -177,7 +180,7 @@ def test_sct_register_to_template_more_than_2_labels(tmp_path, labels_discs):
     assert compute_mean_squared_error(im_label_dest, im_label_src_reg) == 0
 
 
-def test_sct_register_to_template_rootlets(tmp_path):
+def test_sct_register_to_template_rootlets(tmp_path, tmp_path_qc):
     """
     Test registration with rootlets segmentation.
     """
@@ -188,7 +191,8 @@ def test_sct_register_to_template_rootlets(tmp_path):
                                         '-param', 'step=1,type=rootlet,algo=bsplinesyn,metric=CC:'
                                                   'step=2,type=seg,algo=centermassrot,metric=MeanSquares:'
                                                   'step=3,type=seg,algo=bsplinesyn,iter=0,metric=MeanSquares',
-                                        '-ofolder', str(tmp_path)])
+                                        '-ofolder', str(tmp_path),
+                                        '-qc', tmp_path_qc])
     # Apply transformation to source labels
     sct_apply_transfo.main(argv=['-i', sct_test_path('t2', 't2_seg-deepseg_rootlets-manual_midpoints.nii.gz'),
                                  '-d', str(tmp_path/'anat2template.nii.gz'),

--- a/testing/cli/test_cli_sct_straighten_spinalcord.py
+++ b/testing/cli/test_cli_sct_straighten_spinalcord.py
@@ -10,8 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sct_testing
-def test_sct_straighten_spinalcord_no_checks():
+def test_sct_straighten_spinalcord_no_checks(tmp_path_qc):
     """Run the CLI script without checking results.
     TODO: Check the results. (This test replaces the 'sct_testing' test, which did not implement any checks.)"""
     sct_straighten_spinalcord.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
-                                         '-s', sct_test_path('t2', 't2_seg-manual.nii.gz')])
+                                         '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
+                                         '-qc', tmp_path_qc])

--- a/testing/cli/test_cli_sct_warp_template.py
+++ b/testing/cli/test_cli_sct_warp_template.py
@@ -32,7 +32,8 @@ def test_sct_warp_template_point_labels(tmp_path, tmp_path_qc):
     sct_register_to_template.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
                                         '-s', sct_test_path('t2', 't2_seg-manual.nii.gz'),
                                         '-ldisc', sct_test_path('t2', 'labels.nii.gz'),
-                                        '-ref', 'subject', '-ofolder', str(tmp_path)])
+                                        '-ref', 'subject', '-ofolder', str(tmp_path),
+                                        '-qc', tmp_path_qc])
 
     # Warp the PAM50 template to the cropped T2 image space
     path_out = tmp_path/"PAM50_warped"

--- a/testing/cli/test_cli_sct_warp_template.py
+++ b/testing/cli/test_cli_sct_warp_template.py
@@ -9,24 +9,24 @@ from spinalcordtoolbox.utils.sys import sct_test_path
 logger = logging.getLogger(__name__)
 
 
-def test_sct_warp_template_warp_small_PAM50():
+def test_sct_warp_template_warp_small_PAM50(tmp_path_qc):
     """Warp the cropped, resampled version of the template from `sct_testing_data/template`."""
     sct_warp_template.main(argv=['-d', sct_test_path('mt', 'mt1.nii.gz'),
                                  '-w', sct_test_path('mt', 'warp_template2mt.nii.gz'),
                                  '-a', '0',  # -a is '1' by default, but atlas isn't present in 'template'
                                  '-t', sct_test_path('template'),
-                                 '-qc', 'testing-qc'])
+                                 '-qc', tmp_path_qc])
 
 
-def test_sct_warp_template_warp_full_PAM50():
+def test_sct_warp_template_warp_full_PAM50(tmp_path_qc):
     """Warp the full PAM50 template (i.e. the one that is downloaded to `data/PAM50` during installation)."""
     sct_warp_template.main(argv=['-d', sct_test_path('mt', 'mt1.nii.gz'),
                                  '-w', sct_test_path('mt', 'warp_template2mt.nii.gz'),
                                  '-a', '1', '-histo', '1',
-                                 '-qc', 'testing-qc'])
+                                 '-qc', tmp_path_qc])
 
 
-def test_sct_warp_template_point_labels(tmp_path):
+def test_sct_warp_template_point_labels(tmp_path, tmp_path_qc):
     """Warp the full PAM50 template, then test whether point labels are preserved."""
     # Register the cropped T2 image to the full PAM50 template
     sct_register_to_template.main(argv=['-i', sct_test_path('t2', 't2.nii.gz'),
@@ -39,7 +39,7 @@ def test_sct_warp_template_point_labels(tmp_path):
     sct_warp_template.main(argv=['-d', sct_test_path('t2', 't2.nii.gz'),
                                  '-w', str(tmp_path/'warp_template2anat.nii.gz'),
                                  '-a', '0',  # -a is '1' by default, but save time since not needed for point labels
-                                 '-qc', 'testing-qc', '-ofolder', str(path_out)])
+                                 '-qc', tmp_path_qc, '-ofolder', str(path_out)])
 
     # Ensure that point labels were preserved
     point_label_files = ['PAM50_label_discPosterior.nii.gz', 'PAM50_spinal_midpoint.nii.gz',

--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -76,14 +76,14 @@ def test_model_dict():
      None),
 ])
 def test_segment_nifti_binary_seg(fname_image, fname_seg_manual, fname_out, task, thr, expected_dice,
-                                  tmp_path):
+                                  tmp_path, tmp_path_qc):
     """
     Test binary output (produced using values other than `-thr 0`) with sct_deepseg postprocessing CLI arguments.
     """
     # Ignore warnings from ivadomed model source code changing
     warnings.filterwarnings("ignore", category=SourceChangeWarning)
     fname_out = str(tmp_path/fname_out)  # tmp_path for automatic cleanup
-    args = [task, '-i', fname_image, '-o', fname_out, '-qc', str(tmp_path/'qc')]
+    args = [task, '-i', fname_image, '-o', fname_out, '-qc', tmp_path_qc]
     if thr is not None:
         args.extend(['-thr', str(thr)])
     if 'sc_' in task:
@@ -182,7 +182,7 @@ def t2_ax_sc_seg():
      ["-step1-only", "1"]),
 ])
 def test_segment_nifti_multiclass(fname_image, fnames_seg_manual, fname_out, suffixes, task, thr, expected_dice,
-                                  extra_args, tmp_path):
+                                  extra_args, tmp_path, tmp_path_qc):
     """
     Uses the locally-installed sct_testing_data
     """
@@ -194,7 +194,7 @@ def test_segment_nifti_multiclass(fname_image, fnames_seg_manual, fname_out, suf
         pytest.skip("Mouse data must be manually downloaded to run this test.")
 
     fname_out = str(tmp_path / fname_out)
-    sct_deepseg.main([task, '-i', fname_image, '-thr', str(thr), '-o', fname_out, '-qc', str(tmp_path/'qc'),
+    sct_deepseg.main([task, '-i', fname_image, '-thr', str(thr), '-o', fname_out, '-qc', tmp_path_qc,
                       '-largest', '1'] + extra_args)
     # The `-o` argument takes a single filename, even though one (or more!) files might be output.
     # If multiple output files will be produced, `sct_deepseg` will take this singular `-o` and add suffixes to it.
@@ -211,7 +211,7 @@ def test_segment_nifti_multiclass(fname_image, fnames_seg_manual, fname_out, suf
 
 
 @pytest.mark.parametrize("qc_plane", ["Axial", "Sagittal"])
-def test_deepseg_with_cropped_qc(qc_plane, tmp_path):
+def test_deepseg_with_cropped_qc(qc_plane, tmp_path, tmp_path_qc):
     """
     Test that `-qc-seg` cropping works with both Axial and Sagittal QCs.
     """
@@ -219,6 +219,6 @@ def test_deepseg_with_cropped_qc(qc_plane, tmp_path):
     sct_deepseg.main(['lesion_sci_t2',
                       '-i', sct_test_path('t2', 't2_fake_lesion.nii.gz'),
                       '-o', fname_out,
-                      '-qc', str(tmp_path/'qc'),
+                      '-qc', tmp_path_qc,
                       '-qc-plane', qc_plane,
                       '-qc-seg', sct_test_path('t2', 't2_fake_lesion_sc_seg.nii.gz')])

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -244,3 +244,13 @@ def check_testing_data_integrity(files_checksums: Mapping[os.PathLike, str]):
     assert not changed
     # assert not new
     assert not missing
+
+
+@pytest.fixture(scope="session")
+def tmp_path_qc(tmp_path_factory):
+    """
+    Create a session-scoped temporary directory for QC output.
+    This is used to group generated QC reports into a single report, to allow for easier checking of outputs.
+    """
+    qc_path = tmp_path_factory.mktemp('qc-report-')
+    return str(qc_path)  # most SCT scripts require string inputs for paths


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

Many of our `pytest` tests generate QC reports, but it is very tedious to check these reports because we create 1 report per test, and also because Firefox (and maybe other browsers) cannot open HTML files in `/tmp/`. 

Summary of changes:

- Put all `pytest` QC reports into a single report
- Add missing `-qc` flags for any test that can support it.
- Upload the final `pytest` QC report during CI runs.
- Created a personal script that will open the most recent QC report created in `/tmp/pytest/`: [open_pytest_html.sh](https://github.com/user-attachments/files/21372500/open_pytest_html.sh.zip)
   - Devs should download this and alias it to something easy. 

Possible future changes:

- Merge cross-platform QC reports to make them easier to check all at once.
- Add some sort of automated annotation or web view to make it easier to check the QC report without having to download it.
- Add some sort of explicit checkbox/confirmation so that reviewers confirm that they have looked over the QC report before merging.

## Linked issues

Fixes #4740.
