### PR TITLE
Clean up argparse help to only display arguments and descriptions relevant to specific tasks

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -37,7 +37,7 @@ MODELS = {
         ],
         "description": "Cord segmentation model on mouse MRI. Data from University of Queensland.",
         "contrasts": ["t1"],
-        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
+        "thr": 0.0,  # Only for display in argparse help (postprocessing.binarize_prediction is not present in model json)
         "default": False,
     },
     "mice_uqueensland_gm": {
@@ -47,7 +47,7 @@ MODELS = {
         ],
         "description": "Gray matter segmentation model on mouse MRI. Data from University of Queensland.",
         "contrasts": ["t1"],
-        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
+        "thr": 0.0,  # Only for display in argparse help (postprocessing.binarize_prediction is not present in model json)
         "default": False,
     },
     "t2_tumor": {
@@ -56,7 +56,7 @@ MODELS = {
         ],
         "description": "Cord tumor segmentation model, trained on T2-weighted contrast.",
         "contrasts": ["t2"],
-        "thr": 0.5,
+        "thr": 0.5,  # Only for display in argparse help (mirrors postprocessing.binarize_prediction, which is 0.5 in model json)
         "default": False,
     },
     "findcord_tumor": {
@@ -65,7 +65,7 @@ MODELS = {
         ],
         "description": "Cord localisation model, trained on T2-weighted images with tumor.",
         "contrasts": ["t2"],
-        "thr": 0.5,
+        "thr": 0.5,  # Only for display in argparse help (mirrors postprocessing.binarize_prediction, which is 0.5 in model json)
         "default": False,
     },
     "model_seg_sctumor-edema-cavity_t2-t1_unet3d-multichannel": {
@@ -74,7 +74,7 @@ MODELS = {
         ],
         "description": "Multiclass cord tumor segmentation model.",
         "contrasts": ["t2", "t1"],
-        "thr": 0.5,
+        "thr": 0.5,  # Only for display in argparse help (mirrors postprocessing.binarize_prediction, which is 0.5 in model json)
         "default": False,
     },
     "model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg": {
@@ -83,7 +83,7 @@ MODELS = {
         ],
         "description": "Grey/white matter seg on exvivo human T2w.",
         "contrasts": ["t2"],
-        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
+        "thr": 0.0,  # Only for display in argparse help (postprocessing.binarize_prediction is not present in model json)
         "default": False,
     },
     "model_7t_multiclass_gm_sc_unet2d": {
@@ -93,7 +93,7 @@ MODELS = {
         "description": "SC/GM multiclass segmentation on T2*-w contrast at 7T. The model was created by N.J. Laines Medina, "
                        "V. Callot and A. Le Troter at CRMBM-CEMEREM Aix-Marseille University, France",
         "contrasts": ["t2star"],
-        "thr": 0.5,
+        "thr": 0.5,  # Only for display in argparse help (mirrors postprocessing.binarize_prediction, which is 0.5 in model json)
         "default": False,
     },
     "model_seg_epfl_t2w_lumbar_sc": {
@@ -102,13 +102,18 @@ MODELS = {
         ],
         "description": "Lumbar SC segmentation on T2w contrast with 3D UNet",
         "contrasts": ["t2"],
-        "thr": 0.5,
+        "thr": 0.5,  # Only for display in argparse help (mirrors postprocessing.binarize_prediction, which is 0.5 in model json)
         "default": False,
     },
     # NB: Handling image binarization threshold for ivadomed vs. non-ivadomed models:
+    #   - All models:
+    #       - SCT provides a `-thr` argument for overriding default threshold values
+    #       - `-thr` will only be shown to the user if 'model': 'thr' is not None.
+    #       - The argparse help for `-thr` will display the default 'model': 'thr' value
     #   - ivadomed models (above):
-    #       - Threshold value is stored in the ivadomed-specific `.json` sidecar file
+    #       - Threshold value is actually fetched **by the ivadomed package** from a `.json` sidecar file
     #       - Binarization is applied within the ivadomed package
+    #       - Meaning, the 'thr' values above are simply for display in the `-thr` argparse help
     #   - non-ivadomed models (below)
     #       - Models do not have a `.json` sidecar file, since they were not developed with ivadomed
     #       - So, threshold value is stored here, within the model dict

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -37,6 +37,7 @@ MODELS = {
         ],
         "description": "Cord segmentation model on mouse MRI. Data from University of Queensland.",
         "contrasts": ["t1"],
+        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
         "default": False,
     },
     "mice_uqueensland_gm": {
@@ -46,6 +47,7 @@ MODELS = {
         ],
         "description": "Gray matter segmentation model on mouse MRI. Data from University of Queensland.",
         "contrasts": ["t1"],
+        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
         "default": False,
     },
     "t2_tumor": {
@@ -54,6 +56,7 @@ MODELS = {
         ],
         "description": "Cord tumor segmentation model, trained on T2-weighted contrast.",
         "contrasts": ["t2"],
+        "thr": 0.5,
         "default": False,
     },
     "findcord_tumor": {
@@ -62,6 +65,7 @@ MODELS = {
         ],
         "description": "Cord localisation model, trained on T2-weighted images with tumor.",
         "contrasts": ["t2"],
+        "thr": 0.5,
         "default": False,
     },
     "model_seg_sctumor-edema-cavity_t2-t1_unet3d-multichannel": {
@@ -70,6 +74,7 @@ MODELS = {
         ],
         "description": "Multiclass cord tumor segmentation model.",
         "contrasts": ["t2", "t1"],
+        "thr": 0.5,
         "default": False,
     },
     "model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg": {
@@ -78,6 +83,7 @@ MODELS = {
         ],
         "description": "Grey/white matter seg on exvivo human T2w.",
         "contrasts": ["t2"],
+        "thr": 0.0,  # postprocessing.binarize_prediction is not present in model json
         "default": False,
     },
     "model_7t_multiclass_gm_sc_unet2d": {
@@ -87,6 +93,7 @@ MODELS = {
         "description": "SC/GM multiclass segmentation on T2*-w contrast at 7T. The model was created by N.J. Laines Medina, "
                        "V. Callot and A. Le Troter at CRMBM-CEMEREM Aix-Marseille University, France",
         "contrasts": ["t2star"],
+        "thr": 0.5,
         "default": False,
     },
     "model_seg_epfl_t2w_lumbar_sc": {
@@ -95,6 +102,7 @@ MODELS = {
         ],
         "description": "Lumbar SC segmentation on T2w contrast with 3D UNet",
         "contrasts": ["t2"],
+        "thr": 0.5,
         "default": False,
     },
     # NB: Handling image binarization threshold for ivadomed vs. non-ivadomed models:

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -486,17 +486,16 @@ TASKS = {
          'models': ['model_seg_ms_lesion_mp2rage'],
          'citation': textwrap.dedent("""
              ```bibtex
-             @article{10.1162/imag_a_00218,
-                      author{Valošek, Jan and Mathieu, Theo and Schlienger, Raphaëlle and Kowalczyk, Olivia S. and Cohen-Adad, Julien},
-                      title"{Automatic Segmentation of the Spinal Cord Nerve Rootlets}",
-                      journal{Imaging Neuroscience},
-                      year{2024},
-                      month{06},
-                      issn{2837-6056},
-                      doi{10.1162/imag_a_00218},
-                      url{https://doi.org/10.1162/imag_a_00218},
+             @inproceedings{laines2024automatic,
+                 author={Laines Medina, N. and Mchinda, S. and Testud, B. and Demorti{\\`e}re, S. and Chen, M. and Granziera, G. and Reich, D. and Tsagkas, C. and Cohen-Adad, 
+                 J. and Callot, V.},
+                 title={Automatic Multiple Sclerosis Lesion Segmentation in the Spinal Cord on 3T and 7T MP2RAGE Images},
+                 booktitle={Proceedings of the 40th Annual Scientific Meeting of the ESMRMB},
+                 year={2024},
+                 address={Barcelona, Spain},
+                 pages={171}
              }
-             ```"""),
+             ```"""),  # noqa E501 (line too long)
          'group': 'pathology'
          },
     'lesion_ms':

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -259,19 +259,19 @@ def get_parser(subparser_to_return=None):
             metavar=Metavar.str,
             help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
         )
+        # Note: Sagittal view is not currently supported for rootlets/totalspineseg QC
+        # This means that the `-qc-plane` argument (and the `-qc-seg` note) should be hidden for these tasks
+        tasks_without_sagittal_qc = ('rootlets', 'totalspineseg')
         misc.add_argument(
             "-qc-plane",
             metavar=Metavar.str,
             choices=('Axial', 'Sagittal'),
             default='Axial',
-            # Note: Sagittal view is not currently supported for rootlets/totalspineseg QC
-            help=(SUPPRESS if task_name in ('rootlets', 'totalspineseg') else
+            help=(SUPPRESS if task_name in tasks_without_sagittal_qc else
                   "Plane of the output QC. If Sagittal, it is highly recommended to provide the `-qc-seg` option, "
                   "as it will ensure the output QC is cropped to a reasonable field of view."))
-
-        # This note is meaningless for rootlets/totalspineseg QC since sagittal mosaics aren't supported.
         note_qc_seg = ""
-        if task_name not in ('rootlets', 'totalspineseg'):
+        if task_name not in tasks_without_sagittal_qc:
             note_qc_seg += dedent("""
 
                 If `-qc-seg` is not provided, the default behavior will depend on the value of `-qc-plane`:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -187,8 +187,8 @@ def get_parser(subparser_to_return=None):
             metavar=Metavar.file)
         input_output.add_argument(
             "-o",
-            help="Output file name. In case of multi-class segmentation, class-specific suffixes will be added. By default,"
-                 "the suffix specified in the packaged model will be added and output extension will be `.nii.gz`.",
+            help="Output file name. The chosen filename will be used as a base name, and model-specific suffixes will "
+                 "be added to the end depending on the type of output (e.g. '_cord.nii.gz', '_gm.nii.gz', etc.).",
             metavar=Metavar.str)
 
         seg = subparser.add_argument_group('\nTASKS')

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -264,18 +264,26 @@ def get_parser(subparser_to_return=None):
             metavar=Metavar.str,
             choices=('Axial', 'Sagittal'),
             default='Axial',
-            help="Plane of the output QC. If Sagittal, it is highly recommended to provide the `-qc-seg` option, "
-                 "as it will ensure the output QC is cropped to a reasonable field of view. "
-                 "(Note: Sagittal view is not currently supported for rootlets/totalspineseg QC.)")
+            # Note: Sagittal view is not currently supported for rootlets/totalspineseg QC
+            help=(SUPPRESS if task_name in ('rootlets', 'totalspineseg') else
+                  "Plane of the output QC. If Sagittal, it is highly recommended to provide the `-qc-seg` option, "
+                  "as it will ensure the output QC is cropped to a reasonable field of view."))
+
+        # This note is meaningless for rootlets/totalspineseg QC since sagittal mosaics aren't supported.
+        note_qc_seg = ""
+        if task_name not in ('rootlets', 'totalspineseg'):
+            note_qc_seg += dedent("""
+
+                If `-qc-seg` is not provided, the default behavior will depend on the value of `-qc-plane`:
+                  - 'Axial': Without '-qc-seg', a sensible crop radius between 15-40 vox will be automatically used, depending on the resolution and segmentation type.
+                  - 'Sagittal': Without '-qc-seg', the full image will be displayed by default. (For very large images, this may cause a crash, so using `-qc-seg` is highly recommended.)
+            """)   # noqa: E501 (line too long)
         misc.add_argument(
             "-qc-seg",
             metavar=Metavar.file,
-            help=dedent("""
-                    Segmentation file to use for cropping the QC. This option is useful when you want to QC a region that is different from the output segmentation. For example, for lesion segmentation, it might be useful to provide a cord segmentation to expand the QC field of view to include the full cord, while also still excluding irrelevant tissue.
-                    If not provided, the default behavior will depend on the `-qc-plane`:
-                       - 'Axial': A sensibly chosen crop radius between 15-40 vox, depending on the resolution and segmentation type.
-                       - 'Sagittal': The full image. (For very large images, this may cause a crash, so using `-qc-seg` is highly recommended.)
-                """)  # noqa: E501 (line too long)
+            help="Segmentation file to use for cropping the QC. This option is useful when you want to QC a region "
+                 "that is different from the output segmentation. For example, it might be useful to provide a "
+                 "dilated cord segmentation to expand the QC field of view." + note_qc_seg
         )
 
         # Add common arguments

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -210,13 +210,15 @@ def get_parser(subparser_to_return=None):
                  f"`sct_deepseg {task_name} -i t2.nii.gz`")
 
         params = subparser.add_argument_group('\nPARAMETERS')
+        thr_values = [models.MODELS[model_name]['thr'] for model_name in task_dict['models']]
         params.add_argument(
             "-thr",
             type=float,
             dest='binarize_prediction',
-            help="Binarize segmentation with specified threshold. Set to 0 for no thresholding (i.e., soft segmentation). "
-                 "Default value is model-specific and was set during optimization "
-                 "(more info at https://github.com/sct-pipeline/deepseg-threshold).",
+            help=(SUPPRESS if all(t is None for t in thr_values) else
+                  f"Binarize segmentation with specified threshold. Set to 0 for no thresholding (i.e., soft segmentation). "
+                  f"Default value is '{thr_values}', and was chosen by experimentation "
+                  f"(more info at https://github.com/sct-pipeline/deepseg-threshold)."),
             metavar=Metavar.float)
         params.add_argument(
             "-largest",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -173,12 +173,17 @@ def get_parser(subparser_to_return=None):
         )
 
         input_output = subparser.add_argument_group("\nINPUT/OUTPUT")
+        note_lesion_ms_mp2rage = dedent(f"""
+
+            Note: For `lesion_ms_mp2rage`, the input
+            data must be cropped around the spinal cord.
+            ({models.CROP_MESSAGE})
+        """)
         input_output.add_argument(
             "-i",
             nargs="+",
-            help=f"Image to segment. Can be multiple images (separated with space)."
-                 f"\n\nNote: If choosing `lesion_ms_mp2rage`, then the input "
-                 f"data must be cropped around the spinal cord. ({models.CROP_MESSAGE})",
+            help=("Image to segment. Can be multiple images (separated with space)."
+                  + (note_lesion_ms_mp2rage if task_name == 'lesion_ms_mp2rage' else "")),
             metavar=Metavar.file)
         input_output.add_argument(
             "-o",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -199,14 +199,15 @@ def get_parser(subparser_to_return=None):
         seg.add_argument(
             "-custom-url",
             nargs="+",  # NB: `nargs="+"` won't work for installing custom ensemble models, but we no longer have any
-            help="URL(s) pointing to the `.zip` asset for a model release. This option can be used with `-install` to "
-                 "install a specific version of a model. To use this option, navigate to the 'Releases' page of the model, "
-                 "find release you wish to install, and right-click + copy the URL of the `.zip` listed under 'Assets'.\n"
-                 "NB: For multi-model tasks, provide multiple URLs. For single models, just provide one URL.\n"
-                 "Example:\n"
-                 "`sct_deepseg rootlets -install -custom-url "
-                 "https://github.com/ivadomed/model-spinal-rootlets/releases/download/r20240523/model-spinal-rootlets_ventral_D106_r20240523.zip`\n"
-                 "`sct_deepseg rootlets -i sub-amu01_T2w.nii.gz`")
+            # NB: For multi-model tasks, provide multiple URLs. For single models, just provide one URL.
+            #     We don't mention it in the help because we no longer have any multi-model tasks.
+            #     But, if we were to re-add a multi-model task one day, we could selectively amend this message.
+            help=f"URL(s) pointing to the `.zip` asset for a model release. This option can be used with `-install` to "
+                 f"install a specific version of a model. To use this option, navigate to the 'Releases' page of the model, "
+                 f"find release you wish to install, and right-click + copy the URL of the `.zip` listed under 'Assets'.\n"
+                 f"Example:\n"
+                 f"`sct_deepseg {task_name} -install -custom-url CUSTOM_URL`\n"
+                 f"`sct_deepseg {task_name} -i t2.nii.gz`")
 
         params = subparser.add_argument_group('\nPARAMETERS')
         params.add_argument(

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -179,7 +179,7 @@ def get_parser(subparser_to_return=None):
         task_args['-i'] = input_output.add_argument(
             "-i",
             nargs="+",
-            help="Image to segment. Can be multiple images (separated with space).",
+            help="Image filename(s) to segment. If segmenting multiple files, separate filenames with a space.",
             metavar=Metavar.file)
         input_output.add_argument(
             "-o",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -215,6 +215,8 @@ def get_parser(subparser_to_return=None):
             "-thr",
             type=float,
             dest='binarize_prediction',
+            # If a task's default threshold values are None, we assume that thresholding is not applicable for that task
+            # (e.g. multi-class segmentations that are split into multiple binary images before being outputted)
             help=(SUPPRESS if all(t is None for t in thr_values) else
                   f"Binarize segmentation with specified threshold. Set to 0 for no thresholding (i.e., soft segmentation). "
                   f"Default value is '{thr_values}', and was chosen by experimentation "


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

This PR aims to improve the `sct_deepseg -h` (argparse) by limiting what information gets displayed for individual task help (e.g. `sct_deepseg totalspineseg -h`).

The goal is to try and remove arguments that are irrelevant for certain tasks, and also limit warnings and notes to only the tasks that they are relevant for.

Here is a sample before/after:

- Before: https://spinalcordtoolbox.com/stable/user_section/command-line/deepseg/totalspineseg.html
- After: https://spinalcordtoolbox--5008.org.readthedocs.build/5008/user_section/command-line/deepseg/totalspineseg.html

## Linked issues

Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4861.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4974.
Fixes https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4888.
