### PR TITLE
Replace `monai.io` with `project-monai.github.io`

### DIFF
--- a/documentation/source/user_section/command-line.rst
+++ b/documentation/source/user_section/command-line.rst
@@ -13,7 +13,7 @@ Segmentation
 ============
 
 - :ref:`sct_create_mask` - Create mask along z direction.
-- :ref:`sct_deepseg` - Segment anatomical structures or pathologies using deep learning models created with different frameworks (`ivadomed <https://ivadomed.org>`__,  `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, `monai <https://monai.io>`__).
+- :ref:`sct_deepseg` - Segment anatomical structures or pathologies using deep learning models created with different frameworks (`ivadomed <https://ivadomed.org>`__,  `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, `monai <https://project-monai.github.io/>`__).
 - :ref:`sct_deepseg_gm` - Segment spinal cord gray matter using deep learning.
 - :ref:`sct_get_centerline` - Extracts the spinal cord centerline.
 - :ref:`sct_propseg` - Segment spinal cord using propagation of deformation model (PropSeg).

--- a/documentation/source/user_section/tutorials/segmentation/sct_deepseg-example-t2.rst
+++ b/documentation/source/user_section/tutorials/segmentation/sct_deepseg-example-t2.rst
@@ -1,7 +1,7 @@
 Hands-on: Using ``sct_deepseg`` on T2 data
 ##########################################
 
-The :ref:`sct_deepseg` script is designed as a replacement for both :ref:`sct_propseg` and :ref:`sct_deepseg_sc`. It provides access to specialized models created by created with various deep learning frameworks (`ivadomed <https://ivadomed.org/>`__, `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, and `monai <https://monai.io>`__). New models are trained and released on a regular basis, with each new version of SCT providing additional models to choose from.
+The :ref:`sct_deepseg` script is designed as a replacement for both :ref:`sct_propseg` and :ref:`sct_deepseg_sc`. It provides access to specialized models created by created with various deep learning frameworks (`ivadomed <https://ivadomed.org/>`__, `nnUNet <https://github.com/MIC-DKFZ/nnUNet>`__, and `monai <https://project-monai.github.io/>`__). New models are trained and released on a regular basis, with each new version of SCT providing additional models to choose from.
 
 One such model is the "``spinalcord``" model. It is SCT's effort to create a contrast-agnostic segmentation tool that can be used on any type of image (T1, T2, T2*, etc.), in order to ensure consistent morphometric results between contrasts.
 


### PR DESCRIPTION
## Description

This is a tiny PR that fixes 2 broken links (since `monai.io` lost control of that domain, see: https://github.com/Project-MONAI/MONAI/issues/8598). 

## Linked issues

Fixes #5061.