### PR TITLE
Use raw strings for bibtex citation and ANSI escape regex

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -420,7 +420,7 @@ TASKS = {
                              'orientations, as well as multiple scanner manufacturers and field strengths.',
          'url': 'https://github.com/ivadomed/model_seg_sci',
          'models': ['model_seg_sci_multiclass_sc_lesion_nnunet'],
-         'citation': textwrap.dedent("""
+         'citation': textwrap.dedent(r"""
              ```bibtex
              @InProceedings{10.1007/978-3-031-82007-6_19,
                             author="Karthik, Enamundram Naga and Valo{\v{s}}ek, Jan and Farner, Lynn and Pfyffer, Dario and Schading-Sassenhausen, Simon and Lebret, Anna and David, Gergely and Smith, Andrew C. and Weber II, Kenneth A. and Seif, Maryam and Freund, Patrick and Cohen-Adad, Julien",

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -491,7 +491,7 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
             li = li.rstrip()  # strip trailing whitespace
             if len(li) > 0:
                 # Check for ANSI graphics control sequences, and increase width to compensate
-                width_adjusted = width + len("".join(re.findall("\\x1b\[[0-9;]+m", li)))  # noqa: W605
+                width_adjusted = width + len("".join(re.findall(r"\x1b\[[0-9;]+m", li)))
                 # Split the line into two parts: the first line, and wrapped lines
                 init_wrap = textwrap.fill(li, width_adjusted).splitlines()
                 first = init_wrap[0]


### PR DESCRIPTION
## Description

Two non-raw string literals contained backslash escapes that were being mis-decoded:

- **`spinalcordtoolbox/deepseg/models.py`** — the SCIsegV2 model `citation` is a bibtex block with LaTeX escapes. In a plain (non-raw) string, `\v` in the author name `Valo{\v{s}}ek` is decoded as a **vertical-tab control character** (`\x0b`), corrupting the rendered citation, and `\_` (in `sct{\_}deepseg` etc.) raises a `DeprecationWarning` — which becomes a `SyntaxWarning` on Python 3.12+.
- **`spinalcordtoolbox/utils/shell.py`** — the ANSI control-sequence regex `"\\x1b\[[0-9;]+m"` has an invalid escape `\[`, raising the same warning. It was previously silenced with `# noqa: W605` rather than fixed.

Both are switched to raw strings (`r"..."`). I verified:
- regex matching in `shell.py` is **byte-identical** before/after (`re.findall` returns the same matches on ANSI input);
- the citation now preserves its LaTeX escapes verbatim (no more vertical-tab corruption);
- compiling the package produces **zero** invalid-escape warnings (was 2).

The `# noqa: W605` is removed since it's no longer needed.

## Linked issues

No linked issue — these were unfiled.
