### PR TITLE
Clarify `ValueError` if the `-centerline` does not cover all the slices in the input mask

### DIFF
--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -89,9 +89,8 @@ def compute_shape(segmentation, angle_correction=True, centerline_path=None, par
         missing_slices = sorted(set(range(min_z_index, max_z_index + 1)).difference(deriv.keys()))
         if missing_slices:
             raise ValueError(
-                "The provided angle correction centerline does not cover slice(s) "
-                f"{parse_num_list_inv(missing_slices)} of the input mask. Please "
-                "supply a more extensive '-angle-corr-centerline', or disable angle "
+                f"The provided centerline does not cover slice(s) {parse_num_list_inv(missing_slices)} "
+                "of the input mask. Please supply a '-centerline' covering all the slices, or disable angle "
                 "correction ('-angle-corr 0')."
             ) from None
 


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [ ] **Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.

## Description

This is just a tiny follow-up PR on https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/5075, which clarifies `ValueError` if the `-centerline` does not cover all the slices in the input mask. This can happen, for example, if the cord segmentation is shorter than the canal segmentation.

Otherwise, I got an error mentioning the previous arg `-angle-corr-centerline` (renamed to `-centerline` in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/5075):

```
  File "code/spinalcordtoolbox/spinalcordtoolbox/process_seg.py", line 91, in compute_shape
    raise ValueError(
ValueError: The provided angle correction centerline does not cover slice(s) 1 of the input mask. Please supply a more extensive '-angle-corr-centerline', or disable angle correction ('-angle-corr 0').
```

I also searched for other `-angle-corr-centerline` occurrences and didn't find any other except for in `CHANGES.md`.

## Linked issues

Follow-up: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/5075
