### PR TITLE
Improve Apptainer installation by fixing several `sct.def` bugs (install directory, task installation)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,7 +548,7 @@ jobs:
       - name: Download sample data
         run: |
           curl -sL "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20251208.tar.gz" | tar -z -xf -
-      - name: Run 'sct_deepseg spinalcord' (default task)
+      - name: Run 'sct_deepseg spinalcord' (installed by default)
         run: |
           apptainer exec apptainer_build/sct.sif sct_deepseg spinalcord -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2/t2.nii.gz
       - name: Run 'sct_deepseg spine' (added on install)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -541,10 +541,10 @@ jobs:
         run: |
           cd ./apptainer_build
           ./install_sct_containered_$SAFE_REF.sh spine
-      - name: Install deepseg task post-install (with 'lesion_ms' task)
+      - name: Install deepseg task post-install (with 'gm_sc_7t_t2star' task)
         run: |
           cd ./apptainer_build
-          ./install_deepseg_task.sh lesion_ms
+          ./install_deepseg_task.sh gm_sc_7t_t2star
       - name: Download sample data
         run: |
           curl -sL "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20251208.tar.gz" | tar -z -xf -
@@ -554,6 +554,6 @@ jobs:
       - name: Run 'sct_deepseg spine' (added on install)
         run: |          
           apptainer exec apptainer_build/sct.sif sct_deepseg spine -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2/t2.nii.gz
