### PR TITLE
Run tests workflow on pull_request_target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    # Required for access to Dockerhub logins in secrets. Risks are mitigated by limiting permissions of the GITHUB_TOKEN and the Dockerhub token to read-only. If sensitive secrets are needed in the future, consider using an environment with required approval
+    # https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments
     branches:
       - '*'
   schedule:
@@ -42,6 +44,8 @@ env:
     # Disable progress bars for less verbose output
     PIP_PROGRESS_BAR: "off"
     SCT_PROGRESS_BAR: "off"
+
+permissions: {}
 
 jobs:
 


### PR DESCRIPTION
## Checklist

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [x] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

Related to #5200, which needs this update to the `test.yml` github workflow integrated into the `master` branch in order to actually run it on PR modifications.

The `pull_request_target` trigger creates a **privileged workflow** with access to secrets, required to login with Dockerhub in #5200 and prevent rate limiting. Additionally strips all permissions on the workflow for security hardenning.

## Linked issues

Related to #5186, but #5200 will close it.
