### PR TITLE
Restrict `numexpr!=2.14.0` and `h5py!=3.15.0` to address recent installation failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ acvl_utils!=0.2.1
 blosc2!=3.9.0
 # Avoid 1.6 and 1.7 due to method=restore bug: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4209#issuecomment-1739644328
 dipy==1.8.0
+# Avoid 3.15.0 due to known build errors on older versions of macOS (https://github.com/h5py/h5py/issues/2720)
+h5py!=3.15.0
 # PyTorch's Linux distribution is very large due to its GPU support,
 # but we only need that for training models. Our users only need CPU.
 --extra-index-url https://download.pytorch.org/whl/cpu # append_to_freeze


### PR DESCRIPTION
## Description

Coincidentally, two upstream packages released two buggy versions at about the same time:

- `numexpr==2.14.0`: https://github.com/pydata/numexpr/issues/540
- `h5py==3.15.0`: https://github.com/h5py/h5py/issues/2720

Both packages are aware of the issue and have committed to fixing the issues by next release, so it should be safe to pin using `!=` (to avoid having to open a new PR when the issues are fixed).

## Linked issues

- Fixes #5053.
- Fixes #5056.