### PR TITLE
Fix `-custom-url` failure by enforcing "dict of URL lists" convention for totalspineseg

### DIFF
--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -448,17 +448,13 @@ def segment_nnunet(path_img, tmpdir, predictor, device: torch.device, ensemble=F
 def segment_totalspineseg(path_img, tmpdir, predictor, device, label_vert=False):
     # for totalspineseg, the 'predictor' is just the model path
     path_model = predictor
-    # fetch the release subdirectory from the model path (newest last)
-    release_paths = glob.glob(os.path.join(path_model, 'nnUNet', 'results', 'r*'), recursive=True)
-    installed_releases = [
-        os.path.basename(p) for p in
-        sorted(release_paths, key=os.path.getmtime)  # use the most recent release
-    ]
+    # fetch the release subdirectory from the model path
+    installed_releases = sorted(
+        os.path.basename(release_path) for release_path in
+        glob.glob(os.path.join(path_model, 'nnUNet', 'results', 'r*'), recursive=True)
+    )
     # There should always be a release subdirectory, hence the 'assert'
     assert installed_releases, f"No 'nnUNet/results/rYYYYMMDD' subdirectory found in {path_model}"
-    default_release = installed_releases[-1]
-    if len(installed_releases) > 1:
-        logger.info(f"Choosing '{default_release}' out of {installed_releases} based on last modified time")
 
     # Copy the file to the temporary directory using shutil.copyfile
     path_img_tmp = os.path.join(tmpdir, os.path.basename(path_img))
@@ -480,7 +476,7 @@ def segment_totalspineseg(path_img, tmpdir, predictor, device, label_vert=False)
         output_path=tmpdir_nnunet,
         data_path=path_model,
         # totalspineseg requires explicitly specifying the release subdirectory
-        default_release=default_release,
+        default_release=installed_releases[-1],  # use the most recent release
         # totalspineseg expects the device type, not torch.device
         device=device,
         # Try to address stalling due to the use of concurrent.futures in totalspineseg

--- a/spinalcordtoolbox/deepseg/inference.py
+++ b/spinalcordtoolbox/deepseg/inference.py
@@ -448,13 +448,17 @@ def segment_nnunet(path_img, tmpdir, predictor, device: torch.device, ensemble=F
 def segment_totalspineseg(path_img, tmpdir, predictor, device, label_vert=False):
     # for totalspineseg, the 'predictor' is just the model path
     path_model = predictor
-    # fetch the release subdirectory from the model path
-    installed_releases = sorted(
-        os.path.basename(release_path) for release_path in
-        glob.glob(os.path.join(path_model, 'nnUNet', 'results', 'r*'), recursive=True)
-    )
+    # fetch the release subdirectory from the model path (newest last)
+    release_paths = glob.glob(os.path.join(path_model, 'nnUNet', 'results', 'r*'), recursive=True)
+    installed_releases = [
+        os.path.basename(p) for p in
+        sorted(release_paths, key=os.path.getmtime)  # use the most recent release
+    ]
     # There should always be a release subdirectory, hence the 'assert'
     assert installed_releases, f"No 'nnUNet/results/rYYYYMMDD' subdirectory found in {path_model}"
+    default_release = installed_releases[-1]
+    if len(installed_releases) > 1:
+        logger.info(f"Choosing '{default_release}' out of {installed_releases} based on last modified time")
 
     # Copy the file to the temporary directory using shutil.copyfile
     path_img_tmp = os.path.join(tmpdir, os.path.basename(path_img))
@@ -476,7 +480,7 @@ def segment_totalspineseg(path_img, tmpdir, predictor, device, label_vert=False)
         output_path=tmpdir_nnunet,
         data_path=path_model,
         # totalspineseg requires explicitly specifying the release subdirectory
-        default_release=installed_releases[-1],  # use the most recent release
+        default_release=default_release,
         # totalspineseg expects the device type, not torch.device
         device=device,
         # Try to address stalling due to the use of concurrent.futures in totalspineseg

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -786,8 +786,6 @@ def install_model(name_model, custom_url=None):
             # Totalspineseg expects exactly 1 URL string per model (rather than a list of mirrors)
             dict_urls = {seed_name: (urls[0] if isinstance(urls, list) else urls)
                          for seed_name, urls in url_field.items()}
-            # NB: Totalspineseg can install multiple model versions side by side. But, we use the most recent release
-            #     for inference, so we don't have to clear out the existing model files before installing new ones.
             tss_init.init_inference(data_path=Path(folder(name_model)), quiet=False, dict_urls=dict_urls,
                                     store_export=False)  # Avoid having duplicate .zip files stored on disk
             urls_used = url_field

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -786,6 +786,8 @@ def install_model(name_model, custom_url=None):
             # Totalspineseg expects exactly 1 URL string per model (rather than a list of mirrors)
             dict_urls = {seed_name: (urls[0] if isinstance(urls, list) else urls)
                          for seed_name, urls in url_field.items()}
+            # NB: Totalspineseg can install multiple model versions side by side. But, we use the most recent release
+            #     for inference, so we don't have to clear out the existing model files before installing new ones.
             tss_init.init_inference(data_path=Path(folder(name_model)), quiet=False, dict_urls=dict_urls,
                                     store_export=False)  # Avoid having duplicate .zip files stored on disk
             urls_used = url_field

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -856,30 +856,40 @@ def is_up_to_date(path_model):
 
     expected_model_urls = MODELS[model_name]['url'].copy()
     actual_model_urls = source_dict["model_urls"]
+    # old format for cached/on-disk model may have been saved as a single string
+    if isinstance(actual_model_urls, str):
+        actual_model_urls = [actual_model_urls]
 
     if "custom" in source_dict and source_dict["custom"] is True:
         logger.warning(f"Using custom model from URL '{actual_model_urls}'.")
         return True  # Don't reinstall the model if the 'custom' flag is set (since custom URLs would fail comparison)
 
-    # Single-seed models
-    if isinstance(expected_model_urls, list) and isinstance(actual_model_urls, str):
-        if actual_model_urls not in expected_model_urls:
+    # Single-seed models (list of URLs)
+    if is_list_of_urls(expected_model_urls) and is_list_of_urls(actual_model_urls):
+        if not any(url in expected_model_urls for url in actual_model_urls):
             return False
-    # Multi-seed, ensemble models
-    elif isinstance(expected_model_urls, dict) and isinstance(actual_model_urls, dict):
-        for seed, url in actual_model_urls.items():
-            if seed not in expected_model_urls:
-                logger.warning(f"unexpected seed: {seed}")
-                return False
-            if url not in expected_model_urls.pop(seed):
-                logger.warning(f"wrong version for {seed}: {url}")
-                return False
-        if expected_model_urls:
-            logger.warning(f"missing seeds: {list(expected_model_urls.keys())}")
+
+    # Multi-seed, ensemble models (dict of lists of URLs, one list per seed)
+    elif is_dict_of_lists_of_urls(expected_model_urls) and is_dict_of_lists_of_urls(actual_model_urls):
+        expected_seeds = set(expected_model_urls)
+        actual_seeds = set(actual_model_urls)
+
+        if unexpected_seeds := actual_seeds - expected_seeds:
+            logger.warning(f"unexpected seeds: {list(unexpected_seeds)}")
             return False
+        if missing_seeds := expected_seeds - actual_seeds:
+            logger.warning(f"missing seeds: {list(missing_seeds)}")
+            return False
+
+        for seed in actual_seeds:
+            if not set(actual_model_urls[seed]).issubset(expected_model_urls[seed]):
+                logger.warning(f"wrong version for {seed}: {actual_model_urls[seed]}")
+                return False
+
     else:
         logger.warning("Mismatch between 'source.json' URL format and SCT source code URLs")
         return False
+
     logger.info(f"Model '{model_name}' is up to date (Source: {actual_model_urls})")
     return True
 

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -733,14 +733,20 @@ def load_crop_metadata(name_model, path_model):
     return {key: crop_metadata[key] for key in CROP_PAD_KEYS}
 
 
-def is_list_of_urls(obj):
+def is_list_of_urls(url_field):
     """Check if an object is a list of URLs."""
-    if not isinstance(obj, list):
-        return False
-    for url in obj:
-        if not isinstance(url, str) or not url.startswith("http"):
-            return False
-    return True
+    return isinstance(url_field, list) and all(
+        isinstance(url, str) and url.startswith("http")
+        for url in url_field
+    )
+
+
+def is_dict_of_lists_of_urls(url_field):
+    """Check if an object is a dict of lists of URLs."""
+    return isinstance(url_field, dict) and all(
+        isinstance(k, str) and is_list_of_urls(v)
+        for k, v in url_field.items()
+    )
 
 
 def install_model(name_model, custom_url=None):
@@ -778,9 +784,7 @@ def install_model(name_model, custom_url=None):
         # Make sure to preserve the internal folder structure for nnUNet-based models (to allow re-use with 3D Slicer)
         urls_used = download.install_data(model_urls, folder(name_model), dirs_to_preserve=("nnUNetTrainer",))
     # Dict of lists, with each list corresponding to a different model seed for ensembling
-    else:
-        if not isinstance(url_field, dict) and all(is_list_of_urls(urls) for urls in url_field.values()):
-            raise ValueError(f"Invalid url field in MODELS: {url_field}")
+    elif is_dict_of_lists_of_urls(url_field):
         # totalspineseg handles data downloading itself, so just pass the urls along
         if name_model in TASKS['spine']['models']:
             # Totalspineseg expects exactly 1 URL string per model (rather than a list of mirrors)
@@ -809,6 +813,8 @@ def install_model(name_model, custom_url=None):
                 logger.info(f"\nInstalling '{seed_name}'...")
                 urls_used[seed_name] = download.install_data(model_urls, target_directory, keep=(i > 0),
                                                              dirs_to_preserve=dirs_to_preserve)
+    else:
+        raise ValueError(f"Invalid url field in MODELS: {url_field}")
     # Write `source.json` (for model provenance / updating)
     source_dict = {
         'model_name': name_model,

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -782,7 +782,7 @@ def install_model(name_model, custom_url=None):
     if is_list_of_urls(url_field):
         model_urls = url_field
         # Make sure to preserve the internal folder structure for nnUNet-based models (to allow re-use with 3D Slicer)
-        urls_used = download.install_data(model_urls, folder(name_model), dirs_to_preserve=("nnUNetTrainer",))
+        urls_used = [download.install_data(model_urls, folder(name_model), dirs_to_preserve=("nnUNetTrainer",))]
     # Dict of lists, with each list corresponding to a different model seed for ensembling
     elif is_dict_of_lists_of_urls(url_field):
         # totalspineseg handles data downloading itself, so just pass the urls along
@@ -811,8 +811,8 @@ def install_model(name_model, custom_url=None):
                     target_directory = folder(os.path.join(name_model, seed_name))
                     dirs_to_preserve = ()
                 logger.info(f"\nInstalling '{seed_name}'...")
-                urls_used[seed_name] = download.install_data(model_urls, target_directory, keep=(i > 0),
-                                                             dirs_to_preserve=dirs_to_preserve)
+                urls_used[seed_name] = [download.install_data(model_urls, target_directory, keep=(i > 0),
+                                                              dirs_to_preserve=dirs_to_preserve)]
     else:
         raise ValueError(f"Invalid url field in MODELS: {url_field}")
     # Write `source.json` (for model provenance / updating)

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -13,6 +13,7 @@ import logging
 import textwrap
 import shutil
 import glob
+import re
 from pathlib import Path
 from importlib.metadata import metadata
 
@@ -228,8 +229,11 @@ MODELS = {
          # NB: Rather than hardcoding the URLs ourselves, use the URLs from the totalspineseg package.
          # This means that when the totalspineseg package is updated, the URLs will be too, thus triggering
          # a re-installation of the model URLs
-         "url": dict([meta.split(', ') for meta in metadata('totalspineseg').get_all('Project-URL')
-                      if meta.startswith('Dataset')]),
+         "url": {
+             k: re.findall(r'https?://\S+', v)
+             for k, v in (meta.split(', ', 1) for meta in metadata('totalspineseg').get_all('Project-URL'))
+             if k.startswith('Dataset')
+         },
          "description": "Instance segmentation of vertebrae, intervertebral discs (IVDs), spinal cord, and spinal canal on multi-contrasts MRI scans.",
          "contrasts": ["any"],
          "framework": "nnunetv2",
@@ -729,6 +733,16 @@ def load_crop_metadata(name_model, path_model):
     return {key: crop_metadata[key] for key in CROP_PAD_KEYS}
 
 
+def is_list_of_urls(obj):
+    """Check if an object is a list of URLs."""
+    if not isinstance(obj, list):
+        return False
+    for url in obj:
+        if not isinstance(url, str) or not url.startswith("http"):
+            return False
+    return True
+
+
 def install_model(name_model, custom_url=None):
     """
     Download and install specified model under SCT installation dir.
@@ -759,17 +773,20 @@ def install_model(name_model, custom_url=None):
                     f"Expected {n_urls_expected} custom URL(s) for model '{name_model}' "
                     f"but got {len(custom_url)} instead.")
     # List of mirror URLs corresponding to a single model
-    if isinstance(url_field, list):
+    if is_list_of_urls(url_field):
         model_urls = url_field
         # Make sure to preserve the internal folder structure for nnUNet-based models (to allow re-use with 3D Slicer)
         urls_used = download.install_data(model_urls, folder(name_model), dirs_to_preserve=("nnUNetTrainer",))
     # Dict of lists, with each list corresponding to a different model seed for ensembling
     else:
-        if not isinstance(url_field, dict):
-            raise ValueError("Invalid url field in MODELS")
+        if not isinstance(url_field, dict) and all(is_list_of_urls(urls) for urls in url_field.values()):
+            raise ValueError(f"Invalid url field in MODELS: {url_field}")
         # totalspineseg handles data downloading itself, so just pass the urls along
         if name_model in TASKS['spine']['models']:
-            tss_init.init_inference(data_path=Path(folder(name_model)), quiet=False, dict_urls=url_field,
+            # Totalspineseg expects exactly 1 URL string per model (rather than a list of mirrors)
+            dict_urls = {seed_name: (urls[0] if isinstance(urls, list) else urls)
+                         for seed_name, urls in url_field.items()}
+            tss_init.init_inference(data_path=Path(folder(name_model)), quiet=False, dict_urls=dict_urls,
                                     store_export=False)  # Avoid having duplicate .zip files stored on disk
             urls_used = url_field
             # For totalspineseg, for now we need to copy its custom trainer to the `nnunetv2` folder


### PR DESCRIPTION


## Checklist

<!-- Hi, and thank you for submitting a Pull Request! Please make sure to check the boxes below before submitting. -->

- [ ] **PR Sidebar**: I've filled these options within the PR sidebar:
  - [Labels](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#233-labels) (**exactly one** dark purple label!)
  - [Milestone](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#234-milestone)
- [ ] **Guidelines**: I've read the [Contributing guidelines](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)) to make sure my [branch](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-1-branches) and [pull request](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing%3A-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#part-2-pull-requests) meet SCT's guidelines. (Feel free to stop and fixup your commits before submitting.)
- [ ] **Documentation**: I've updated the [relevant documentation](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages.
- [ ] **Tests**: I've added [relevant tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Testing) for my contribution, if necessary. I've also made sure that my contribution passes [all of the automated tests](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#24-checking-the-automated-tests) (which will be triggered after the PR is submitted).
- [ ] Only **after** the automated test suite passes: I will tag a [reviewer](https://github.com/spinalcordtoolbox/spinalcordtoolbox/wiki/Contributing:-Submitting-changes-to-SCT-(Opening-a-Pull-Request)#231-reviewers) in the PR sidebar. (You can also ask for help with specific questions in the PR comments before the tests pass.)

## Description

For `model_seg_ms_lesion` (and any other multi-fold/multi-model tasks), we use a convention of "dict of URL lists". The list represents a number of mirrors that `install_model` can fall back to if the first URL fails. 

> NB: Newly in #5283, we preserve the "dict of urls" format even if we just have 1 URL. We used to coerce it to a dict of single URL strings, but that made things more complicated re: iteration.

Notably, however, `totalspineseg` doesn't adopt the concept of "mirrors", and it always expects a dict of URL strings. This worked fine prior to #5283, but by keeping the "dict of lists" format, it means that the default value (in `MODELS`) doesn't match SCT's expected format, nor do _we_ pass the expected format to TSS.

This caused a failure when `-custom-url` was used with `sct_deepseg spine`, and the URLs were passed to TSS as a dict of lists, instead of a dict of URLs.

## Testing

I ran this and it worked OK:

```
sct_deepseg spine -install -custom-url \
    https://github.com/neuropoly/totalspineseg/releases/download/r20260730/Dataset101_TotalSpineSeg_step1_r20260730.zip \
    https://github.com/neuropoly/totalspineseg/releases/download/r20260730/Dataset102_TotalSpineSeg_step2_r20260730.zip
```

As did the default value:

```
sct_deepseg spine -install
```

However, notably, totalspineseg tries to keep multiple releases on disk side-by-side, meaning we might need to be careful with how we manage them. I made what I hope to be a useful follow-up fix, but we should definitely discuss that point more.

## Linked issues

Fixes #5296.