### PR TITLE
Add -qc-contrast option to override QC report contrast label

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -340,7 +340,7 @@ class QcImage:
 
 
 def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None, path_qc=None, dataset=None,
-                subject=None, process=None, fps=None, p_resample=None):
+                subject=None, contrast=None, process=None, fps=None, p_resample=None):
     """
     Generate a QC entry allowing to quickly review results. This function is the entry point and is called by SCT
     scripts (e.g. sct_propseg).
@@ -353,6 +353,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     :param path_qc: str: Path to save QC report
     :param dataset: str: Dataset name
     :param subject: str: Subject name
+    :param contrast: str: Contrast/acquisition name. If not provided, this will fall back to the name of the
+                          parent directory of `fname_in1` (which may not be meaningful for all directory layouts).
     :param process: str: Name of SCT function. e.g., sct_propseg
     :param fps: float: Number of frames per second for output gif images. Used only for sct_frmi_moco and sct_dmri_moco.
     :param p_resample: float: Resolution (in mm) to resample the image to. If not provided, resampling will fall back
@@ -507,7 +509,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
         [images_after_moco, images_before_moco], centermass = qcslice_layout(qcslice)
         qc_image._centermass = centermass
         with create_qc_entry(
-            path_input, path_qc, command, cmdline, plane, dataset, subject,
+            path_input, path_qc, command, cmdline, plane, dataset, subject, contrast,
             image_extension='gif',
         ) as imgs_to_generate:
             qc_image._make_QC_image_for_4d_volumes(
@@ -518,6 +520,6 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, plane=None, args=None
     else:
         img, *mask = qcslice_layout(qcslice)
         with create_qc_entry(
-            path_input, path_qc, command, cmdline, plane, dataset, subject,
+            path_input, path_qc, command, cmdline, plane, dataset, subject, contrast,
         ) as imgs_to_generate:
             qc_image._make_QC_image_for_3d_volumes(img, mask, plane, imgs_to_generate)

--- a/spinalcordtoolbox/reports/qc2.py
+++ b/spinalcordtoolbox/reports/qc2.py
@@ -73,6 +73,7 @@ def create_qc_entry(
     plane: str,
     dataset: Optional[str],
     subject: Optional[str],
+    contrast: Optional[str] = None,
     image_extension: str = 'png',
 ) -> AbstractContextManager[dict[str, Path]]:
     """
