### PR TITLE
Remove `-test-time-aug` from `lesion_ms` test due to 1+ hour duration

### DIFF
--- a/testing/cli/test_sct_deepseg.py
+++ b/testing/cli/test_sct_deepseg.py
@@ -89,10 +89,13 @@ def test_segment_nifti_binary_seg(fname_image, fname_seg_manual, fname_out, task
     if 'sc_' in task:
         # TODO: Replace the "general" testing of these arguments with specific tests with specific input data
         args.extend(['-largest', '1', '-fill-holes', '1', '-remove-small', '5mm3'])
+
     # try out `use_mirroring` for `lesion_ms` model only (due to longer inference time)
     # based on https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4995#issuecomment-3410672883
-    if task == 'lesion_ms':
-        args.extend(['-test-time-aug'])
+    # FIXME: This takes upwards of 1-2 hours to complete based on OS. Disable for now until we can speed up testing.
+    # if task == 'lesion_ms':
+    #     args.extend(['-test-time-aug'])
+
     sct_deepseg.main(argv=args)
     # Make sure output file exists
     assert os.path.isfile(fname_out)


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [ ] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

This PR is a tiny hotfix that removes a very slow option from the CLI.

## Other ideas

I spent a lot of time today exploring ways to make the `pytest` output more useful. There are many verbose options we could rely on, potentially turned on via a `workflow_dispatch` option. But, I hit a bit of a wall in terms of implementation, so I wanted to push the fix in isolation for now until I can think a little more on this.

## Linked issues

Fixes #5116.
