### PR TITLE
Add citation for RootletSeg model in models.py

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -424,7 +424,18 @@ TASKS = {
                              'subject, 45 images).',
          'url': 'https://github.com/ivadomed/model-spinal-rootlets',
          'models': ['model_seg_spinal_rootlets_nnunet'],
-         'citation': None
+         'citation': textwrap.dedent("""
+             ```bibtex
+             @misc{krejci2025rootletsegdeeplearningmethod,
+              title={RootletSeg: Deep learning method for spinal rootlets segmentation across MRI contrasts}, 
+              author={Katerina Krejci and Jiri Chmelik and Sandrine Bédard and Falk Eippert and Ulrike Horn and Virginie Callot and Julien Cohen-Adad and Jan Valosek},
+              year={2025},
+              eprint={2509.16255},
+              archivePrefix={arXiv},
+              primaryClass={q-bio.TO},
+              url={https://arxiv.org/abs/2509.16255}, 
+            }
+             ```
          },
     'gm_wm_mouse_t1':
         {'description': 'Exvivo mouse GM/WM segmentation for T1w contrast',

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -427,15 +427,15 @@ TASKS = {
          'citation': textwrap.dedent("""
              ```bibtex
              @misc{krejci2025rootletsegdeeplearningmethod,
-              title={RootletSeg: Deep learning method for spinal rootlets segmentation across MRI contrasts}, 
-              author={Katerina Krejci and Jiri Chmelik and Sandrine Bédard and Falk Eippert and Ulrike Horn and Virginie Callot and Julien Cohen-Adad and Jan Valosek},
-              year={2025},
-              eprint={2509.16255},
-              archivePrefix={arXiv},
-              primaryClass={q-bio.TO},
-              url={https://arxiv.org/abs/2509.16255}, 
-            }
-             ```
+                   title={RootletSeg: Deep learning method for spinal rootlets segmentation across MRI contrasts}, 
+                   author={Katerina Krejci and Jiri Chmelik and Sandrine Bédard and Falk Eippert and Ulrike Horn and Virginie Callot and Julien Cohen-Adad and Jan Valosek},
+                   year={2025},
+                   eprint={2509.16255},
+                   archivePrefix={arXiv},
+                   primaryClass={q-bio.TO},
+                   url={https://arxiv.org/abs/2509.16255}, 
+             }
+             ```"""),  # noqa E501 (line too long)
          },
     'gm_wm_mouse_t1':
         {'description': 'Exvivo mouse GM/WM segmentation for T1w contrast',


### PR DESCRIPTION
Added citation for RootletSeg deep learning method (new [arXiv preprint](
https://doi.org/10.48550/arXiv.2509.16255) available). 

Resolves: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5015