### PR TITLE
Fix `Coordinate` constructor mutating its input list (#5220)

### DIFF
--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -36,7 +36,9 @@ class Coordinate:
                              "string with coordinates delimited by commas.")
 
         if len(coord) == 3:
-            coord.append(0)
+            # Use concatenation rather than `coord.append(0)` to avoid mutating a
+            # list passed in by the caller (see issue #5220).
+            coord = coord + [0]
         elif len(coord) != 4:
             raise ValueError("Parameter must be a list with coordinates [x, y, z] or [x, y, z, value].")
 

--- a/testing/api/test_types.py
+++ b/testing/api/test_types.py
@@ -1,0 +1,35 @@
+# pytest unit tests for spinalcordtoolbox.types
+
+import pytest
+
+from spinalcordtoolbox.types import Coordinate
+
+
+def test_coordinate_from_list_of_three():
+    coord = Coordinate([1, 2, 3])
+    assert (coord.x, coord.y, coord.z, coord.value) == (1, 2, 3, 0)
+
+
+def test_coordinate_from_list_of_four():
+    coord = Coordinate([1, 2, 3, 7])
+    assert (coord.x, coord.y, coord.z, coord.value) == (1, 2, 3, 7)
+
+
+def test_coordinate_does_not_mutate_input_list():
+    # A 3-element list passed to Coordinate() must not be mutated in place
+    # (issue #5220): building a Coordinate should not append a value to the
+    # caller's list.
+    src = [1, 2, 3]
+    Coordinate(src)
+    assert src == [1, 2, 3]
+
+
+def test_coordinate_from_string():
+    coord = Coordinate("1,2,3")
+    assert (coord.x, coord.y, coord.z, coord.value) == (1, 2, 3, 0)
+
+
+@pytest.mark.parametrize("bad", [[1, 2], [1, 2, 3, 4, 5]])
+def test_coordinate_rejects_wrong_length(bad):
+    with pytest.raises(ValueError):
+        Coordinate(bad)


### PR DESCRIPTION
## Description

Fixes #5220.

`Coordinate.__init__` normalised a 3-element `[x, y, z]` input to `[x, y, z, value]` with `coord.append(0)`. Because that appends in place, a list owned by the caller was silently modified with a trailing `0`:

```python
src = [1, 2, 3]
Coordinate(src)
# src is now [1, 2, 3, 0]
```

As noted in the issue, this is why `image.reorient_coordinates()` had to defensively wrap its input in `Coordinate(list(coord))`.

## Changes

- `spinalcordtoolbox/types.py`: replace `coord.append(0)` with `coord = coord + [0]`, so a new list is built and the caller's list is never mutated. Behaviour is otherwise unchanged.
- `testing/api/test_types.py` (new): unit tests for construction from 3- and 4-element lists and from a string, wrong-length rejection, and a regression test asserting the input list is left untouched.

## Testing

```
$ pytest testing/api/test_types.py -q
6 passed
```