### PR TITLE
WIP: Proof of concept for qc refactor

### DIFF
--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -40,7 +40,8 @@ def get_parser():
         choices=('sct_propseg', 'sct_deepseg_sc', 'sct_deepseg_gm', 'sct_deepseg_lesion',
                  'sct_register_multimodal', 'sct_register_to_template', 'sct_warp_template',
                  'sct_label_vertebrae', 'sct_detect_pmj', 'sct_label_utils', 'sct_get_centerline',
-                 'sct_fmri_moco', 'sct_dmri_moco', 'sct_image_stitch', 'sct_fmri_compute_tsnr'))
+                 'sct_fmri_moco', 'sct_dmri_moco', 'sct_image_stitch', 'sct_fmri_compute_tsnr',
+                 'scratch'))
 
     optional = parser.optional_arggroup
     optional.add_argument(
@@ -110,20 +111,33 @@ def main(argv: Sequence[str]):
     if arguments.p == 'sct_deepseg_lesion' and arguments.plane is None:
         parser.error('Please provide the plane of the output QC with `-plane`')
 
-    generate_qc(fname_in1=arguments.i,
-                fname_in2=arguments.d,
-                fname_seg=arguments.s,
-                # Internal functions use capitalized strings ('Axial'/'Sagittal')
-                plane=arguments.plane.capitalize() if isinstance(arguments.plane, str) else arguments.plane,
-                args=f'("sct_qc {list2cmdline(argv)}")',
-                path_qc=arguments.qc,
-                dataset=arguments.qc_dataset,
-                subject=arguments.qc_subject,
-                process=arguments.p,
-                fps=arguments.fps,
-                p_resample=arguments.resample,
-                draw_text=bool(arguments.text_labels),
-                path_custom_labels=arguments.custom_labels)
+    if arguments.p == 'scratch':
+        from spinalcordtoolbox.reports.qc2 import scratch
+        scratch(
+            fname_input=arguments.i,
+            fname_output=arguments.d,
+            fname_seg=arguments.s,
+            argv=argv,
+            path_qc=arguments.qc,
+            dataset=arguments.qc_dataset,
+            subject=arguments.qc_subject,
+            p_resample=(0.6 if arguments.resample is None else arguments.resample),
+        )
+    else:
+        generate_qc(fname_in1=arguments.i,
+                    fname_in2=arguments.d,
+                    fname_seg=arguments.s,
+                    # Internal functions use capitalized strings ('Axial'/'Sagittal')
+                    plane=arguments.plane.capitalize() if isinstance(arguments.plane, str) else arguments.plane,
+                    args=f'("sct_qc {list2cmdline(argv)}")',
+                    path_qc=arguments.qc,
+                    dataset=arguments.qc_dataset,
+                    subject=arguments.qc_subject,
+                    process=arguments.p,
+                    fps=arguments.fps,
+                    p_resample=arguments.resample,
+                    draw_text=bool(arguments.text_labels),
+                    path_custom_labels=arguments.custom_labels)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here is a proof-of-concept re-implementation of the QC report for `sct_register_multimodal`. @joshuacwnewton I'd love to get your opinion, and I'm sorry for the large diff.

I tried to make it modular, so that parts of it could be re-used for other QC reports with minimal copy-pasting. In particular, I wanted to cleanly separate two steps that were previously intermixed:
- The step of determining the exact orientation and resolution and position of the slices we want to show (the "slicing spec").
- The step of extracting these slices from each relevant image.

I implemented this "slicing spec" for axial slices, but I think it will work well with sagittal slices too.

Two incidental benefits are that:
- I was able to center each axial slice individually, with possibly-fractional coordinates. (The previous code could only do integer coordinates, but this was *after* resampling to a fixed resolution, so this wasn't any truer to the original image voxels.) I think this is what [this old TODO comment](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/9c499409970de40db50db6d49cc572242e348c32/spinalcordtoolbox/reports/slice.py#L264) was referring to.
- The code runs a bit faster (on my laptop, 1.6 seconds, compared to 2.2 seconds for the corresponding `sct_qc` command), possibly because it resamples fewer total voxels (intuitively, it doesn't resample any cropped voxels).

I was also careful to take #5026 into account when adding slice labels.

For ease of comparison, I implemented this POC as an extra option for `sct_qc -p`, named `scratch`. Here is a QC report with three rows:
1. The result of running `sct_register_multimodal -qc` from [this tutorial](https://spinalcordtoolbox.com/stable/user_section/tutorials/multimodal-registration/contrast-agnostic-registration.html).
2. The result of running `sct_qc -p sct_register_multimodal` on the same images. It looks very different, because the code paths in `qc.py` and `qc2.py` have diverged for this report. This is something I want to fix with this POC.
3. The result of running `sct_qc -p scratch` on the same images (this POC). It looks very similar to 1, with the addition of slice labels.

[qc-2025-10-03.zip](https://github.com/user-attachments/files/22688207/qc-2025-10-03.zip)

### Implementation notes

SCT normally does image resampling through `nibabel`, which wraps `scipy.ndimage`. Here, for more control and better performance, I decided to use `scipy.ndimage` directly. (In particular, `nibabel` doesn't expose the crucial `prefilter=False` option for resampling.)

I also decided to use `nibabel`'s utilities for image orientations directly, instead of SCT's `Image` class, because I wanted to manipulate an abstract image FOV (described by just an affine matrix and a shape tuple) without doing costly manipulations of the data array.

### TODO

Before merging, I would:
- make both `sct_qc` and `sct_register_multimodal` use the new code,
- make `sct_register_to_template` use the new code as well,
- remove the two old code paths.