@@ -98,7 +99,8 @@ def create_qc_entry(
         dataset = path_input.parent.parent.parent.name
     if subject is None:
         subject = path_input.parent.parent.name
-    contrast = path_input.parent.name
+    if contrast is None:
+        contrast = path_input.parent.name
     timestamp = mod_date.strftime('%Y_%m_%d_%H%M%S.%f')
 
     # Make sure the image directory exists
@@ -608,6 +610,7 @@ def sct_register(
     path_qc: str,
     dataset: str | None,
     subject: str | None,
+    contrast: str | None = None,
     p_resample: float | None = 0.6,
 ):
     """
@@ -626,6 +629,7 @@ def sct_register(
         plane='Axial',
         dataset=dataset,
         subject=subject,
+        contrast=contrast,
     ) as imgs_to_generate:
 
         img_input = Image(fname_input)
@@ -654,6 +658,7 @@ def sct_fmri_compute_tsnr(
     path_qc: str,
     dataset: str | None,
     subject: str | None,
+    contrast: str | None = None,
     p_resample: float | None = 0.6,
 ):
     """
@@ -674,6 +679,7 @@ def sct_fmri_compute_tsnr(
         plane='Axial',
         dataset=dataset,
         subject=subject,
+        contrast=contrast,
     ) as imgs_to_generate:
 
         img_input = Image(fname_input)
@@ -731,6 +737,7 @@ def sct_label_vertebrae(
     dataset: str | None,
     subject: str | None,
     path_custom_labels: str,
+    contrast: str | None = None,
     draw_text: bool = True,
     p_resample: float | None = None,
     offset_text: bool = True,
@@ -751,6 +758,7 @@ def sct_label_vertebrae(
         plane='Sagittal',
         dataset=dataset,
         subject=subject,
+        contrast=contrast,
     ) as imgs_to_generate:
 
         img_input = Image(fname_input)
@@ -857,6 +865,7 @@ def sct_label_utils(
     path_qc: str,
     dataset: str | None,
     subject: str | None,
+    contrast: str | None = None,
     p_resample: float | None = None,
 ):
     """
@@ -875,6 +884,7 @@ def sct_label_utils(
         plane='Sagittal',
         dataset=dataset,
         subject=subject,
+        contrast=contrast,
     ) as imgs_to_generate:
 
         img_input = Image(fname_input)
@@ -1212,6 +1222,7 @@ def sct_deepseg(
     subject: Optional[str],
     plane: Optional[str],
     fname_qc_seg: Optional[str],
+    contrast: Optional[str] = None,
 ):
     """
     Generate a QC report for sct_deepseg, based on which task was used.
@@ -1228,6 +1239,7 @@ def sct_deepseg(
         plane=plane,
         dataset=dataset,
         subject=subject,
+        contrast=contrast,
     ) as imgs_to_generate:
         # Custom QC to handle multiclass segmentation outside the spinal cord
         if "rootlets" in argv:

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -254,6 +254,11 @@ def get_parser(subparser_to_return=None):
             metavar=Metavar.str,
             help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
         )
+        misc.add_argument(
+            '-qc-contrast',
+            metavar=Metavar.str,
+            help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+        )
         task_args['-qc-plane'] = misc.add_argument(
             "-qc-plane",
             metavar=Metavar.str,
@@ -560,6 +565,7 @@ def main(argv: Sequence[str]):
                 path_qc=os.path.abspath(arguments.qc),
                 dataset=arguments.qc_dataset,
                 subject=arguments.qc_subject,
+                contrast=arguments.qc_contrast,
             )
             path_custom_labels = os.path.join(
                 __sct_dir__, 'spinalcordtoolbox', 'reports',
@@ -604,6 +610,7 @@ def main(argv: Sequence[str]):
                     path_qc=os.path.abspath(arguments.qc),
                     dataset=arguments.qc_dataset,
                     subject=arguments.qc_subject,
+                    contrast=arguments.qc_contrast,
                     plane=arguments.qc_plane,
                     fname_qc_seg=fname_qc_seg
                 )

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -170,6 +170,11 @@ def get_parser():
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
     optional.add_argument(
+        '-qc-contrast',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
+    optional.add_argument(
         '-dl',
         action='store_true',
         help="Use deep learning–based motion correction (DenseNet).\n"
@@ -215,6 +220,7 @@ def main(argv: Sequence[str]):
     qc_fps = arguments.qc_fps
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
+    qc_contrast = arguments.qc_contrast
     qc_seg = arguments.qc_seg
 
     mutually_inclusive_args = (path_qc, qc_seg)
@@ -248,7 +254,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_image, fname_in2=param.fname_data, fname_seg=qc_seg,
                     args=argv, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
-                    subject=qc_subject, process='sct_dmri_moco')
+                    subject=qc_subject, contrast=qc_contrast, process='sct_dmri_moco')
 
     display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho', verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -134,6 +134,11 @@ def get_parser():
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
     optional.add_argument(
+        '-qc-contrast',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
+    optional.add_argument(
         '-dl',
         action='store_true',
         help="Use deep learning–based motion correction (DenseNet).\n"
@@ -177,6 +182,7 @@ def main(argv: Sequence[str]):
     qc_fps = arguments.qc_fps
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
+    qc_contrast = arguments.qc_contrast
     qc_seg = arguments.qc_seg
 
     mutually_inclusive_args = (path_qc, qc_seg)
@@ -208,7 +214,7 @@ def main(argv: Sequence[str]):
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_image, fname_in2=param.fname_data, fname_seg=qc_seg,
                     args=argv, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
-                    subject=qc_subject, process='sct_fmri_moco')
+                    subject=qc_subject, contrast=qc_contrast, process='sct_fmri_moco')
 
     display_viewer_syntax([fname_output_image, param.fname_data], mode='ortho,ortho', verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -127,6 +127,11 @@ def get_parser():
         metavar=Metavar.str,
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
+    optional.add_argument(
+        "-qc-contrast",
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
 
     # Arguments which implement shared functionality
     parser.add_common_args()
@@ -212,11 +217,12 @@ def main(argv: Sequence[str]):
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
+    qc_contrast = arguments.qc_contrast
 
     # Generate QC report
     if path_qc is not None:
         generate_qc(fname_input_data, fname_seg=file_output, args=argv, path_qc=os.path.abspath(path_qc),
-                    dataset=qc_dataset, subject=qc_subject, process='sct_get_centerline')
+                    dataset=qc_dataset, subject=qc_subject, contrast=qc_contrast, process='sct_get_centerline')
 
     im_type_ctl = 'softseg' if arguments.centerline_soft else 'seg'
     display_viewer_syntax([fname_input_data, file_output], im_types=['anat', im_type_ctl], opacities=['', '0.7'], verbose=verbose)

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -191,6 +191,11 @@ def get_parser():
         metavar=Metavar.str,
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
+    optional.add_argument(
+        '-qc-contrast',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
 
     # Arguments which implement shared functionality
     parser.add_common_args()
@@ -303,6 +308,7 @@ def main(argv: Sequence[str]):
             path_qc=os.path.abspath(arguments.qc),
             dataset=arguments.qc_dataset,
             subject=arguments.qc_subject,
+            contrast=arguments.qc_contrast,
         )
 
 

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -90,6 +90,12 @@ def get_parser():
         help='If provided, this string will be mentioned in the QC report as the subject the process '
              'was run on')
     optional.add_argument(
+        '-qc-contrast',
+        metavar='CONTRAST',
+        help='If provided, this string will be mentioned in the QC report as the contrast the process '
+             'was run on. If not provided, this will fall back to the name of the parent directory of '
+             '`-i` (which may not be meaningful for all directory layouts).')
+    optional.add_argument(
         '-fps',
         metavar='float',
         type=float,
@@ -120,6 +126,7 @@ def main(argv: Sequence[str]):
         path_qc=arguments.qc,
         dataset=arguments.qc_dataset,
         subject=arguments.qc_subject,
+        contrast=arguments.qc_contrast,
     )
     if arguments.resample is None:
         assert 'p_resample' not in kwargs  # Use the report's default
@@ -153,6 +160,7 @@ def main(argv: Sequence[str]):
                     path_qc=arguments.qc,
                     dataset=arguments.qc_dataset,
                     subject=arguments.qc_subject,
+                    contrast=arguments.qc_contrast,
                     process=arguments.p,
                     fps=arguments.fps,
                     p_resample=arguments.resample,

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -265,6 +265,11 @@ def get_parser():
         metavar=Metavar.str,
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
+    optional.add_argument(
+        '-qc-contrast',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
 
     # Arguments which implement shared functionality
     parser.add_common_args()
@@ -416,6 +421,7 @@ def main(argv: Sequence[str]):
             path_qc=os.path.abspath(arguments.qc),
             dataset=arguments.qc_dataset,
             subject=arguments.qc_subject,
+            contrast=arguments.qc_contrast,
         )
 
     # If dest wasn't registered (e.g. unidirectional registration due to '-initwarp'), then don't output syntax

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -266,6 +266,11 @@ def get_parser():
         metavar=Metavar.str,
         help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
     )
