### PR TITLE
Only create "detailed summary" test files in CI (and only when the directory exists)

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -42,6 +42,10 @@ def pytest_sessionstart():
 
 def pytest_sessionfinish():
     """Perform actions that must be done after the test session."""
+    # don't generate summary files locally, since they are time-consuming and delay local testing
+    if "CI" not in os.environ:
+        return
+
     # get the newest temporary path created by pytest
     pytest_tempdirs = glob(os.path.join(tempfile.gettempdir(), "pytest-of-*", "pytest-current"))
     tmp_path = max(pytest_tempdirs, key=lambda p: os.path.getctime(p)) if pytest_tempdirs else ""

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -48,7 +48,7 @@ def pytest_sessionfinish():
 
     # get the newest temporary path created by pytest
     pytest_tempdirs = glob(os.path.join(tempfile.gettempdir(), "pytest-of-*", "pytest-current"))
-    tmp_path = max(pytest_tempdirs, key=lambda p: os.path.getctime(p)) if pytest_tempdirs else ""
+    tmp_path = max(pytest_tempdirs, key=lambda p: os.path.getctime(p), default="")
 
     # generate directory summaries for both sct_testing_data and the temporary directory
     for (folder, fname_out) in [(tmp_path, "pytest-tmp.json"),

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -43,10 +43,8 @@ def pytest_sessionstart():
 def pytest_sessionfinish():
     """Perform actions that must be done after the test session."""
     # get the newest temporary path created by pytest
-    tmp_path = max(
-        glob(os.path.join(tempfile.gettempdir(), "pytest-of-*", "pytest-current")),
-        key=lambda p: os.path.getctime(p),
-    )
+    pytest_tempdirs = glob(os.path.join(tempfile.gettempdir(), "pytest-of-*", "pytest-current"))
+    tmp_path = max(pytest_tempdirs, key=lambda p: os.path.getctime(p)) if pytest_tempdirs else ""
 
     # generate directory summaries for both sct_testing_data and the temporary directory
     for (folder, fname_out) in [(tmp_path, "pytest-tmp.json"),


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

This PR contains 2 tiny fixes for some issues with the "detailed summary" test in out CI.

- Don't run `max` on an empty list.
- Don't run the functionality at all locally

This doubly handles a user error encountered in Windows, while also minimizing the annoyance of generating these files for devs locally.

## Linked issues

Fixes #4864.