### PR TITLE
Tag QC reports from automated tests with the OS used

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,7 +234,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Pytest QC (${{ matrix.os }})
+          name: Pytest QC (${{ runner.os }})
           path: "/tmp/pytest-of-runner/pytest-current/qc-report-current"
 
   ubuntu-22_04:


### PR DESCRIPTION
`.github/workflows/create-release.yml` correctly uses `matrix.os`, but `.github/workflows/tests.yml` should use `runner.os` instead, since it's not being run inside a matrix.

(Currently, the uploaded QC reports for this workflow get an empty pair of parentheses in their filename.)

See: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#detecting-the-operating-system