### PR TITLE
`test_cli.py`: Increase threshold for macOS duration failures

### DIFF
--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -1,6 +1,7 @@
 # pytest unit tests for all cli scripts
 
 import os
+import platform
 import pytest
 from importlib.metadata import entry_points
 import subprocess
@@ -37,4 +38,8 @@ def test_calling_scripts_with_no_args_shows_usage(capsys, script):
     assert b'usage' in completed_process.stderr
     if "CI" in os.environ:
         max_duration = 2.0 if script not in deprecated_scripts else 5.0
+        # GitHub Actions' macOS 15+ runners take consistently longer, so bump by 1s
+        # macOS 13/14 runners are fine with the baseline duration (have yet to fail)
+        if platform.platform == "darwin" and int(platform.mac_ver()[0]) > 14:
+            max_duration += 1.0
         assert duration < max_duration, f"Expected '{script} -h' to execute in under {max_duration}s; took {duration}"


### PR DESCRIPTION


## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

Previously, in issue #4515, I reported that macOS runners failed sporadically, with large variations in execution time.

However, I've been monitoring the failing tests for a few weeks now, and the behavior seems to have ironed out -- macOS 13/14 runners are consistently under 2s, while macOS 15 runners will often have times in the 2-3s range.

So, I think we can be a bit more granular with these tests, rather than skipping them entirely.

## Linked issues

Fixes #4515.
Supersedes #4605, #4938.
