### PR TITLE
Hide developer-specific arguments in argparse help

### DIFF
--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -305,30 +305,34 @@ class SCTArgumentParser(argparse.ArgumentParser):
             nargs='?',
             metavar=Metavar.file,
             action=TimeProfilingAction,
-            help="Enables time-based profiling of the program, dumping the results to the specified file.\n"
-                 "\n"
-                 "If no file is specified, human-readable results are placed into a 'time_profiling_results.txt' "
-                 f"document in the current directory ('{os.getcwd()}'). If the specified file is a `.prof` file, the "
-                 "file will instead be in binary format, ready for use with common post-profiler utilities (such as "
-                 "`snakeviz`)."
+            help=argparse.SUPPRESS
+            # TODO: Find a way to only show these "developer" util helpers in certain contexts
+            # help="Enables time-based profiling of the program, dumping the results to the specified file.\n"
+            #      "\n"
+            #      "If no file is specified, human-readable results are placed into a 'time_profiling_results.txt' "
+            #      f"document in the current directory ('{os.getcwd()}'). If the specified file is a `.prof` file, the "
+            #      "file will instead be in binary format, ready for use with common post-profiler utilities (such as "
+            #      "`snakeviz`)."
         )
         arg_group.add_argument(
             '-trace-memory',
             nargs='?',
             metavar=Metavar.folder,
             action=MemoryTracingAction,
-            help="Enables memory tracing of the program.\n"
-                 "\n"
-                 "When active, a measure of the peak memory (in KiB) will be output to the file `peak_memory.txt`. "
-                 "Optionally, developers can also modify the SCT code to add additional `snapshot_memory()` calls. "
-                 "These calls will 'snapshot' the memory usage at that moment, saving the memory trace at that point "
-                 "into a second file (`memory_snapshots.txt`).\n"
-                 "\n"
-                 f"By default, both outputs will be placed in the current directory ('{os.getcwd()}'). Optionally, you "
-                 "may provide an alternative directory (`-trace-memory <dir_name>`), in which case all files will "
-                 "be placed in that directory instead.\n"
-                 "Note that this WILL incur an overhead to runtime, so it is generally advised that you do not run "
-                 "this in conjunction with the time profiler or in time-sensitive contexts."
+            help=argparse.SUPPRESS
+            # TODO: Find a way to only show these "developer" util helpers in certain contexts
+            # help="Enables memory tracing of the program.\n"
+            #      "\n"
+            #      "When active, a measure of the peak memory (in KiB) will be output to the file `peak_memory.txt`. "
+            #      "Optionally, developers can also modify the SCT code to add additional `snapshot_memory()` calls. "
+            #      "These calls will 'snapshot' the memory usage at that moment, saving the memory trace at that point "
+            #      "into a second file (`memory_snapshots.txt`).\n"
+            #      "\n"
+            #      f"By default, both outputs will be placed in the current directory ('{os.getcwd()}'). Optionally, you "
+            #      "may provide an alternative directory (`-trace-memory <dir_name>`), in which case all files will "
+            #      "be placed in that directory instead.\n"
+            #      "Note that this WILL incur an overhead to runtime, so it is generally advised that you do not run "
+            #      "this in conjunction with the time profiler or in time-sensitive contexts."
         )
 
         # Return the arg_group to allow for chained operations


### PR DESCRIPTION
## Checklist

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] ~~**Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).~~ N/A
- [x] ~~**Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.~~ N/A

## Description

Very small PR; as discussed a few SCT meetings ago, the verbosity of the developer-specific arguments `-profile-time` and `-trace-memory` were both overwhelming to users, and almost never relevant. As such, until a better solution can be devised, we've hidden their usage descriptions from the `--help`/error helper messages.

## Linked issues

N/A
