### PR TITLE
Use the full SC width as the bridge width when lesion only has partial overlap with midsagittal slices

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -393,9 +393,14 @@ class AnalyzeLesion:
             # Create a lookup series for the current axial slice
             dorsal_lookup = slice_data.set_index('sagittal_slice')['dorsal_bridge_width']
             ventral_lookup = slice_data.set_index('sagittal_slice')['ventral_bridge_width']
-            # Get widths for the two sagittal slices. If there is no bridge for given slices, use 0.
-            dorsal_bridges = [dorsal_lookup.get(sag_slice, 0) for sag_slice in self.interpolation_slices_RPI]
-            ventral_bridges = [ventral_lookup.get(sag_slice, 0) for sag_slice in self.interpolation_slices_RPI]
+            # Get bridge widths for the two sagittal slices.
+            # NB: In the `_measure_tissue_bridges` method (where these values were determined) there
+            # is logic that checks if the lesion is missing, and if it is, use a bridge width value
+            # equal to the spinal cord width. This produces a more accurate interpolated value, and replaces
+            # the old faulty behavior where we would just set the bridge width to 0 if the lesion was missing.
+            # See: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5184#issuecomment-4014030850
+            dorsal_bridges = [dorsal_lookup[sag_slice] for sag_slice in self.interpolation_slices_RPI]
+            ventral_bridges = [ventral_lookup[sag_slice] for sag_slice in self.interpolation_slices_RPI]
             # Interpolate tissue bridges
             dorsal_bridge_interpolated = self._interpolate_values(*dorsal_bridges)
             ventral_bridge_interpolated = self._interpolate_values(*ventral_bridges)
@@ -471,16 +476,27 @@ class AnalyzeLesion:
             printv('  Slices with lesion: ' + str(sagittal_lesion_slices_print), self.verbose, type='info')
 
         # --------------------------------------
-        # Compute tissue bridges for each sagittal slice containing the lesion
+        # Compute tissue bridges for each sagittal slice containing the lesion **and** the interpolation slices
         # --------------------------------------
+        # Note: We want to compute the bridge widths for the full 3D bounding box around the lesion, even if there
+        #       are some place in the bounding box where the lesion is not present. (If the lesion is not present, then
+        #       the bridge width will be the full width of the spinal cord.)
+        #       The reason we do this is because, for the interpolated midsagittal bridge width calculation, we need to
+        #       average the bridge widths between two sagittal slices. And, if the lesion is present in one sagittal
+        #       slice but not the other, we still need to compute the average. For more info on this edge case, see:
+        #       https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5184
+        axial_lesion_slices = [np.unique(np.where(im_lesion_data[sagittal_slice, :, :])[1])  # 2D, dim=[AP, SI] --> [1]
+                               for sagittal_slice in sagittal_lesion_slices]
+        axial_lesion_slices = sorted(list(set(np.concatenate(axial_lesion_slices))))
+
         tissue_bridges_dict = {}
         # Loop across sagittal slices
-        for sagittal_slice in sagittal_lesion_slices:
-            # Get all axial slices (S-I direction) with the lesion for the selected sagittal slice
-            # In other words, we will iterate through the lesion in S-I direction and compute tissue bridges for each
-            # axial slice with the lesion
-            axial_lesion_slices = np.unique(np.where(im_lesion_data[sagittal_slice, :, :])[1])  # 2D, dim=[AP, SI] --> [1]
-            # Iterate across axial slices to compute tissue bridges
+        # NB: Make sure we include both of the `self.interpolation_slices_RPI` slices in the `sagittal_lesion_slices` list,
+        #     even if the lesion is not present in those slices. This is because we need to still compute placeholder values
+        #     for the interpolation.
+        sagittal_slices_all = sorted(list(set(sagittal_lesion_slices) | set(self.interpolation_slices_RPI)))
+        for sagittal_slice in sagittal_slices_all:
+            # Iterate across axial slices in the sagittal slice to compute tissue bridges
             for axial_slice in axial_lesion_slices:
                 # Get the lesion segmentation mask of the selected 2D axial slice
                 slice_lesion_data = im_lesion_data[sagittal_slice, :, axial_slice]