-      - name: Run 'sct_deepseg lesion_ms' (added in post-install
+      - name: Run 'sct_deepseg gm_sc_7t_t2star' (added in post-install)
         run: |          
-          apptainer exec apptainer_build/sct.sif sct_deepseg lesion_ms -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2_lesion/t2.nii.gz
+          apptainer exec apptainer_build/sct.sif sct_deepseg gm_sc_7t_t2star -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2s/t2s.nii.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -517,6 +517,17 @@ jobs:
     name: Apptainer (Ubuntu Latest)
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        run: |
+          echo "-- Dotnet"
+          sudo rm -rf /usr/share/dotnet
+          echo "-- Android"
+          sudo rm -rf /usr/local/lib/android
+          echo "-- Haskell"
+          sudo rm -rf /opt/ghc
+          echo "-- CodeQL"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
       - name: Install Apptainer + dependencies
         run: |
           sudo apt update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -537,20 +537,23 @@ jobs:
         run: |
           mkdir apptainer_build
           tar -xvf ./contrib/apptainer/sct_apptainer_$SAFE_REF.tar.gz -C ./apptainer_build
-      - name: Run installer scripts (with 'spinalcord' task)
+      - name: Run installer scripts (with 'spine' task)
         run: |
           cd ./apptainer_build
-          ./install_sct_containered_$SAFE_REF.sh spinalcord
-      - name: Install deepseg task post-install (with 'spine' task)
+          ./install_sct_containered_$SAFE_REF.sh spine
+      - name: Install deepseg task post-install (with 'lesion_ms' task)
         run: |
           cd ./apptainer_build
-          ./install_deepseg_task.sh spine
+          ./install_deepseg_task.sh lesion_ms
       - name: Download sample data
         run: |
           curl -sL "https://github.com/spinalcordtoolbox/sct_tutorial_data/archive/refs/tags/SCT-Course-20251208.tar.gz" | tar -z -xf -
-      - name: Run 'sct_deepseg spinalcord'
+      - name: Run 'sct_deepseg spinalcord' (default task)
         run: |
           apptainer exec apptainer_build/sct.sif sct_deepseg spinalcord -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2/t2.nii.gz
-      - name: Run 'sct_deepseg spine'
+      - name: Run 'sct_deepseg spine' (added on install)
         run: |          
           apptainer exec apptainer_build/sct.sif sct_deepseg spine -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2/t2.nii.gz
+      - name: Run 'sct_deepseg lesion_ms' (added in post-install
+        run: |          
+          apptainer exec apptainer_build/sct.sif sct_deepseg lesion_ms -i sct_tutorial_data-SCT-Course-20251208/single_subject/data/t2_lesion/t2.nii.gz

--- a/contrib/apptainer/install_deepseg_task.sh
+++ b/contrib/apptainer/install_deepseg_task.sh
@@ -6,16 +6,16 @@ if [ "$#" == "0" ]; then
   exit 1
 fi
 
-# Just passes the arguments through, saving the results to a temporary file so the original isn't deleted if it fails
-APPTAINER_BIND=' ' apptainer build --build-arg task_installs="$*" sct_tmp.sif sct_model_install.def
+# Just passes the arguments through
+# NB: Even though we are forcefully overwriting the original `sct.sif` file, the original file won't be touched
+#     if the build step fails (since it gets extracted to a tmpdir). This is inherent to "Bootstrap: localimage".
+APPTAINER_BIND=' ' apptainer build --force --build-arg task_installs="$*" sct.sif sct_model_install.def
 
-# Removes the old .sif and replaced it with the new one, given the prior command ran correctly
-if [ ! -f sct_tmp.sif ]; then
-  echo "Failed to install new SCT DeepSeg tasks, terminating"
+# Catch errors and alert user that the `sct.sif` file was not updated
+status=$?
+if [ $status -ne 0 ];  then
+  echo "Apptainer build step exited with non-zero exit code, 'sct.sif' file not updated."
   exit 1
 fi
-echo "Replacing old sct.dif with updated one!"
-rm sct.sif
-mv sct_tmp.sif sct.sif
 
 echo "Done!"

--- a/contrib/apptainer/install_deepseg_task.sh
+++ b/contrib/apptainer/install_deepseg_task.sh
@@ -12,7 +12,7 @@ APPTAINER_BIND=' ' apptainer build --build-arg task_installs="$*" sct_tmp.sif sc
 # Removes the old .sif and replaced it with the new one, given the prior command ran correctly
 if [ ! -f sct_tmp.sif ]; then
   echo "Failed to install new SCT DeepSeg tasks, terminating"
-  exit 0
+  exit 1
 fi
 echo "Replacing old sct.dif with updated one!"
 rm sct.sif

--- a/contrib/apptainer/sct.def
+++ b/contrib/apptainer/sct.def
@@ -25,7 +25,7 @@ From: ubuntu:22.04
     chmod +x install_sct
 
     # Install SCT within the container
-    ./install_sct -y
+    ./install_sct -iy
 
     # Update the PATH so that SCT commands are always available
     export PATH="$PATH:/root/sct/bin"

--- a/contrib/apptainer/sct.def
+++ b/contrib/apptainer/sct.def
@@ -34,7 +34,7 @@ From: ubuntu:22.04
     sct_version
 
     # If any tasks were designated by the user, install their corresponding models
-    if [ ! "{{ task_installs }}" == "" ]; then
+    if [ -n "{{ task_installs }}" ]; then
         # Install each task requested by the user, one by one
         for task in {{ task_installs }}; do
             sct_deepseg "$task" -install || echo "Failed to install task $task"

--- a/contrib/apptainer/sct.def
+++ b/contrib/apptainer/sct.def
@@ -12,6 +12,11 @@ From: ubuntu:22.04
     export PATH="$PATH:/root/sct/bin"
 
 %post
+    # stricter shell mode
+    # https://sipb.mit.edu/doc/safe-shell/
+    set -e            # exit if non-zero error is encountered (NB: /bin/dash doesn't support `pipefail`)
+    set -u            # exit if unset variables used
+
     # Install our non-Python dependencies
     apt-get update
     apt-mark hold openssh-client dbus  # Pinning these so that it doesn't crash due to this: https://github.com/apptainer/apptainer/issues/1822#issuecomment-2051581258

--- a/contrib/apptainer/sct_model_install.def
+++ b/contrib/apptainer/sct_model_install.def
@@ -10,6 +10,11 @@ From: sct.sif
     export PATH="$PATH:/root/sct/bin"
 
 %post
+    # stricter shell mode
+    # https://sipb.mit.edu/doc/safe-shell/
+    set -e            # exit if non-zero error is encountered (NB: /bin/dash doesn't support `pipefail`)
+    set -u            # exit if unset variables used
+
     # Ubuntu 24.04 AppArmour strips the path, but doesn't run %environment to restore it for god knows why
     export PATH="$PATH:/root/sct/bin"
 


### PR DESCRIPTION
## Description

After merging my previous PR #5158 and backporting the changes 7.2, I came across several more issues.

### 1. Installation directory

In the previous PR, I changed the Apptainer installation steps from `(1. Fetch installer 2. Install SCT 3. Symlink expected install directory to /root/sct)` to `(1. Clone repo to /root/sct 2. Install SCT)`. The idea was that we would have more control over which source files we use in the installation, and skip having to do the final symlinking step (resulting in a consistent location for the source files from the get-go).

However, I forgot that `install_sct` has this logic:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/2818f57f0219b8b4981387861a091ef7ffe7fa3f/install_sct#L485-L494

Meaning, unless we explicitly request an in-place installation, `install_sct` will see `requirements-freeze.txt`, assume that we don't want an in-place installation, and install SCT to `~/sct_vX.Y` instead.

### 2. Task install syntax

Also, in the process of fixing this issue and testing locally, I realized that the `./install_sct_containered.sh` script doesn't actually install tasks due to faulty POSIX testing syntax:

```
+ [ ! spine == ] 
/.post.script: 23: [: spine: unexpected operator
```

### 3. Halting post-install steps on error

We hadn't caught the previous issues because we hadn't `set -eu`, meaning the `apptainer build` command succeeds even if the post-install steps fail.

### 4. Reinstalling `spinalcord` which is already default

We _also_ hadn't caught the previous issues because my `tests.yml` addition had been attempting to install a model that already gets installed by default. So, even though the install was failing, the resulting `sct_deepseg` test wasn't failing becaues the model is still present.

### 5. Disk Usage for GHA

Finally, this PR tries to mitigate disk usage errors on GitHub Actions by:

1. Reducing how many copies of the Apptainer image file we create when re-generating the image on `sct_deepseg` task installs.
2. Removing default packages from the GitHub runners that are unneeded for testing Apptainer.

----

This PR tries to fixes each of these issues (one commit each). I've also performed `./bundle_for_release.sh 7.2` and `./install_sct_7.2_containered.sh spine` locally to confirm everything works.

(Sorry for not catching these things on my previous reviews. :sweat:)

## Linked issues

Fixes #5121.
Amends #5158.
