### PR TITLE
Refactor the broken link checker

### DIFF
--- a/.github/workflows/check-broken-links.sh
+++ b/.github/workflows/check-broken-links.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Find and check each URL in the files provided as arguments to the script.
+# The (($# == 0)) test is to prevent grep from using standard input if no files were given.
+# The grep -H option is to output the filename even if a single file was given.
+# The grep -Zz options are to make the filename and matching URL terminated by null bytes,
+# which is the safest way to delimit arbitrary text.
+# The (($? == 1)) test is to prevent the script from exiting if no URLs were found.
+# Setting IFS= (the empty string) prevents `read` from trimming whitespace.
+# The </dev/null redirection is to prevent check-url.sh from stealing the output of grep.
+{ (($# == 0)) || grep -EioHZz \
+  --exclude 'sct.def' \
+  --exclude 'CHANGES.md' \
+  --exclude 'requirements.txt' \
+  --exclude 'requirements-freeze.txt' \
+  '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' \
+  -- "$@" || (($? == 1)) ; } |
+  while IFS= read -rd '' filename && IFS= read -rd '' url; do
+    .github/workflows/check-url.sh "$filename" "$url" </dev/null
+  done
+
+# Summarize the results
+touch valid_urls.txt redirected_urls.txt invalid_urls.txt
+NUM_OK=$(wc -l valid_urls.txt | cut -d " " -f 1)
+NUM_REDIRECT=$(wc -l redirected_urls.txt | cut -d " " -f 1)
+NUM_BAD=$(wc -l invalid_urls.txt | cut -d " " -f 1)
+cat invalid_urls.txt
+echo -en "========== \033[0;32m$NUM_OK passed\033[0;0m, \033[0;33m$NUM_REDIRECT redirected\033[0;0m, \033[0;31m$NUM_BAD failed\033[0;0m ==========\n"
+
+# Exit with failure if there are any bad URLs
+((NUM_BAD == 0))

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -13,30 +13,7 @@ jobs:
 
     - name: Check for broken links
       run: |
-        # Create URL files for later reference
-        touch valid_urls.txt redirected_urls.txt invalid_urls.txt
-        
-        # Get the list of URLs within the project
-        git_diff_urls=$(find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.py" -o -name "*.rst" \) |
-          xargs grep -Eio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' |
-          sed 's/:/;/'
-        )
-        
-        # Filter out files which are in the blacklist
-        while read l; do
-          git_diff_urls=$(grep -v "$l" <<< "$git_diff_urls")
-        # This `cat` call MUST be here; otherwise a subshell is created, and recursive variable updating is not possible
-        #   Thank you to JN for figuring this out: https://stackoverflow.com/a/16854326
-        done <<< $(cat ".github/workflows/check_url_blacklist.txt")
-        
-        # Check each remaining file in the URL for validity
-        xargs -rn 1 ".github/workflows/check-url.sh" <<< "$git_diff_urls"
-
-    - name: Summarize
-      run: |
-        NUM_OK=$(wc -l valid_urls.txt | cut -d " " -f 1)
-        NUM_REDIRECT=$(wc -l redirected_urls.txt | cut -d " " -f 1)
-        NUM_BAD=$(wc -l invalid_urls.txt | cut -d " " -f 1)
-        cat invalid_urls.txt
-        echo -en "========== \033[0;32m$NUM_OK passed\033[0;0m, \033[0;33m$NUM_REDIRECT redirected\033[0;0m, \033[0;31m$NUM_BAD failed\033[0;0m ==========\n"
-        exit $NUM_BAD
+        find \
+          -type d \( -path ./.git -o -path ./python \) -prune -o \
+          -type f \( -name '*.txt' -o -name '*.md' -o -name '*.py' -o -name '*.rst' \) \
+          -exec .github/workflows/check-broken-links.sh '{}' +

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -24,7 +24,7 @@ jobs:
         set -eu -o pipefail
         git diff --name-only --diff-filter=d \
           --merge-base refs/remotes/origin/master -- \
-          | (grep '\.py$' || (($? == 1)) ) \
+          | { grep '\.py$' || (($? == 1)) ; } \
           | xargs --delimiter='\n' --no-run-if-empty flake8
 
     - name: Check shell scripts with shellcheck
@@ -37,40 +37,8 @@ jobs:
     # Add any file patterns you want ignored to 'check_url_blacklist.txt'
     - name: Check for broken links
       run: |
-        # Fail outright if any failure occurs, rather than attempting to proceed
         set -eu -o pipefail
-
-        # Get a list of files which have been changed from master on this branch
-        git_diff_files=$(git diff origin/master... --name-only)
-        
-        # Filter out any which are in the blacklist
-        while read l; do
-          git_diff_files=$(grep -v "$l" <<< "$git_diff_files" || (($? == 1)) )
-        # This `cat` call MUST be here; otherwise a subshell is created, and recursive variable updating is not possible
-        #   Thank you to JN for figuring this out: https://stackoverflow.com/a/16854326
-        done <<< $(cat ".github/workflows/check_url_blacklist.txt")
-        
-        # If no files remain, end here to avoid an error
-        if [[ "$git_diff_files" == "" ]]; then
-          echo "No files outside the blacklist were changed, ending URL checks."
-          exit 0
-        fi
-        
-        # Get all urls within the changed files; the '||' is to prevent grep from crashing the entire script if it finds nothing
-        git_diff_urls=$(grep -HEio '\b(https?)://[-a-z0-9+&@#/%?=~_|$!:,.;]*[a-z0-9+&@#/%=~_|$]' "$git_diff_files" || (($? == 1)) )
-        
-        # If no URLs were found within, end early to avoid an error
-        if [[ "$git_diff_urls" == "" ]]; then
-          echo "No URLs found in changed files, ending URL checks."
-          exit 0
-        fi
-
-        # Replace all colons with semi-colons...
-        git_diff_urls=${git_diff_urls//":"/";"}
-        # ... then replace the 'https' signatures to use colons again...
-        git_diff_urls=${git_diff_urls//"https;//"/"https://"}
-        # ... as well as 'http' (which really shouldn't be used anymore, but better safe than sorry)
-        git_diff_urls=${git_diff_urls//"http;//"/"http://"}
-        
-        # Check each remaining file in the URL for validity
-        xargs -rn 1 ".github/workflows/check-url.sh" <<< "$git_diff_urls"
+        git diff --name-only --diff-filter=d \
+          --merge-base refs/remotes/origin/master -- \
+          | { grep -E '\.(txt|md|py|rst)$' || (($? == 1)) ; } \
+          | xargs --delimiter='\n' --no-run-if-empty .github/workflows/check-broken-links.sh

--- a/.github/workflows/check-url.sh
+++ b/.github/workflows/check-url.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ $# -ne 1 ]; then
+if [ $# -ne 2 ]; then
     exit 1;
 fi
 
-filename=$(cut -d ";" -f 1 <<< "$1")
-URL=$(cut -d ";" -f 2 <<< "$1")
+filename=$0
+URL=$1
 # --head: Sends a HEAD request. We use this to be good netizens, since we only need the header to check the response code.
 # --silent: Hides the curl progress bar, which is unnecessary noise when testing >600 urls.
 # --insecure: Skip SSL verification. Since we're only checking the headers, this should be safe to do. (https://curl.se/docs/sslcerts.html)

--- a/.github/workflows/check_url_blacklist.txt
+++ b/.github/workflows/check_url_blacklist.txt
@@ -1,5 +1,0 @@
-sct.def
-CHANGES.md
-requirements.txt
-requirements-freeze.txt
-./python/envs/


### PR DESCRIPTION
Here's a rewrite of the broken link checker, as a standalone bash script, so that:
- we don't have to repeat mostly the same logic twice; and
- it's checkable by shellcheck.

The new `check-broken-links.sh` script accepts a list of files to check as its arguments, which can come from either:
- a `find` command for the daily run which checks everything; or
- a `git diff` command for the files touched by any given pull request.

In either case, the exclude list which used to be in `check_url_blacklist.txt` is now included inline in the `check-broken-links.sh` script. It could be restored as a file by using `grep --exclude-from` instead of `grep --exclude`, but I think that would make a future reader less likely to check the documentation of `grep --exclude` to see how the exclusions are interpreted (it's somewhat subtle).

I took the liberty of changing `check-url.sh` so that it takes two real arguments, rather than having to split around a semicolon.

Fixes #5045.