### PR TITLE
Fix failing CI runs for Arch (`rl_print_keybindings`) and Debian 10 (EOL)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,13 @@ jobs:
     container: debian:10
     steps:
       - name: Dependencies
-        run: |  # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
+        # NB: libgl1-mesa-dev is needed for PyQT testing (https://stackoverflow.com/q/33085297/7584115)
+        # NB: We echo "archive.debian.org" to address https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4105
+        run: |  
+          echo "deb http://archive.debian.org/debian/ buster main non-free contrib" > /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian/ buster main non-free contrib" >> /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security/ buster/updates main non-free contrib" >> /etc/apt/sources.list
+          echo "deb-src http://archive.debian.org/debian-security/ buster/updates main non-free contrib" >> /etc/apt/sources.list
           apt update && apt install -y libglib2.0-0 libgl1-mesa-dev procps gcc git curl libgl1-mesa-dev
       - uses: actions/checkout@v4
       - name: Install SCT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     container: archlinux
     steps:
@@ -118,7 +118,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     container: debian:10
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    # if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     container: archlinux
     steps:
@@ -118,7 +118,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    # if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     container: debian:10
     steps:

--- a/install_sct
+++ b/install_sct
@@ -693,8 +693,14 @@ if [[ $OS == linux ]]; then
   conda install -y -c conda-forge libstdcxx-ng
   # Ensure that libffi isn't linked incorrectly (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3927#issuecomment-1573896770)
   conda install -y -c conda-forge libffi
-  # Ensure that PyQt5 has the correct dependencies on Ubuntu
+  # Ensure that PyQt5 has the correct dependencies on Ubuntu (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3925)
+  # NB: We also need to copy the necessary dependencies to a separate subfolder that we add to LD_LIBRARY_PATH in compat/launcher.py
+  #     We do this to avoid exposing the full `lib/` directory, which can cause conflicts with system libraries.
+  #     This should copy 1 .so file and 2 symlinks, but the symlinks are relative, so copying them to a separate folder should be OK.
+  #     Related issue: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4971
   conda install -y -c conda-forge xorg-libxinerama
+  mkdir "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/sct_ld_library_path/"
+  find "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/lib/" | grep -i "libxcb-xinerama.so.*" | xargs -I {} cp {} "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/sct_ld_library_path/"
 fi
 
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)

--- a/install_sct
+++ b/install_sct
@@ -700,7 +700,7 @@ if [[ $OS == linux ]]; then
   #     Related issue: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4971
   conda install -y -c conda-forge xorg-libxinerama
   mkdir "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/sct_ld_library_path/"
-  find "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/lib/" | grep -i "libxcb-xinerama.so.*" | xargs -I {} cp {} "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/sct_ld_library_path/"
+  cp "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/lib/libxcb-xinerama.so."* "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/sct_ld_library_path/"
 fi
 
 # Skip pip==21.2 to avoid dependency resolver issue (https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3593)

--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -31,16 +31,17 @@ def main():
     env['VXM_BACKEND'] = 'pytorch'
     env['NEURITE_BACKEND'] = 'pytorch'
 
-    # Warn the user if they have `LD_LIBRARY_PATH` set
-    sct_lib_path = os.path.join(__sct_dir__, 'python', 'envs', 'venv_sct', 'lib')
+    # Warn the user if they have `LD_LIBRARY_PATH` set (while not triggering false positives for our own path).
+    sct_lib_path = os.path.join(__sct_dir__, 'python', 'envs', 'venv_sct', 'sct_ld_library_path')
     ld_library_path = env.get("LD_LIBRARY_PATH", "")
     if ld_library_path and ld_library_path != sct_lib_path:
         print(f"WARNING: The environment variable `LD_LIBRARY_PATH` is set to '{ld_library_path}'. "
               f"This may cause conflicts with library files bundled with SCT. Please consider unsetting "
               f"this variable if you run into errors related to 'Undefined symbols' or `.so` files.")
 
-    # Add SCT's `venv_sct/lib` folder to the `LD_LIBRARY_PATH`, allowing us to supply libraries
+    # Add SCT's `venv_sct/sct_ld_library_path` folder to the `LD_LIBRARY_PATH`, allowing us to supply libraries
     # that may be missing from the user's system, such as `libxcb-xinerama.so.0` on Ubuntu (#3925).
+    # The files inside this folder are determined at install time inside `install_sct`.
     env['LD_LIBRARY_PATH'] = (sct_lib_path if not ld_library_path
                               else os.pathsep.join([ld_library_path, sct_lib_path]))
 


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

Our full "tests.yml" CI has been failing for about a week now on two OSs: [sample run](https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/16495111042)

#### 1. Debian 10

This is precisely the same issue (and fix) as https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4106.

#### 2. Arch

This one is a little more complicated...

 - `bash` and `readline` recently updated in lockstep to `5.3` and `8.3` respectively, with the new `bash` version explicitly depending on the new `readline` version. ([helpful thread on `bug-readline`](https://lists.gnu.org/archive/html/bug-readline/2025-07/msg00033.html))
 - Arch's 'bleeding edge' package repositories got these updates immediately, while other package repositories (such as `conda-forge`) still have `readline==8.2` (which, importantly, is incompatible with `bash==5.3`)
 - SCT [recently made a change](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4869) to set `LD_LIBRARY_PATH` in our internal wrapper script to solve issue [#3925](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3925). This makes specific Ubuntu-related libraries available to PyQt5.
 - However, it has the unfortunate side-effect of prioritizing the version of `readline` inside of `venv_sct`, resulting in a crash in `bash`.

This PR tries to minimize the impact of our #3925 fix by only exposing the specific libraries required in that issue. Doing so allows `bash` to properly use the system version of `readline`, which should almost always be compatible.

## Linked issues

Fixes #4970.
Fixes #4971.
Improved fix for #3925. (Superseding #4869)