### PR TITLE
Fix failing tests due to faulty `platform` syntax

### DIFF
--- a/testing/cli/test_cli.py
+++ b/testing/cli/test_cli.py
@@ -5,6 +5,7 @@ import platform
 import pytest
 from importlib.metadata import entry_points
 import subprocess
+import sys
 import time
 
 scripts = [cs.name for cs in entry_points().select(group='console_scripts') if cs.value.startswith("spinalcordtoolbox")]
@@ -40,6 +41,6 @@ def test_calling_scripts_with_no_args_shows_usage(capsys, script):
         max_duration = 2.0 if script not in deprecated_scripts else 5.0
         # GitHub Actions' macOS 15+ runners take consistently longer, so bump by 1s
         # macOS 13/14 runners are fine with the baseline duration (have yet to fail)
-        if platform.platform == "darwin" and int(platform.mac_ver()[0]) > 14:
+        if sys.platform == "darwin" and int(platform.mac_ver()[0].split(".")[0]) > 14:
             max_duration += 1.0
         assert duration < max_duration, f"Expected '{script} -h' to execute in under {max_duration}s; took {duration}"


### PR DESCRIPTION

## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

I'm embarrassed that I let this slip through:

- `platform.platform` isn't a string like `sys.platform` -- it's a function call.
- `platform.platform()` is not an alias for `sys.platform`, and so it can't be used to save an import. (It's a much longer string, rather than just "darwin".)
- `platform.mac_ver()[0]` does not return the major version like I believed -- it's the full version specifier.

This time I've actually opened up my macOS 15 VM and checked that these conditions are met:

<img width="596" height="386" alt="image" src="https://github.com/user-attachments/assets/0dd11c0d-6e34-4520-a07e-614eef8cab25" />

Sorry about this. :sweat: 

## Linked issues

Fixes #4515.
Supersedes #4990.