### PR TITLE
Remove hardcoded path to `D:\` drive for older Windows tests

### DIFF
--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sct_version: [ "5.8", "5.7" ]
-        os: [ windows-2025 ]
+        sct_version: [ "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3.0", "5.2.0", "5.1.0" ]
+        os: [ ubuntu-latest, macos-latest, macos-15, windows-2025 ]
         exclude:
           # Windows support was only properly introduced in 5.7
           - sct_version: "5.6"

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -81,7 +81,7 @@ jobs:
             export VERSION_TXT=$(< spinalcordtoolbox/version.txt)
             # SCT_DIR was different in the first iteration of Windows support
             if [ "${VERSION_TXT}" == "5.7" ] || [ ${VERSION_TXT} == "5.8" ]; then
-              export SCT_DIR="D:\a\spinalcordtoolbox\spinalcordtoolbox"
+              export SCT_DIR="${{ github.workspace }}"
             else
               export SCT_DIR="$USERPROFILE\sct_${VERSION_TXT}"
             fi

--- a/.github/workflows/test-past-releases.yml
+++ b/.github/workflows/test-past-releases.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sct_version: [ "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3.0", "5.2.0", "5.1.0" ]
-        os: [ ubuntu-latest, macos-latest, macos-15, windows-2025 ]
+        sct_version: [ "5.8", "5.7" ]
+        os: [ windows-2025 ]
         exclude:
           # Windows support was only properly introduced in 5.7
           - sct_version: "5.6"


### PR DESCRIPTION
## Description

Simple path fix:

- Failing run: https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/16399178566
- Passing run (this branch): https://github.com/spinalcordtoolbox/spinalcordtoolbox/actions/runs/16525119778

## Linked issues

Fixes #4988.
