### PR TITLE
Fix logging message to correctly print voxel size in `centermassrot` 

### DIFF
--- a/spinalcordtoolbox/registration/algorithms.py
+++ b/spinalcordtoolbox/registration/algorithms.py
@@ -752,7 +752,7 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
     nx, ny, nz, nt, px, py, pz, pt = image.Image(fname_dest[0]).dim
 
     logger.info(f"  matrix size: {str(nx)} x {str(ny)} x {str(nz)}")
-    logger.info(f"  voxel size: {str(px)}mm x {str(py)}mm x {str(nz)}mm")
+    logger.info(f"  voxel size: {str(px)}mm x {str(py)}mm x {str(pz)}mm")
 
     # Split source volume along z
     logger.info("\nSplit input segmentation...")


### PR DESCRIPTION
## Description

Dead-simple bug and fix (axes dimension `nz` was being reported instead of pixel size `pz`).

## Linked issues

Fixes #5021.