### PR TITLE
Improved Handling of Parallel Processes for QC Writing

### DIFF
--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -119,7 +119,7 @@ def create_qc_entry(
     path_result = path_json / f'qc_{timestamp}.json'
 
     # Create a mutex for the QC file to avoid a race condition if multiple files try to write simultaneously
-    # KO, MB, and JN: The hash here is required to sanitize the path name. Otherwise, special characters for the OS
+    # KO, MGP, and JN: The hash here is required to sanitize the path name. Otherwise, special characters for the OS
     #   (i.e. slashes) being present  can result in "orphaned" paths, due to how PortaLocker works; under the
     #   hood it creates a "lock" file to track the semaphore's state, and references that when determining whether a
     #   process can acquire it or not. As this creation is NOT sanitized (using a raw 'PathLib' query), we need to do

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -17,8 +17,7 @@ import shutil
 from typing import Optional, Sequence
 
 import numpy as np
-import portalocker
-from portalocker import Lock, LockFlags
+from portalocker import BoundedSemaphore
 from scipy.ndimage import center_of_mass
 import skimage.exposure
 
@@ -119,7 +118,7 @@ def create_qc_entry(
     path_result = path_json / f'qc_{timestamp}.json'
 
     # Create a mutex for the QC file to avoid a race condition if multiple files try to write simultaneously
-    qc_mutex = portalocker.BoundedSemaphore(
+    qc_mutex = BoundedSemaphore(
         maximum=1,  # Mutually exclusive access
         name=str(path_qc.resolve()),  # Lock the directory itself
         timeout=60,  # Wait up to 60 seconds for the directory to become free again

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -13,9 +13,6 @@ import tempfile
 import datetime
 import logging
 from pathlib import Path
-from contextlib import contextmanager
-
-import portalocker
 
 from .sys import printv
 

--- a/spinalcordtoolbox/utils/fs.py
+++ b/spinalcordtoolbox/utils/fs.py
@@ -262,24 +262,3 @@ def relpath_or_abspath(child_path, parent_path):
         return abspath.relative_to(parent_path)
     except ValueError:
         return abspath
-
-
-@contextmanager
-def mutex(name):
-    """
-    Use a bounded semaphore as a mutex to prevent parallel processes from running.
-
-    portalocker.BoundedSemaphore is very similar to threading.BoundedSemaphore,
-    but works across multiple processes and across multiple operating systems. So,
-    we can spawn multiple processes using `sct_run_batch`, while still ensuring
-    that we create QC reports sequentially (without mangling the output files).
-
-    We use a mutex over a lock because the mutex doesn't depend on the destination
-    of the locked files, which allows us to avoid locking on e.g. NFS-mounted drives.
-    """
-    semaphore = portalocker.BoundedSemaphore(maximum=1, name=name, timeout=60, check_interval=0.1)
-    semaphore.acquire()
-    try:
-        yield semaphore
-    finally:
-        semaphore.release()


### PR DESCRIPTION
## Checklist

- [x] **PR Sidebar**: I've filled in each of the options within the PR sidebar. ([Reviewers](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers), [Assignees](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#232-assignees), [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!), [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone), [Development](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#235-development).)
- [x] ~~**Contributing Docs**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)~~ N/A
- [x] ~~**Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).~~ N/A
- [x] ~~**Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.~~ N/A

## Description

In preparation for #5084, I reviewed existing uses of the `mutex` utility. This revealed that, as coded, said `mutex` utility (being a context manager) was overly restrictive in two regards:
* It prevents the addition of an informative error message when an error occurred during QC writing. 
* It prevents conditional locking; while not immediately relevant to QC writing, resolving this will allow any fixes to be conditional on whether a model is in the process of being installed or not.

This PR aims to address these shortcomings, replacing the use of `mutex` with a more explicit `BoundedSemaphore` instance to provide better control of error flow. This also removes the sole use of `mutex` in SCT; as such, it has been removed.

## Linked issues
Initial preparation for #5084