+    optional.add_argument(
+        '-qc-contrast',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the contrast the process was run on."
+    )
 
     # Arguments which implement shared functionality
     parser.add_common_args()
@@ -841,6 +846,7 @@ def main(argv: Sequence[str]):
             path_qc=os.path.abspath(arguments.qc),
             dataset=arguments.qc_dataset,
             subject=arguments.qc_subject,
+            contrast=arguments.qc_contrast,
         )
     display_viewer_syntax([fname_data, fname_template2anat], verbose=verbose)
     display_viewer_syntax([fname_template, fname_anat2template], verbose=verbose)


### PR DESCRIPTION
## Summary
Fixes #5243.

QC reports derive `contrast` from `path_input.parent.name`, with no way to override it -- unlike `dataset`/`subject`, which already support `-qc-dataset`/`-qc-subject` overrides with the same fallback-derivation pattern. When the input file lives inside a tool-output subdirectory (e.g. `.../sct_fmri_moco/file.nii.gz`), the derived "contrast" ends up being the SCT command name itself, making the "Contrast" column useless for grouping/filtering.

This PR mirrors the existing `dataset`/`subject` override mechanism for `contrast`:

- `create_qc_entry()` (qc2.py) and `generate_qc()` (qc.py) now accept an optional `contrast` parameter, falling back to `path_input.parent.name` only when `None` (fully backward compatible).
- `qc2.sct_register`, `sct_fmri_compute_tsnr`, `sct_label_vertebrae`, `sct_label_utils`, `sct_deepseg` accept/pass through `contrast`.
- New `-qc-contrast` CLI flag (mirroring `-qc-dataset`/`-qc-subject`) on: `sct_qc`, `sct_register_multimodal`, `sct_register_to_template`, `sct_fmri_moco`, `sct_dmri_moco`, `sct_deepseg`, `sct_label_utils`, `sct_get_centerline`.

## Not yet covered
A few other scripts also expose `-qc-dataset`/`-qc-subject` directly (`sct_warp_template`, `sct_detect_pmj`, `sct_image` (`sct_image_stitch`), `sct_straighten_spinalcord`, `sct_analyze_lesion`, `sct_process_segmentation`, `sct_deepseg_gm`, `sct_propseg`, `sct_deepseg_sc`) and would need the same one-line pattern added. Opened as draft pending feedback on whether to extend this PR to those too, or handle them separately.

## Test plan
- [x] `python -m py_compile` on all touched files
- [x] Verified via `sct_qc -p sct_deepseg_sc -qc-contrast ...` (legacy `generate_qc` path): output JSON `contrast` field reflects the override, image path is `{dataset}/{subject}/{contrast}/sct_deepseg_sc/...`
- [x] Verified via `sct_qc -p sct_register_multimodal -qc-contrast ...` (qc2 path): same result
- [x] Verified omitting `-qc-contrast` reproduces todays behavior exactly (`contrast` = `path_input.parent.name`)
- [ ] Existing QC test suite (not yet run)
