### PR TITLE
Fix broken `-remove-sym` flag by using the right argparse value + rewriting for 2 output files

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -20,7 +20,7 @@ import textwrap
 import numpy as np
 
 import spinalcordtoolbox.labels as sct_labels
-from spinalcordtoolbox.image import Image, zeros_like
+from spinalcordtoolbox.image import Image, zeros_like, add_suffix
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports import qc2
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_loglevel
@@ -44,8 +44,12 @@ def get_parser():
     io_group.add_argument(
         '-o',
         metavar=Metavar.file,
-        default='labels.nii.gz',
-        help="Output image. Note: Only some label utilities create an output image."
+        nargs='+',
+        default=None,
+        help="Output image. Note: Only some label utilities create an output image. "
+             "`-remove-sym` produces two output images, so provide two space-separated filenames "
+             "(one for `-i`, one for `-remove-sym`). If omitted, a `_sym` suffix is added to the "
+             "input filenames. (default: labels.nii.gz)"
     )
     io_group.add_argument(
         '-ilabel',
@@ -153,8 +157,8 @@ def get_parser():
     func_group.add_argument(
         '-remove-sym',
         metavar=Metavar.file,
-        help="Remove labels from input image (`-i`) and reference image (specified here) that don't match. You must "
-             "provide two output names separated by `,`."
+        help="Remove labels from input image (`-i`) and reference image (specified here) that don't match. This "
+             "produces two output images; use `-o` to provide two space-separated output filenames."
     )
     func_group.add_argument(
         '-remove',
@@ -214,7 +218,19 @@ def main(argv: Sequence[str]):
     set_loglevel(verbose=verbose, caller_module_name=__name__)
 
     input_filename = arguments.i
-    output_fname = arguments.o
+
+    # Validate the output filename(s) early, before any processing occurs.
+    # `-remove-sym` produces two outputs (filtered `-i` and filtered reference); every other
+    # function produces a single output.
+    n_expected = 2 if arguments.remove_sym is not None else 1
+    if arguments.o is None:
+        if arguments.remove_sym is not None:
+            arguments.o = [add_suffix(arguments.i, '_sym'), add_suffix(arguments.remove_sym, '_sym')]
+        else:
+            arguments.o = ['labels.nii.gz']
+    elif len(arguments.o) != n_expected:
+        parser.error(f"'-o' expects {n_expected} filename(s) but got {len(arguments.o)}")
+    output_fnames = arguments.o
 
     img = Image(input_filename)
     dtype = None
@@ -275,7 +291,6 @@ def main(argv: Sequence[str]):
 
         # second pass use previous pass result as reference
         ref_out = sct_labels.remove_missing_labels(ref, out)
-        ref_out.save(path=ref.absolutepath)
     elif arguments.remove is not None:
         labels = arguments.remove
         out = sct_labels.remove_labels_from_image(img, labels)
@@ -291,46 +306,20 @@ def main(argv: Sequence[str]):
             out = launch_sagittal_viewer(img, parse_num_list(arguments.create_viewer), msg)
 
     printv("Generating output files...")
+    # `-remove-sym` filters both `-i` and the reference image, so it produces two
+    # (input, result) pairs. Every other function produces a single pair.
     if arguments.remove_sym is not None:
-        # If the user provided the '-remove-sym' option, we expect two output names separated by a comma
-        output_names = output_fname.split(',')
-        if len(output_names) != 2:
-            # Raise an error if the user did not provide two output names
-            raise ValueError("When using '-remove-sym', you must provide two output names separated by a comma. Example: '-o output1.nii.gz,output2.nii.gz'")
-        else:
-            out.save(path=output_names[0], dtype=dtype)
-            ref_out.save(path=output_names[1], dtype=dtype)
-            display_viewer_syntax([input_filename, output_names[0]], verbose=verbose)
-            display_viewer_syntax([arguments.remove_sym, output_names[1]], verbose=verbose)
-        if arguments.qc is not None:
-            # In this case we have two output files, so we will generate QC for both
-            qc2.sct_label_utils(
-                fname_input=input_filename,
-                fname_seg=output_names[0],
-                command='sct_label_utils',
-                argv=argv,
-                path_qc=os.path.abspath(arguments.qc),
-                dataset=arguments.qc_dataset,
-                subject=arguments.qc_subject,
-            )
-            qc2.sct_label_utils(
-                fname_input=arguments.remove_sym,
-                fname_seg=output_names[1],
-                command='sct_label_utils',
-                argv=argv,
-                path_qc=os.path.abspath(arguments.qc),
-                dataset=arguments.qc_dataset,
-                subject=arguments.qc_subject,
-            )
-
+        inputs, results = [input_filename, arguments.remove_sym], [out, ref_out]
     else:
-        out.save(path=output_fname, dtype=dtype)
-        display_viewer_syntax([input_filename, output_fname], verbose=verbose)
+        inputs, results = [input_filename], [out]
 
+    for fname_input, fname_output, result in zip(inputs, output_fnames, results):
+        result.save(path=fname_output, dtype=dtype)
+        display_viewer_syntax([fname_input, fname_output], verbose=verbose)
         if arguments.qc is not None:
             qc2.sct_label_utils(
-                fname_input=input_filename,
-                fname_seg=output_fname,
+                fname_input=fname_input,
+                fname_seg=fname_output,
                 command='sct_label_utils',
                 argv=argv,
                 path_qc=os.path.abspath(arguments.qc),

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -46,10 +46,7 @@ def get_parser():
         metavar=Metavar.file,
         nargs='+',
         default=None,
-        help="Output image. Note: Only some label utilities create an output image. "
-             "`-remove-sym` produces two output images, so provide two space-separated filenames "
-             "(one for `-i`, one for `-remove-sym`). If omitted, a `_sym` suffix is added to the "
-             "input filenames. (default: labels.nii.gz)"
+        help="Output image (default: labels.nii.gz). Note: Only some label utilities create an output image."
     )
     io_group.add_argument(
         '-ilabel',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -44,8 +44,12 @@ def get_parser():
     io_group.add_argument(
         '-o',
         metavar=Metavar.file,
-        default='labels.nii.gz',
-        help="Output image. Note: Only some label utilities create an output image."
+        nargs='+',
+        default=None,
+        help="Output image. Note: Only some label utilities create an output image. "
+             "`-remove-sym` produces two output images, so provide two space-separated filenames "
+             "(one for `-i`, one for `-remove-sym`). If omitted, a `_sym` suffix is added to the "
+             "input filenames. (default: labels.nii.gz)"
     )
     io_group.add_argument(
         '-ilabel',

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -291,19 +291,52 @@ def main(argv: Sequence[str]):
             out = launch_sagittal_viewer(img, parse_num_list(arguments.create_viewer), msg)
 
     printv("Generating output files...")
-    out.save(path=output_fname, dtype=dtype)
-    display_viewer_syntax([input_filename, output_fname], verbose=verbose)
+    if arguments.remove_sym is not None:
+        # If the user provided the '-remove-sym' option, we expect two output names separated by a comma
+        output_names = output_fname.split(',')
+        if len(output_names) != 2:
+            # Raise an error if the user did not provide two output names
+            raise ValueError("When using '-remove-sym', you must provide two output names separated by a comma. Example: '-o output1.nii.gz,output2.nii.gz'")
+        else:
+            out.save(path=output_names[0], dtype=dtype)
+            ref_out.save(path=output_names[1], dtype=dtype)
+            display_viewer_syntax([input_filename, output_names[0]], verbose=verbose)
+            display_viewer_syntax([arguments.remove_sym, output_names[1]], verbose=verbose)
+        if arguments.qc is not None:
+            # In this case we have two output files, so we will generate QC for both
+            qc2.sct_label_utils(
+                fname_input=input_filename,
+                fname_seg=output_names[0],
+                command='sct_label_utils',
+                argv=argv,
+                path_qc=os.path.abspath(arguments.qc),
+                dataset=arguments.qc_dataset,
+                subject=arguments.qc_subject,
+            )
+            qc2.sct_label_utils(
+                fname_input=arguments.remove_sym,
+                fname_seg=output_names[1],
+                command='sct_label_utils',
+                argv=argv,
+                path_qc=os.path.abspath(arguments.qc),
+                dataset=arguments.qc_dataset,
+                subject=arguments.qc_subject,
+            )
 
-    if arguments.qc is not None:
-        qc2.sct_label_utils(
-            fname_input=input_filename,
-            fname_seg=output_fname,
-            command='sct_label_utils',
-            argv=argv,
-            path_qc=os.path.abspath(arguments.qc),
-            dataset=arguments.qc_dataset,
-            subject=arguments.qc_subject,
-        )
+    else:
+        out.save(path=output_fname, dtype=dtype)
+        display_viewer_syntax([input_filename, output_fname], verbose=verbose)
+
+        if arguments.qc is not None:
+            qc2.sct_label_utils(
+                fname_input=input_filename,
+                fname_seg=output_fname,
+                command='sct_label_utils',
+                argv=argv,
+                path_qc=os.path.abspath(arguments.qc),
+                dataset=arguments.qc_dataset,
+                subject=arguments.qc_subject,
+            )
 
 
 def display_voxel(img: Image, verbose: int = 1) -> Sequence[Coordinate]:

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -270,7 +270,7 @@ def main(argv: Sequence[str]):
         out = sct_labels.remove_missing_labels(img, ref)
     elif arguments.remove_sym is not None:
         # first pass use img as source
-        ref = Image(arguments.remove_reference)
+        ref = Image(arguments.remove_sym)
         out = sct_labels.remove_missing_labels(img, ref)
 
         # second pass use previous pass result as reference

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -44,12 +44,8 @@ def get_parser():
     io_group.add_argument(
         '-o',
         metavar=Metavar.file,
-        nargs='+',
-        default=None,
-        help="Output image. Note: Only some label utilities create an output image. "
-             "`-remove-sym` produces two output images, so provide two space-separated filenames "
-             "(one for `-i`, one for `-remove-sym`). If omitted, a `_sym` suffix is added to the "
-             "input filenames. (default: labels.nii.gz)"
+        default='labels.nii.gz',
+        help="Output image. Note: Only some label utilities create an output image."
     )
     io_group.add_argument(
         '-ilabel',


### PR DESCRIPTION
## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [x] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [x] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [x] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [x] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [x] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

`sct_label_utils -remove-sym` was using the `-remove-reference`  argument value instead of the `-remove-sym` argument value.

Also, as `-remove-sym` produces 2 outputs, a small rewrite was necessary to accommodate these outputs.

## Linked issues

Fixes #5254 