### PR TITLE
Increase QC `.gif` speed from 3 FPS to 5 FPS

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -314,7 +314,7 @@ class QcImage:
             gif_out_path = str(imgs_to_generate['path_background_img'])
 
         if self._fps is None:
-            self._fps = 3
+            self._fps = 5
         writer = mpl_animation.PillowWriter(self._fps)
         logger.info('Saving gif %s', gif_out_path)
         ani.save(gif_out_path, writer=writer, dpi=self.dpi)

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -156,7 +156,7 @@ def get_parser():
         '-qc-fps',
         metavar=Metavar.float,
         type=float,
-        default=3,
+        default=5,
         help="This float number is the number of frames per second for the output gif images."
     )
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -120,7 +120,7 @@ def get_parser():
         '-qc-fps',
         metavar=Metavar.float,
         type=float,
-        default=3,
+        default=5,
         help="This float number is the number of frames per second for the output gif images."
     )
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -93,6 +93,7 @@ def get_parser():
         '-fps',
         metavar='float',
         type=float,
+        default=5,
         help='The number of frames per second for output gif images. Only useful for sct_fmri_moco and '
              'sct_dmri_moco.')
 


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [ ] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

I tested both 6FPS and 5FPS, and found 6FPS to be a touch too fast, but happy to switch it back to 6FPS.

5FPS:

<img width="1500" height="300" alt="overlay_img_5fps" src="https://github.com/user-attachments/assets/da571de3-dacc-452a-8558-2addb7d97d38" />

6FPS:

<img width="1500" height="300" alt="overlay_img_6fps" src="https://github.com/user-attachments/assets/45156e9b-7522-4e46-8f89-1e3dd97226d7" />

For my own learning:

- Do people look at the gif for the overall alignment across time (i.e. letting the different time points blur together to get a general picture?) -- **the faster the better**
- Or, do people look at the gif for individual slices? -- **balance between fast/slow**


## Linked issues

Fixes #5142.