@@ -491,15 +507,19 @@ class AnalyzeLesion:
                 # Get the indices of the spinal cord mask for the selected axial slice
                 sc_indices = np.where(slice_sc_data)[0]
 
-                # Compute ventral and dorsal tissue bridges
-                dorsal_bridge_width = lesion_indices[0] - sc_indices[0]         # [0] returns the most dorsal elements
-                # if the lesion extends the spinal cord, the dorsal bridge is set to 0
-                if dorsal_bridge_width < 0:
-                    dorsal_bridge_width = 0
-                ventral_bridge_width = sc_indices[-1] - lesion_indices[-1]      # [-1] returns the most ventral elements
-                # if the lesion extends the spinal cord, the ventral bridge is set to 0
-                if ventral_bridge_width < 0:
-                    ventral_bridge_width = 0
+                # If lesion isn't present in this slice, then both bridge widths will just be the full width of the spinal cord.
+                if lesion_indices.size == 0:
+                    dorsal_bridge_width = ventral_bridge_width = sc_indices.size
+                else:
+                    # Compute ventral and dorsal tissue bridges
+                    dorsal_bridge_width = lesion_indices[0] - sc_indices[0]         # [0] returns the most dorsal elements
+                    # if the lesion extends the spinal cord, the dorsal bridge is set to 0
+                    if dorsal_bridge_width < 0:
+                        dorsal_bridge_width = 0
+                    ventral_bridge_width = sc_indices[-1] - lesion_indices[-1]      # [-1] returns the most ventral elements
+                    # if the lesion extends the spinal cord, the ventral bridge is set to 0
+                    if ventral_bridge_width < 0:
+                        ventral_bridge_width = 0
 
                 tissue_bridges_dict[sagittal_slice, axial_slice] = \
                     {'dorsal_bridge_width': dorsal_bridge_width,

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -386,6 +386,7 @@ class AnalyzeLesion:
             self.measure_pd.loc[idx, 'interpolated_total_bridge_width [mm]'] = np.nan
             return
 
+        debug = {}
         for axial_slice in axial_slices:
             # Get bridges for the 2 sagittal slices used for the interpolation
             # Filter for current axial slice once
@@ -404,6 +405,13 @@ class AnalyzeLesion:
             # Interpolate tissue bridges
             dorsal_bridge_interpolated = self._interpolate_values(*dorsal_bridges)
             ventral_bridge_interpolated = self._interpolate_values(*ventral_bridges)
+            # debug
+            debug[axial_slice] = {}
+            debug[axial_slice][f"slice_{self.interpolation_slices_RPI[0]+1}"] = round(dorsal_bridges[0] * p_lst[1] * np.cos(self.angles_sagittal[axial_slice]), 2)
+            debug[axial_slice][f"slice_{self.interpolation_slices_RPI[1]+1}"] = round(dorsal_bridges[1] * p_lst[1] * np.cos(self.angles_sagittal[axial_slice]), 2)
+            debug[axial_slice]["slice_interp"] = round(dorsal_bridge_interpolated * p_lst[1] * np.cos(
+                self.angles_sagittal[axial_slice]), 2)
+
             # Get the width of the tissue bridges in mm (by multiplying by p_lst[1]) and use np.cos(self.angles_sagittal[SLICE])
             # to correct for the angle of the spinal cord with respect to the axial slice
             interpolated_dorsal_bridge_width_mm[axial_slice] = (dorsal_bridge_interpolated * p_lst[1] *

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -131,7 +131,10 @@ def compute_expected_measurements(lesion_params, path_seg=None):
                 # If 0/2 interp slices have lesion: find the interpolated minimum SC AP diameter, then take 1/2 of that for dorsal/ventral
                 if tissue_bridge_ceil is None and tissue_bridge_floor is None:
                     sc_width_interp = (decimal * sc_min_ap_diameters[z_ceil] + (1 - decimal) * sc_min_ap_diameters[z_floor])
-                    tissue_bridge_interp = sc_width_interp if 'total' in key else sc_width_interp/2
+                    # FIXME: This is proof that my solution overlaps Jan's solution
+                    #   - Jan uses /2 the sc_width (total sums to SC width, individual bridges are too small)
+                    #   - I use the full sc_width (total sums to 2x SC width, individual bridges are the right size)
+                    tissue_bridge_interp = sc_width_interp*2 if 'total' in key else sc_width_interp
                 else:
                     # If 1/2 interp slices have lesion: use 0.0 as a placeholder value (FIXME: #5184/#5202)
                     if tissue_bridge_ceil is None:

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -263,7 +263,7 @@ def test_sct_analyze_lesion_matches_expected_dummy_lesion_measurements(dummy_les
                 # The values will be adjusted according to the cos of the angle
                 # between the spinal cord centerline and the S-I axis, as per:
                 # https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3681#discussion_r804822552
-                if key == 'max_equivalent_diameter [mm]' or 'bridge' in key:
+                if key == 'max_equivalent_diameter [mm]':
                     # The values are the same, but one value has slightly more precision than the other, so it is
                     # greater than expected --> rounding both values to the same number of decimal points before
                     # comparing

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -136,11 +136,14 @@ def compute_expected_measurements(lesion_params, path_seg=None):
                     #   - I use the full sc_width (total sums to 2x SC width, individual bridges are the right size)
                     tissue_bridge_interp = sc_width_interp*2 if 'total' in key else sc_width_interp
                 else:
-                    # If 1/2 interp slices have lesion: use 0.0 as a placeholder value (FIXME: #5184/#5202)
+                    # If 1/2 interp slices have lesion: use sc_width (AP diameter)
+                    # FIXME: We just grab the minimum diameters since those were readily available, but the actual API code
+                    #        uses a per-axial-slice AP diameter, meaning that the expected vs. actual may differ.
+                    #        Fixing this would require refactoring this function to capture SC widths at each axial slice, which is possible but more work.
                     if tissue_bridge_ceil is None:
-                        tissue_bridge_ceil = 0.0
+                        tissue_bridge_ceil = 2*sc_min_ap_diameters[z_ceil] if 'total' in key else sc_min_ap_diameters[z_ceil]
                     if tissue_bridge_floor is None:
-                        tissue_bridge_floor = 0.0
+                        tissue_bridge_floor = 2*sc_min_ap_diameters[z_floor] if 'total' in key else sc_min_ap_diameters[z_floor]
                     # If 2/2 interp slices have lesion: interpolate like normal
                     tissue_bridge_interp = (decimal * tissue_bridge_ceil + (1 - decimal) * tissue_bridge_floor)
 

--- a/testing/cli/test_cli_sct_analyze_lesion.py
+++ b/testing/cli/test_cli_sct_analyze_lesion.py
@@ -110,12 +110,38 @@ def compute_expected_measurements(lesion_params, path_seg=None):
                 tissue_bridges[f"slice_{z}_ventral_bridge_width [mm]"] = min(ventral_bridge_widths)
                 tissue_bridges[f"slice_{z}_total_bridge_width [mm]"] = (min(dorsal_bridge_widths) +
                                                                         min(ventral_bridge_widths))
-            # Estimate the interpolated bridge widths at the mid-sagittal slice
+
+            # Find the minimum spinal cord AP diameter across each all SI slices for each of the interpolation slices
             decimal = mid_sagittal_slice - math.floor(mid_sagittal_slice)
             z_ceil, z_floor = int(np.ceil(mid_sagittal_slice)), int(np.floor(mid_sagittal_slice))
+            sc_min_ap_diameters = {}
+            for z in [z_ceil, z_floor]:
+                ap_diameters = []
+                for y in range(starting_coord[1], starting_coord[1] + dim[1]):
+                    ap_diameters.append(np.sum(Image(path_seg).data[:, y, z]))
+                sc_min_ap_diameters[z] = min(ap_diameters)
+
+            # Estimate the interpolated bridge widths at the mid-sagittal slice
             for key in ['dorsal_bridge_width', 'ventral_bridge_width', 'total_bridge_width']:
-                tissue_bridges[f'interpolated_{key} [mm]'] = (decimal * tissue_bridges.get(f'slice_{z_ceil}_{key} [mm]', 0.0) +
-                                                              (1 - decimal) * tissue_bridges.get(f'slice_{z_floor}_{key} [mm]', 0.0))
+                # NB: We have to fall back to 'None' here instead of '0.0' because the tissue bridge may actually be 0.0,
+                #     and we need to distinguish between missing slices vs. lesions that are at the extent of the SC
+                tissue_bridge_ceil = tissue_bridges.get(f'slice_{z_ceil}_{key} [mm]', None)
+                tissue_bridge_floor = tissue_bridges.get(f'slice_{z_floor}_{key} [mm]', None)
+
+                # If 0/2 interp slices have lesion: find the interpolated minimum SC AP diameter, then take 1/2 of that for dorsal/ventral
+                if tissue_bridge_ceil is None and tissue_bridge_floor is None:
+                    sc_width_interp = (decimal * sc_min_ap_diameters[z_ceil] + (1 - decimal) * sc_min_ap_diameters[z_floor])
+                    tissue_bridge_interp = sc_width_interp if 'total' in key else sc_width_interp/2
+                else:
+                    # If 1/2 interp slices have lesion: use 0.0 as a placeholder value (FIXME: #5184/#5202)
+                    if tissue_bridge_ceil is None:
+                        tissue_bridge_ceil = 0.0
+                    if tissue_bridge_floor is None:
+                        tissue_bridge_floor = 0.0
+                    # If 2/2 interp slices have lesion: interpolate like normal
+                    tissue_bridge_interp = (decimal * tissue_bridge_ceil + (1 - decimal) * tissue_bridge_floor)
+
+                tissue_bridges[f'interpolated_{key} [mm]'] = tissue_bridge_interp
 
             # Compute the bridge ratio using the interpolated bridge widths
             for key in ['dorsal', 'ventral']:


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [ ] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

> [!WARNING]
> This PR is an alternative to PR https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/5179. It arrives at a similar solution, but developed completely independently by accident.
> 
> - Jan's work: Designed to solve https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5123
> - My work: Designed to solve https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5184.
>
> Both of the underlying issues actually have similar root causes but were uncovered in separate investigations.

> [!TIP]
> Early in `sct_analyze_lesion`, we identify a **midsagittal slice** (float valued). To estimate the bridge widths at this midsagittal slice, we first take the 2 closest sagittal slices (integer values) using `floor` and `ceil` (called **interpolation slices** in-code). Then, for each axial slice in the lesion, we compute the bridge width by interpolating between he bridge widths found at each of those 2 sagittal slices.
>
> There are multiple different "missing lesion" cases to handle here:
>
> 1. There are no detected lesions at all.
> 2. There is a lesion, but it overlaps with 0 of the 2 interpolation slices.
> 3. There is a lesion, but it overlaps with 1 of the 2 interpolation slices.
>
> On `master`, all three cases are hanlded poorly. My PR tries to fix cases 2 and 3. @valosekj's PR fixes cases 1 and 2.

Functionally, this PR addresses the following faulty lines of code on `master`:

https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/621c69f21374bcc4708061179ae2e534402900ee/testing/cli/test_cli_sct_analyze_lesion.py#L116-L118

`0.0` should _not_ be used as a fallback value, because when it gets averaged (as part of the interpolation process), it will skew the average towards a very small bridge width value. Then, when we take the `min` of all of the bridge widths, the result will be faulty.

The fix here is to instead use the spinal cord width. The idea being that, when the lesion is missing from a slice, using the full `sc_width` is the appropriate value in cases such as these:

<img width="268" height="268" alt="image" src="https://github.com/user-attachments/assets/af5d0508-8ab9-4d29-835b-7063ca074c30" />

By using the full width, the interpolation value is no longer erroneously small, and thus taking the `min` of all of the bridge widths leads to the expected result.

## Linked issues

Related to https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5184.