### PR TITLE
Tweak `totalspineseg` axial mosaic QC report to make it easier to read

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -48,13 +48,16 @@ logger = logging.getLogger(__name__)
 # (the height is automatically adjusted based on the aspect ratio of the image)
 # Notes:
 #   - This shouldn't ever need to be changed, since "target width" is related
-#     to the design of the QC report interface. If things need to be scaled,
-#     it should be done to the array itself before it is written to the .
+#     to the design of the QC report interface. The images are currently rendered
+#     at 1060px wide, so we should match that in the mosaic arrays we generate.
+#     NOTE: This will result in arrays smaller than 1060px wide, since mosaic
+#     gird wrapping won't exceed this value. But, a smaller visible mosaic is
+#     worth the trade-off of pixel accuracy when rendering the final image.
 #   - `matplotlib` uses inches/DPI to define the canvas. But, given we want
 #     a fixed output size, we can choose some arbitrary values for both.
 #     Presumably, choosing a different DPI value (and thus a different canvas
 #     size in inches) wouldn't change the output image at all. (Is this true?)
-TARGET_WIDTH_PIXL = 1500
+TARGET_WIDTH_PIXL = 1060
 DPI = 300
 TARGET_WIDTH_INCH = TARGET_WIDTH_PIXL / DPI
 

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -305,7 +305,7 @@ def sct_deepseg(
         elif "totalspineseg" in argv:
             sct_deepseg_spinal_rootlets(
                 imgs_to_generate, fname_input, fname_seg, fname_seg2, species,
-                radius=(40, 40), base_scaling=0.5)  # downscale to get "big picture" view of all slices
+                radius=(40, 40), base_scaling=1.0)  # skip upscaling to get "big picture" view of all slices
         # Non-rootlets, axial/sagittal DeepSeg QC report
         elif plane == 'Axial':
             sct_deepseg_axial(

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -301,11 +301,13 @@ def sct_deepseg(
         if "rootlets" in argv:
             sct_deepseg_spinal_rootlets(
                 imgs_to_generate, fname_input, fname_seg, fname_seg2, species,
-                radius=(23, 23), base_scaling=2.5)  # standard upscale to see rootlets detail
+                radius=(23, 23), base_scaling=2.5,  # standard upscale to see rootlets detail
+                outline=True)  # add outlines (and labels) to highlight the difficult-to-see rootlets seg
         elif "totalspineseg" in argv:
             sct_deepseg_spinal_rootlets(
                 imgs_to_generate, fname_input, fname_seg, fname_seg2, species,
-                radius=(40, 40), base_scaling=1.0)  # skip upscaling to get "big picture" view of all slices
+                radius=(40, 40), base_scaling=1.0,  # skip upscaling to get "big picture" view of all slices
+                outline=False)  # skip outlines (and labels) because the images will be too small to display them
         # Non-rootlets, axial/sagittal DeepSeg QC report
         elif plane == 'Axial':
             sct_deepseg_axial(
@@ -524,13 +526,12 @@ def sct_deepseg_spinal_rootlets(
                   interpolation='none',
                   aspect=aspect)
 
-        # only display outlines and segmentation labels if scale is large enough to accommodate
+        # only display outlines and segmentation labels if opted into
         # (in practice, this saves them from being added to the tiny totalspineseg QC)
-        if scale >= 1.0:
+        if outline:
             add_segmentation_labels(ax, img, colors=colormaps[i].colors, radius=tuple(r for r in radius))
-            if outline:
-                # linewidth 0.5 is too thick, 0.25 is too thin
-                plot_outlines(img, ax=ax, facecolor='none', edgecolor='black', linewidth=0.3)
+            # linewidth 0.5 is too thick, 0.25 is too thin
+            plot_outlines(img, ax=ax, facecolor='none', edgecolor='black', linewidth=0.3)
 
     ax.get_xaxis().set_visible(False)
     ax.get_yaxis().set_visible(False)

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 #     to the design of the QC report interface. The images are currently rendered
 #     at 1060px wide, so we should match that in the mosaic arrays we generate.
 #     NOTE: This will result in arrays smaller than 1060px wide, since mosaic
-#     gird wrapping won't exceed this value. But, a smaller visible mosaic is
+#     grid wrapping won't exceed this value. But, a smaller visible mosaic is
 #     worth the trade-off of pixel accuracy when rendering the final image.
 #   - `matplotlib` uses inches/DPI to define the canvas. But, given we want
 #     a fixed output size, we can choose some arbitrary values for both.


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

When testing the "full `pytest` QC report" check, I noticed that the `totalspineseg` axial mosaic QC report looked very small and hard to read.

This PR adds several fixes to make the size a bit more manageable. It should be easy to double-check the QC report by checking the artifact uploaded to `tests.yml` for Ubuntu 24.04.

Note that this is still just a stopgap for when we can implement a better QC report for totalspineseg, as the axial mosaic isn't all that useful to begin with.

## Linked issues

Fixes #4982.
