### PR TITLE
Filter out `@ file` lines from `pip freeze` to prevent `pip install -r` from failing on stable releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -49,7 +49,7 @@ jobs:
         conda activate venv_sct
         # NB: "@ file" comes from conda packages containing `direct_url.json` files that get misinterpreted by pip.
         #     Generally, these will only be "standard" packages like `packaging`, `wheel`, etc. that get installed 
-        #     when the conda environment is first created, which I don't think aren't strictly necessary to pin in 
+        #     when the conda environment is first created, which aren't strictly necessary to pin in 
         #     `requirements-freeze.txt`. So, we filter them out here, as they would break a `pip` install.
         #     See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5150
         pip freeze | grep -v "-e git+" | grep -v "torch" | grep -v "@ file" > requirements-freeze.txt


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [ ] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

If a conda package has a `direct_url.json` file, `pip freeze` will incorrectly parse it and put the `url` in the output of `pip freeze`, making it incompatible with `pip install -r`.

We don't generally install conda packages, _except_ when we first create a bare conda environment. So, the only packages that get installed will be e.g. `wheel`, `packaging`, `setuptools`, etc. We don't really need to freeze these, I think, since they should have no bearing on the numerical results of our processing.

## Linked issues

Fixes #5150.
