### PR TITLE
Allow `blosc2>=3.9.1` due to re-added support for `numpy==1.26`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,11 @@
 # acvl_utils is a utility package used by `nnunetv2`. v0.2.1 broke usage of `nnunetv2`, so skip it:
 # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4679
 acvl_utils!=0.2.1
-# blosc2 is a utility package used by `nnunetv2`, and v3.9.0 and above require `numpy==2.0`.
-# 3.9.0 specifically forgot to specify `>=2.0`, so it will break if installed alongside `numpy==1.26`
-blosc2<3.9.0
+# blosc2 is a utility package used by `nnunetv2`, and v3.9.0 required `numpy==2.0`
+# However, 3.9.0 specifically forgot to specify `>=2.0`, so it will break if installed alongside `numpy==1.26`
+# 3.9.1 and above re-added `numpy==1.26` support, so it is safe to skip this version but allow newer versions
+# See: https://github.com/Blosc/python-blosc2/issues/485
+blosc2!=3.9.0
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
 dipy==1.8.0
 # PyTorch's Linux distribution is very large due to its GPU support,


### PR DESCRIPTION
## Description

`blosc2` added a bunch of changes to support `numpy==1.26`, and they also now actively test that the package is compatible with 1.26, so we should be safe to simply exclude 3.9.0.

See also: https://github.com/Blosc/python-blosc2/issues/485#issuecomment-3356289168

cc: @mathieuboudreau (since we might want to echo this change to `totalspineseg` to get future `blosc2` updates)

See: 

## Linked issues

Fixes #5041.
